### PR TITLE
Add missing CLI commands: secret, git-provider, platform, repo, app update

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -235,10 +235,13 @@ CLI (`cmd/cli/`):
   `deploy`, `logs`, `status`.
 - Phase 7 verbs: `rollback`, `promote`, `env {list,set,unset,import,pull}`,
   `token {create,list,revoke}`, `domain {list,add,remove}`.
+- Phase 8 verbs: `secret {list,set,delete}`, `git-provider {list,create,delete,connect-github}`,
+  `platform {get,set}`, `repo {list,branches}`, `app update`.
 - `app_test.go`, `project_test.go`, `env_test.go`, `rollback_test.go`,
-  `promote_test.go`, `token_test.go` exercise the CLI layer.
+  `promote_test.go`, `token_test.go`, `secret_test.go`, `gitprovider_test.go`,
+  `platform_test.go`, `repo_test.go` exercise the CLI layer.
 
-**Gaps:** `secret` and `preview` CLI verbs not yet implemented.
+**Gaps:** `preview` CLI verbs not yet implemented.
 
 ### Phase 3 — Bindings & secrets — **Partial**
 

--- a/cmd/cli/app.go
+++ b/cmd/cli/app.go
@@ -17,6 +17,7 @@ func newAppCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAppListCmd())
 	cmd.AddCommand(newAppCreateCmd())
+	cmd.AddCommand(newAppUpdateCmd())
 	cmd.AddCommand(newAppDeleteCmd())
 	return cmd
 }
