### PR TITLE
Fix #11: Auto-generate passwords for all database templates

### DIFF
--- a/ui/src/lib/templates.ts
+++ b/ui/src/lib/templates.ts
@@ -1,5 +1,13 @@
 import type { AppSpec } from './types';
 
+/** Generate a cryptographically random alphanumeric string. */
+function generatePassword(length = 24): string {
+	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	const values = new Uint8Array(length);
+	crypto.getRandomValues(values);
+	return Array.from(values, (v) => chars[v % chars.length]).join('');
+}
+
 export type TemplateCategory = 'database' | 'app' | 'blank';
 
 export interface TemplateField {
@@ -53,7 +61,10 @@ export const templates: Template[] = [
 					{
 						name: 'production',
 						replicas: 1,
-						env: [{ name: 'POSTGRES_PASSWORD', value: '' }]
+						env: [
+							{ name: 'POSTGRES_USER', value: 'postgres' },
+							{ name: 'POSTGRES_PASSWORD', value: generatePassword() }
+						]
 					}
 				]
 			}
@@ -117,7 +128,7 @@ export const templates: Template[] = [
 						replicas: 1,
 						env: [
 							{ name: 'PAPERLESS_URL', value: '' },
-							{ name: 'PAPERLESS_SECRET_KEY', value: '' },
+							{ name: 'PAPERLESS_SECRET_KEY', value: generatePassword(48) },
 							{ name: 'PAPERLESS_TIME_ZONE', value: 'UTC' },
 							{ name: 'PAPERLESS_OCR_LANGUAGE', value: 'eng' }
 						]
@@ -152,7 +163,7 @@ export const templates: Template[] = [
 						env: [
 							{ name: 'DOMAIN', value: '' },
 							{ name: 'SIGNUPS_ALLOWED', value: 'false' },
-							{ name: 'ADMIN_TOKEN', value: '' }
+							{ name: 'ADMIN_TOKEN', value: generatePassword(48) }
 						]
 					}
 				]


### PR DESCRIPTION
## Summary

- Database templates crashed on deploy because password env vars were empty strings
- Added `generatePassword()` helper using `crypto.getRandomValues`
- Postgres: `POSTGRES_PASSWORD` + `POSTGRES_USER` auto-filled
- Paperless: `PAPERLESS_SECRET_KEY` auto-generated (48 chars)
- Vaultwarden: `ADMIN_TOKEN` auto-generated (48 chars)
- Redis/Mealie: already worked, unchanged

## Test plan

- [ ] Deploy Postgres from template → pod starts, no CrashLoopBackOff
- [ ] Deploy Paperless from template → pod starts with a real secret key
- [ ] Deploy Vaultwarden from template → admin panel accessible
- [ ] Redis still works (no change)
- [ ] Mealie still works (no change)

Fixes #11. Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)