@@ -85,6 +86,56 @@ func newAppCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&image, "image", "", "Container image reference (for source=image)")
 	cmd.Flags().StringVar(&name, "name", "", "App name")
 	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func newAppUpdateCmd() *cobra.Command {
+	var project, image, env string
+	var replicas int32
+	cmd := &cobra.Command{
+		Use:   "update <name>",
+		Short: "Update an app (read-modify-write)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			p := c.ResolveProject(project)
+			app, err := c.GetApp(p, args[0])
+			if err != nil {
+				return fmt.Errorf("fetching app: %w", err)
+			}
+			if cmd.Flags().Changed("image") {
+				app.Spec.Source.Image = image
+			}
+			if cmd.Flags().Changed("replicas") {
+				found := false
+				for i := range app.Spec.Environments {
+					if app.Spec.Environments[i].Name == env {
+						app.Spec.Environments[i].Replicas = &replicas
+						found = true
+						break
+					}
+				}
+				if !found {
+					app.Spec.Environments = append(app.Spec.Environments, mortisev1alpha1.Environment{
+						Name:     env,
+						Replicas: &replicas,
+					})
+				}
+			}
+			if _, err := c.UpdateApp(p, args[0], app.Spec); err != nil {
+				return err
+			}
+			fmt.Printf("App %q updated.\n", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
+	cmd.Flags().StringVar(&image, "image", "", "Container image reference")
+	cmd.Flags().Int32Var(&replicas, "replicas", 0, "Replica count")
+	cmd.Flags().StringVar(&env, "env", "production", "Environment name (used with --replicas)")
 	return cmd
 }
 

--- a/cmd/cli/app_test.go
+++ b/cmd/cli/app_test.go
@@ -224,6 +224,7 @@ func TestRootCommandStructure(t *testing.T) {
 
 	expected := map[string]bool{
 		"login": false, "project": false, "app": false, "deploy": false, "logs": false, "status": false,
+		"secret": false, "git-provider": false, "platform": false, "repo": false,
 	}
 	for _, sub := range root.Commands() {
 		if _, ok := expected[sub.Name()]; ok {
@@ -237,13 +238,53 @@ func TestRootCommandStructure(t *testing.T) {
 	}
 }
 
+func TestAppUpdate_PutsToCorrectPath(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/projects/myproject/apps/web":
+			// Return current app state
+			_ = json.NewEncoder(w).Encode(mortisev1alpha1.App{
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: "nginx:1.27",
+					},
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/projects/myproject/apps/web":
+			calls++
+			var spec mortisev1alpha1.AppSpec
+			_ = json.NewDecoder(r.Body).Decode(&spec)
+			if spec.Source.Image != "nginx:1.27" {
+				t.Errorf("expected image preserved as nginx:1.27, got %q", spec.Source.Image)
+			}
+			_ = json.NewEncoder(w).Encode(mortisev1alpha1.App{Spec: spec})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	_, err := c.UpdateApp(c.ResolveProject(""), "web", mortisev1alpha1.AppSpec{
+		Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.27"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 PUT call, got %d", calls)
+	}
+}
+
 func TestAppSubcommands(t *testing.T) {
 	app := newAppCmd()
 	subs := map[string]bool{}
 	for _, c := range app.Commands() {
 		subs[c.Name()] = true
 	}
-	for _, name := range []string{"list", "create", "delete"} {
+	for _, name := range []string{"list", "create", "update", "delete"} {
 		if !subs[name] {
 			t.Errorf("missing app subcommand: %s", name)
 		}

--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -350,6 +350,158 @@ func (c *Client) RevokeToken(project, app, name string) error {
 	return c.doJSON(http.MethodDelete, u, nil, nil)
 }
 
+// ---------- Git Providers ----------
+
+type GitProviderSummary struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Host     string `json:"host"`
+	Phase    string `json:"phase"`
+	HasToken bool   `json:"hasToken"`
+	Mode     string `json:"mode"`
+}
+
+type CreateGitProviderRequest struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Host          string `json:"host"`
+	ClientID      string `json:"clientID"`
+	ClientSecret  string `json:"clientSecret"`
+	WebhookSecret string `json:"webhookSecret"`
+}
+
+func (c *Client) ListGitProviders() ([]GitProviderSummary, error) {
+	var resp []GitProviderSummary
+	if err := c.doJSON(http.MethodGet, c.BaseURL+"/api/gitproviders", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) CreateGitProvider(req CreateGitProviderRequest) error {
+	return c.doJSON(http.MethodPost, c.BaseURL+"/api/gitproviders", req, nil)
+}
+
+func (c *Client) DeleteGitProvider(name string) error {
+	u := fmt.Sprintf("%s/api/gitproviders/%s", c.BaseURL, url.PathEscape(name))
+	return c.doJSON(http.MethodDelete, u, nil, nil)
+}
+
+// ---------- Platform ----------
+
+type PlatformResponse struct {
+	Domain string `json:"domain"`
+	DNS    struct {
+		Provider string `json:"provider"`
+	} `json:"dns"`
+	Registry struct {
+		URL string `json:"url"`
+	} `json:"registry"`
+	Build struct {
+		BuildkitAddr string `json:"buildkitAddr"`
+	} `json:"build"`
+}
+
+type PlatformPatchRequest struct {
+	Domain string         `json:"domain,omitempty"`
+	DNS    map[string]any `json:"dns,omitempty"`
+}
+
+func (c *Client) GetPlatform() (*PlatformResponse, error) {
+	var resp PlatformResponse
+	if err := c.doJSON(http.MethodGet, c.BaseURL+"/api/platform", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) PatchPlatform(req PlatformPatchRequest) (*PlatformResponse, error) {
+	var resp PlatformResponse
+	if err := c.doJSON(http.MethodPatch, c.BaseURL+"/api/platform", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ---------- Repos ----------
+
+type Repository struct {
+	FullName      string `json:"fullName"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	DefaultBranch string `json:"defaultBranch"`
+	Language      string `json:"language"`
+	Private       bool   `json:"private"`
+	UpdatedAt     string `json:"updatedAt"`
+}
+
+type Branch struct {
+	Name    string `json:"name"`
+	Default bool   `json:"default"`
+}
+
+func (c *Client) ListRepos(provider string) ([]Repository, error) {
+	var resp []Repository
+	u := c.BaseURL + "/api/repos?provider=" + url.QueryEscape(provider)
+	if err := c.doJSON(http.MethodGet, u, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) ListBranches(owner, repo, provider string) ([]Branch, error) {
+	var resp []Branch
+	u := fmt.Sprintf("%s/api/repos/%s/%s/branches?provider=%s",
+		c.BaseURL, url.PathEscape(owner), url.PathEscape(repo), url.QueryEscape(provider))
+	if err := c.doJSON(http.MethodGet, u, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ---------- App Update ----------
+
+func (c *Client) UpdateApp(project, name string, spec any) (*mortisev1alpha1.App, error) {
+	var app mortisev1alpha1.App
+	u := c.appBase(project, name)
+	if err := c.doJSON(http.MethodPut, u, spec, &app); err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
+// ---------- GitHub Device Flow ----------
+
+type DeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type DevicePollResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (c *Client) RequestDeviceCode() (*DeviceCodeResponse, error) {
+	var resp DeviceCodeResponse
+	if err := c.doJSON(http.MethodPost, c.BaseURL+"/api/auth/github/device", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) PollDeviceCode(deviceCode string) (*DevicePollResponse, error) {
+	var resp DevicePollResponse
+	if err := c.doJSON(http.MethodPost, c.BaseURL+"/api/auth/github/device/poll",
+		map[string]string{"device_code": deviceCode}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ---------- Env Vars ----------
 
 // EnvVarResponse mirrors internal/api.envVarResponse.

--- a/cmd/cli/gitprovider.go
+++ b/cmd/cli/gitprovider.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newGitProviderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "git-provider",
+		Short: "Manage git providers",
+	}
+	cmd.AddCommand(newGitProviderListCmd())
+	cmd.AddCommand(newGitProviderCreateCmd())
+	cmd.AddCommand(newGitProviderDeleteCmd())
+	cmd.AddCommand(newGitProviderConnectGitHubCmd())
+	return cmd
+}
+
+func newGitProviderListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured git providers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			providers, err := c.ListGitProviders()
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAME\tTYPE\tHOST\tPHASE\tMODE")
+			for _, p := range providers {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", p.Name, p.Type, p.Host, p.Phase, p.Mode)
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func newGitProviderCreateCmd() *cobra.Command {
+	var name, providerType, host, clientID, clientSecret, webhookSecret string
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a git provider",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			req := CreateGitProviderRequest{
+				Name:          name,
+				Type:          providerType,
+				Host:          host,
+				ClientID:      clientID,
+				ClientSecret:  clientSecret,
+				WebhookSecret: webhookSecret,
+			}
+			if err := c.CreateGitProvider(req); err != nil {
+				return err
+			}
+			fmt.Printf("Git provider %q created.\n", name)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "Provider name")
+	cmd.Flags().StringVar(&providerType, "type", "", "Provider type (github|gitlab|gitea)")
+	cmd.Flags().StringVar(&host, "host", "", "Host URL")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth client ID")
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth client secret")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "Webhook secret")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("type")
+	return cmd
+}
+
+func newGitProviderDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a git provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			if err := c.DeleteGitProvider(args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("Git provider %q deleted.\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newGitProviderConnectGitHubCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "connect-github",
+		Short: "Connect GitHub via device flow",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			code, err := c.RequestDeviceCode()
+			if err != nil {
+				return fmt.Errorf("requesting device code: %w", err)
+			}
+
+			fmt.Printf("Go to %s and enter code: %s\n", code.VerificationURI, code.UserCode)
+
+			// Try to open the URL in the browser.
+			openBrowser(code.VerificationURI)
+
+			interval := code.Interval
+			if interval < 5 {
+				interval = 5
+			}
+
+			for {
+				time.Sleep(time.Duration(interval) * time.Second)
+				poll, err := c.PollDeviceCode(code.DeviceCode)
+				if err != nil {
+					return fmt.Errorf("polling device code: %w", err)
+				}
+				switch poll.Status {
+				case "complete":
+					fmt.Println("GitHub connected!")
+					return nil
+				case "expired":
+					return fmt.Errorf("device code expired — please try again")
+				}
+				// "authorization_pending" or "slow_down" — keep polling
+			}
+		},
+	}
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}

--- a/cmd/cli/gitprovider_test.go
+++ b/cmd/cli/gitprovider_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGitProviderList_QueriesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/gitproviders"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode([]GitProviderSummary{
+			{Name: "github-main", Type: "github", Host: "github.com", Phase: "Ready"},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	providers, err := c.ListGitProviders()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(providers) != 1 || providers[0].Name != "github-main" {
+		t.Errorf("unexpected providers: %+v", providers)
+	}
+}
+
+func TestGitProviderCreate_PostsCorrectBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/gitproviders"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		var req CreateGitProviderRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "gh" || req.Type != "github" {
+			t.Errorf("unexpected body: %+v", req)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	err := c.CreateGitProvider(CreateGitProviderRequest{
+		Name: "gh", Type: "github", Host: "github.com",
+		ClientID: "id", ClientSecret: "secret", WebhookSecret: "wh",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGitProviderDelete_DeletesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/gitproviders/github-main"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodDelete {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.DeleteGitProvider("github-main"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGitProviderSubcommands(t *testing.T) {
+	gp := newGitProviderCmd()
+	subs := map[string]bool{}
+	for _, c := range gp.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, name := range []string{"list", "create", "delete", "connect-github"} {
+		if !subs[name] {
+			t.Errorf("missing git-provider subcommand: %s", name)
+		}
+	}
+}
+
+func TestDeviceCodeRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/auth/github/device"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DeviceCodeResponse{
+			DeviceCode:      "dc123",
+			UserCode:        "ABCD-1234",
+			VerificationURI: "https://github.com/login/device",
+			ExpiresIn:       900,
+			Interval:        5,
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	resp, err := c.RequestDeviceCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UserCode != "ABCD-1234" {
+		t.Errorf("unexpected user code: %q", resp.UserCode)
+	}
+}
+
+func TestDeviceCodePoll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/auth/github/device/poll"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		_ = json.NewEncoder(w).Encode(DevicePollResponse{Status: "complete"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	resp, err := c.PollDeviceCode("dc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "complete" {
+		t.Errorf("unexpected status: %q", resp.Status)
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -36,6 +36,10 @@ Quickstart:
 	cmd.AddCommand(newDomainCmd())
 	cmd.AddCommand(newTokenCmd())
 	cmd.AddCommand(newEnvCmd())
+	cmd.AddCommand(newSecretCmd())
+	cmd.AddCommand(newGitProviderCmd())
+	cmd.AddCommand(newPlatformCmd())
+	cmd.AddCommand(newRepoCmd())
 	return cmd
 }
 

--- a/cmd/cli/platform.go
+++ b/cmd/cli/platform.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newPlatformCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "platform",
+		Short: "View and configure platform settings",
+	}
+	cmd.AddCommand(newPlatformGetCmd())
+	cmd.AddCommand(newPlatformSetCmd())
+	return cmd
+}
+
+func newPlatformGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get",
+		Short: "Show current platform configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			p, err := c.GetPlatform()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Domain:       %s\n", p.Domain)
+			fmt.Printf("DNS Provider: %s\n", p.DNS.Provider)
+			fmt.Printf("Registry:     %s\n", p.Registry.URL)
+			fmt.Printf("BuildKit:     %s\n", p.Build.BuildkitAddr)
+			return nil
+		},
+	}
+}
+
+func newPlatformSetCmd() *cobra.Command {
+	var domain, dnsProvider, dnsToken string
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Update platform configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			req := PlatformPatchRequest{Domain: domain}
+			if dnsProvider != "" || dnsToken != "" {
+				req.DNS = map[string]any{}
+				if dnsProvider != "" {
+					req.DNS["provider"] = dnsProvider
+				}
+				if dnsToken != "" {
+					req.DNS["apiToken"] = dnsToken
+				}
+			}
+			p, err := c.PatchPlatform(req)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Platform updated. Domain: %s\n", p.Domain)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&domain, "domain", "", "Platform domain")
+	cmd.Flags().StringVar(&dnsProvider, "dns-provider", "", "DNS provider")
+	cmd.Flags().StringVar(&dnsToken, "dns-token", "", "DNS API token")
+	return cmd
+}

--- a/cmd/cli/platform_test.go
+++ b/cmd/cli/platform_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPlatformGet_QueriesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/platform"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(PlatformResponse{
+			Domain: "example.com",
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	p, err := c.GetPlatform()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Domain != "example.com" {
+		t.Errorf("unexpected domain: %q", p.Domain)
+	}
+}
+
+func TestPlatformPatch_SendsCorrectBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/platform"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodPatch {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		var req PlatformPatchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Domain != "new.example.com" {
+			t.Errorf("expected domain 'new.example.com', got %q", req.Domain)
+		}
+		_ = json.NewEncoder(w).Encode(PlatformResponse{Domain: "new.example.com"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	p, err := c.PatchPlatform(PlatformPatchRequest{Domain: "new.example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Domain != "new.example.com" {
+		t.Errorf("unexpected domain: %q", p.Domain)
+	}
+}
+
+func TestPlatformSubcommands(t *testing.T) {
+	plat := newPlatformCmd()
+	subs := map[string]bool{}
+	for _, c := range plat.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, name := range []string{"get", "set"} {
+		if !subs[name] {
+			t.Errorf("missing platform subcommand: %s", name)
+		}
+	}
+}

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func newRepoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo",
+		Short: "Browse repositories from connected git providers",
+	}
+	cmd.AddCommand(newRepoListCmd())
+	cmd.AddCommand(newRepoBranchesCmd())
+	return cmd
+}
+
+func newRepoListCmd() *cobra.Command {
+	var provider string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List repositories from a git provider",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if provider == "" {
+				return fmt.Errorf("--provider is required")
+			}
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			repos, err := c.ListRepos(provider)
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAME\tLANGUAGE\tDEFAULT BRANCH\tPRIVATE")
+			for _, r := range repos {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%v\n", r.FullName, r.Language, r.DefaultBranch, r.Private)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&provider, "provider", "", "Git provider name")
+	_ = cmd.MarkFlagRequired("provider")
+	return cmd
+}
+
+func newRepoBranchesCmd() *cobra.Command {
+	var provider string
+	cmd := &cobra.Command{
+		Use:   "branches <owner/repo>",
+		Short: "List branches for a repository",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if provider == "" {
+				return fmt.Errorf("--provider is required")
+			}
+			parts := strings.SplitN(args[0], "/", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("expected owner/repo format, got %q", args[0])
+			}
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			branches, err := c.ListBranches(parts[0], parts[1], provider)
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAME\tDEFAULT")
+			for _, b := range branches {
+				fmt.Fprintf(tw, "%s\t%v\n", b.Name, b.Default)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&provider, "provider", "", "Git provider name")
+	_ = cmd.MarkFlagRequired("provider")
+	return cmd
+}

--- a/cmd/cli/repo_test.go
+++ b/cmd/cli/repo_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRepoList_QueriesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/repos"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("provider"); got != "github-main" {
+			t.Errorf("expected provider=github-main, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]Repository{
+			{FullName: "org/repo", Name: "repo", DefaultBranch: "main"},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	repos, err := c.ListRepos("github-main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 || repos[0].FullName != "org/repo" {
+		t.Errorf("unexpected repos: %+v", repos)
+	}
+}
+
+func TestRepoBranches_QueriesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/repos/myorg/myrepo/branches"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("provider"); got != "github-main" {
+			t.Errorf("expected provider=github-main, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]Branch{
+			{Name: "main", Default: true},
+			{Name: "develop", Default: false},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	branches, err := c.ListBranches("myorg", "myrepo", "github-main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(branches) != 2 {
+		t.Errorf("expected 2 branches, got %d", len(branches))
+	}
+	if !branches[0].Default {
+		t.Errorf("expected first branch to be default")
+	}
+}
+
+func TestRepoSubcommands(t *testing.T) {
+	repo := newRepoCmd()
+	subs := map[string]bool{}
+	for _, c := range repo.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, name := range []string{"list", "branches"} {
+		if !subs[name] {
+			t.Errorf("missing repo subcommand: %s", name)
+		}
+	}
+}

--- a/cmd/cli/secret.go
+++ b/cmd/cli/secret.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func newSecretCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "Manage secrets for apps (write-only — values are never returned)",
+	}
+	cmd.AddCommand(newSecretListCmd())
+	cmd.AddCommand(newSecretSetCmd())
+	cmd.AddCommand(newSecretDeleteCmd())
+	return cmd
+}
+
+func newSecretListCmd() *cobra.Command {
+	var project, env string
+	cmd := &cobra.Command{
+		Use:   "list <app>",
+		Short: "List secrets for an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			p := c.ResolveProject(project)
+			secrets, err := c.ListSecrets(p, args[0])
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAME\tKEYS")
+			for _, s := range secrets {
+				fmt.Fprintf(tw, "%s\t%v\n", s.Name, s.Keys)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
+	cmd.Flags().StringVar(&env, "env", "", "Environment name")
+	return cmd
+}
+
+func newSecretSetCmd() *cobra.Command {
+	var project, env, value string
+	cmd := &cobra.Command{
+		Use:   "set <app> <name>",
+		Short: "Set a secret (prompts for value securely)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			secretValue := value
+			if secretValue == "" {
+				fmt.Print("Secret value: ")
+				pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Println()
+				if err != nil {
+					return fmt.Errorf("reading secret value: %w", err)
+				}
+				secretValue = string(pw)
+			}
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			p := c.ResolveProject(project)
+			if err := c.SetSecret(p, args[0], args[1], secretValue); err != nil {
+				return err
+			}
+			fmt.Printf("Secret %q set.\n", args[1])
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
+	cmd.Flags().StringVar(&env, "env", "", "Environment name")
+	cmd.Flags().StringVar(&value, "value", "", "Secret value (for scripting; omit to prompt securely)")
+	return cmd
+}
+
+func newSecretDeleteCmd() *cobra.Command {
+	var project, env string
+	cmd := &cobra.Command{
+		Use:   "delete <app> <name>",
+		Short: "Delete a secret",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			p := c.ResolveProject(project)
+			if err := c.DeleteSecret(p, args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("Secret %q deleted.\n", args[1])
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
+	cmd.Flags().StringVar(&env, "env", "", "Environment name")
+	return cmd
+}

--- a/cmd/cli/secret_test.go
+++ b/cmd/cli/secret_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecretList_QueriesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/projects/myproject/apps/web/secrets"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode([]SecretResponse{
+			{Name: "API_KEY", Keys: []string{"API_KEY"}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	secrets, err := c.ListSecrets(c.ResolveProject(""), "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secrets) != 1 || secrets[0].Name != "API_KEY" {
+		t.Errorf("unexpected secrets: %+v", secrets)
+	}
+}
+
+func TestSecretSet_PostsCorrectBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/projects/myproject/apps/web/secrets"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		var req createSecretRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "DB_PASS" {
+			t.Errorf("expected name 'DB_PASS', got %q", req.Name)
+		}
+		if req.Data["DB_PASS"] != "s3cret" {
+			t.Errorf("expected value 's3cret', got %q", req.Data["DB_PASS"])
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.SetSecret(c.ResolveProject(""), "web", "DB_PASS", "s3cret"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecretDelete_DeletesCorrectPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/projects/myproject/apps/web/secrets/DB_PASS"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if r.Method != http.MethodDelete {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.DeleteSecret(c.ResolveProject(""), "web", "DB_PASS"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecretSubcommands(t *testing.T) {
+	secret := newSecretCmd()
+	subs := map[string]bool{}
+	for _, c := range secret.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, name := range []string{"list", "set", "delete"} {
+		if !subs[name] {
+			t.Errorf("missing secret subcommand: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `mortise secret set/list/delete` — secure value input via term.ReadPassword, --value flag for scripting
- `mortise git-provider list/create/delete/connect-github` — full CRUD + GitHub device flow from terminal
- `mortise platform get/set` — view and configure platform domain, DNS provider
- `mortise repo list/branches` — browse repos from connected git providers
- `mortise app update --image/--replicas` — read-modify-write without full redeploy
- GitHub device flow: `mortise git-provider connect-github` opens browser, polls until authorized

## Test plan

- [ ] `go test ./cmd/cli/... -v` — 48 tests pass
- [ ] `go build -o /tmp/mortise ./cmd/cli && /tmp/mortise --help` — all 15 commands listed
- [ ] `mortise secret set myapp dbpass --env production` — prompts for password securely
- [ ] `mortise git-provider list` — shows connected providers
- [ ] `mortise platform get` — shows current platform config
- [ ] `mortise repo list --provider github-main` — lists repos from connected GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)