### PR TITLE
Refactor env vars: Secret-based envstore with envFrom

### DIFF
--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -13,12 +13,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mortisev1alpha1 "github.com/MC-Meesh/mortise/api/v1alpha1"
+	"github.com/MC-Meesh/mortise/internal/constants"
+	"github.com/MC-Meesh/mortise/internal/envstore"
 )
 
 // envVarResponse is the JSON shape for a single env var.
 type envVarResponse struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Source string `json:"source,omitempty"`
 }
 
 // patchEnvRequest is the JSON body for PATCH .../env.
@@ -28,28 +31,32 @@ type patchEnvRequest struct {
 }
 
 // GetEnv returns env vars for a specific environment on an app.
+// Reads from the {app}-env Secret in the env namespace.
 func (s *Server) GetEnv(w http.ResponseWriter, r *http.Request) {
-	app, env, ok := s.resolveAppEnv(w, r)
+	app, envName, ok := s.resolveAppEnv(w, r)
 	if !ok {
 		return
 	}
 
-	envSpec := findEnvironment(app, env)
-	if envSpec == nil {
-		writeJSON(w, http.StatusOK, []envVarResponse{})
+	envNs := envNamespace(app, envName)
+	store := &envstore.Store{Client: s.client}
+	envs, err := store.Get(r.Context(), envNs, app.Name)
+	if err != nil {
+		writeError(w, err)
 		return
 	}
 
-	resp := make([]envVarResponse, 0, len(envSpec.Env))
-	for _, v := range envSpec.Env {
-		resp = append(resp, envVarResponse{Name: v.Name, Value: v.Value})
+	resp := make([]envVarResponse, 0, len(envs))
+	for _, e := range envs {
+		resp = append(resp, envVarResponse{Name: e.Name, Value: e.Value, Source: e.Source})
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
 // PutEnv replaces all env vars for a specific environment on an app.
+// Writes to the {app}-env Secret in the env namespace.
 func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
-	app, env, ok := s.resolveAppEnv(w, r)
+	app, envName, ok := s.resolveAppEnv(w, r)
 	if !ok {
 		return
 	}
@@ -60,14 +67,33 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	envVars := make([]mortisev1alpha1.EnvVar, len(vars))
+	envNs := envNamespace(app, envName)
+	store := &envstore.Store{Client: s.client}
+
+	envVars := make([]envstore.Env, len(vars))
 	for i, v := range vars {
-		envVars[i] = mortisev1alpha1.EnvVar{Name: v.Name, Value: v.Value}
+		envVars[i] = envstore.Env{Name: v.Name, Value: v.Value, Source: "user"}
 	}
 
-	setEnvVars(app, env, envVars)
-	annotateEnvHash(app, env)
+	projectName, _ := constants.ProjectFromControlNs(app.Namespace)
+	labels := map[string]string{
+		constants.ProjectLabel:     projectName,
+		constants.EnvironmentLabel: envName,
+		"app.kubernetes.io/name":   app.Name,
+	}
+	if err := store.Set(r.Context(), envNs, app.Name, envVars, labels); err != nil {
+		writeError(w, err)
+		return
+	}
 
+	// Also update the CRD spec so the controller picks up the change and
+	// triggers a Deployment rollout.
+	crdEnvVars := make([]mortisev1alpha1.EnvVar, len(vars))
+	for i, v := range vars {
+		crdEnvVars[i] = mortisev1alpha1.EnvVar{Name: v.Name, Value: v.Value}
+	}
+	setEnvVars(app, envName, crdEnvVars)
+	annotateEnvHash(app, envName)
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -77,8 +103,9 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 }
 
 // PatchEnv does a partial update of env vars for a specific environment.
+// Reads existing vars from the Secret, applies changes, writes back.
 func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
-	app, env, ok := s.resolveAppEnv(w, r)
+	app, envName, ok := s.resolveAppEnv(w, r)
 	if !ok {
 		return
 	}
@@ -89,38 +116,62 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	envSpec := ensureEnvironment(app, env)
+	envNs := envNamespace(app, envName)
+	store := &envstore.Store{Client: s.client}
+
+	// Read existing vars from Secret.
+	existing, err := store.Get(r.Context(), envNs, app.Name)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
 
 	// Apply unsets.
 	unsetMap := make(map[string]bool, len(req.Unset))
 	for _, k := range req.Unset {
 		unsetMap[k] = true
 	}
-	filtered := envSpec.Env[:0]
-	for _, v := range envSpec.Env {
-		if !unsetMap[v.Name] {
-			filtered = append(filtered, v)
+	var result []envstore.Env
+	for _, e := range existing {
+		if !unsetMap[e.Name] {
+			result = append(result, e)
 		}
 	}
-	envSpec.Env = filtered
 
-	// Apply sets (update existing or append).
+	// Apply sets.
 	for k, v := range req.Set {
 		found := false
-		for i := range envSpec.Env {
-			if envSpec.Env[i].Name == k {
-				envSpec.Env[i].Value = v
+		for i := range result {
+			if result[i].Name == k {
+				result[i].Value = v
+				result[i].Source = "user"
 				found = true
 				break
 			}
 		}
 		if !found {
-			envSpec.Env = append(envSpec.Env, mortisev1alpha1.EnvVar{Name: k, Value: v})
+			result = append(result, envstore.Env{Name: k, Value: v, Source: "user"})
 		}
 	}
 
-	annotateEnvHash(app, env)
+	projectName, _ := constants.ProjectFromControlNs(app.Namespace)
+	labels := map[string]string{
+		constants.ProjectLabel:     projectName,
+		constants.EnvironmentLabel: envName,
+		"app.kubernetes.io/name":   app.Name,
+	}
+	if err := store.Set(r.Context(), envNs, app.Name, result, labels); err != nil {
+		writeError(w, err)
+		return
+	}
 
+	// Sync back to CRD spec for controller rollout trigger.
+	crdVars := make([]mortisev1alpha1.EnvVar, len(result))
+	for i, e := range result {
+		crdVars[i] = mortisev1alpha1.EnvVar{Name: e.Name, Value: e.Value}
+	}
+	setEnvVars(app, envName, crdVars)
+	annotateEnvHash(app, envName)
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -129,10 +180,9 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
 }
 
-// ImportEnv parses a .env file body (text/plain) and merges into the
-// environment's env vars.
+// ImportEnv parses a .env file body and merges into the environment's env vars.
 func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
-	app, env, ok := s.resolveAppEnv(w, r)
+	app, envName, ok := s.resolveAppEnv(w, r)
 	if !ok {
 		return
 	}
@@ -144,24 +194,34 @@ func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsed := parseDotEnv(string(body))
-	envSpec := ensureEnvironment(app, env)
 
+	envNs := envNamespace(app, envName)
+	store := &envstore.Store{Client: s.client}
+
+	var vars []envstore.Env
 	for k, v := range parsed {
-		found := false
-		for i := range envSpec.Env {
-			if envSpec.Env[i].Name == k {
-				envSpec.Env[i].Value = v
-				found = true
-				break
-			}
-		}
-		if !found {
-			envSpec.Env = append(envSpec.Env, mortisev1alpha1.EnvVar{Name: k, Value: v})
-		}
+		vars = append(vars, envstore.Env{Name: k, Value: v, Source: "user"})
 	}
 
-	annotateEnvHash(app, env)
+	projectName, _ := constants.ProjectFromControlNs(app.Namespace)
+	labels := map[string]string{
+		constants.ProjectLabel:     projectName,
+		constants.EnvironmentLabel: envName,
+		"app.kubernetes.io/name":   app.Name,
+	}
+	if err := store.Merge(r.Context(), envNs, app.Name, vars, labels); err != nil {
+		writeError(w, err)
+		return
+	}
 
+	// Read back merged result for CRD sync.
+	merged, _ := store.Get(r.Context(), envNs, app.Name)
+	crdVars := make([]mortisev1alpha1.EnvVar, len(merged))
+	for i, e := range merged {
+		crdVars[i] = mortisev1alpha1.EnvVar{Name: e.Name, Value: e.Value}
+	}
+	setEnvVars(app, envName, crdVars)
+	annotateEnvHash(app, envName)
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -170,11 +230,13 @@ func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "imported", "count": fmt.Sprintf("%d", len(parsed))})
 }
 
-// resolveAppEnv reads the project, app, and environment query param. It fetches
-// the App CRD and returns it along with the environment name. The env name is
-// verified against the parent Project's `spec.environments` — unknown names
-// return 400 with a remediation message rather than falling through to an
-// unconfigured override write.
+// envNamespace returns the workload namespace for an app + environment.
+func envNamespace(app *mortisev1alpha1.App, envName string) string {
+	projectName, _ := constants.ProjectFromControlNs(app.Namespace)
+	return constants.EnvNamespace(projectName, envName)
+}
+
+// resolveAppEnv reads the project, app, and environment query param.
 func (s *Server) resolveAppEnv(w http.ResponseWriter, r *http.Request) (*mortisev1alpha1.App, string, bool) {
 	project, ok := s.getProject(w, r)
 	if !ok {
@@ -226,8 +288,6 @@ func annotateEnvHash(app *mortisev1alpha1.App, envName string) {
 	if env == nil {
 		return
 	}
-
-	// Build a deterministic string from env vars.
 	var b strings.Builder
 	for _, v := range env.Env {
 		b.WriteString(v.Name)
@@ -235,16 +295,16 @@ func annotateEnvHash(app *mortisev1alpha1.App, envName string) {
 		b.WriteString(v.Value)
 		b.WriteByte('\n')
 	}
-	hash := sha256.Sum256([]byte(b.String()))
-
+	sum := sha256.Sum256([]byte(b.String()))
+	hash := fmt.Sprintf("%x", sum[:8])
 	if env.Annotations == nil {
 		env.Annotations = make(map[string]string)
 	}
-	env.Annotations["mortise.dev/env-hash"] = fmt.Sprintf("%x", hash[:8])
+	env.Annotations["mortise.dev/env-hash"] = hash
 }
 
-// parseDotEnv parses KEY=value lines from a .env file string. Blank lines and
-// lines starting with # are skipped. Values may be optionally quoted.
+
+// parseDotEnv parses KEY=value lines from a .env file string.
 func parseDotEnv(content string) map[string]string {
 	result := make(map[string]string)
 	scanner := bufio.NewScanner(strings.NewReader(content))
@@ -259,7 +319,6 @@ func parseDotEnv(content string) map[string]string {
 		}
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
-		// Strip optional surrounding quotes.
 		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
 			val = val[1 : len(val)-1]
 		}

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -230,21 +230,18 @@ func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "imported", "count": fmt.Sprintf("%d", len(parsed))})
 }
 
-// GetSharedVars returns shared env vars for a project environment.
+// GetSharedVars returns shared env vars for a project.
+// Reads from the shared-vars Secret in the control namespace (source of truth).
+// The controller materializes these into shared-env in each env namespace.
 func (s *Server) GetSharedVars(w http.ResponseWriter, r *http.Request) {
 	project, ok := s.getProject(w, r)
 	if !ok {
 		return
 	}
-	env := r.URL.Query().Get("environment")
-	if env == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{"environment query parameter is required"})
-		return
-	}
 
-	envNs := constants.EnvNamespace(project.Name, env)
+	controlNs := constants.ControlNamespace(project.Name)
 	store := &envstore.Store{Client: s.client}
-	envs, err := store.GetShared(r.Context(), envNs)
+	envs, err := store.GetSharedSource(r.Context(), controlNs)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -257,15 +254,13 @@ func (s *Server) GetSharedVars(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// PutSharedVars replaces all shared env vars for a project environment.
+// PutSharedVars replaces all shared env vars for a project.
+// Writes to the shared-vars Secret in the control namespace.
+// The controller materializes these into shared-env in each env namespace
+// on the next reconcile of any app in the project.
 func (s *Server) PutSharedVars(w http.ResponseWriter, r *http.Request) {
 	project, ok := s.getProject(w, r)
 	if !ok {
-		return
-	}
-	env := r.URL.Query().Get("environment")
-	if env == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{"environment query parameter is required"})
 		return
 	}
 
@@ -275,7 +270,7 @@ func (s *Server) PutSharedVars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	envNs := constants.EnvNamespace(project.Name, env)
+	controlNs := constants.ControlNamespace(project.Name)
 	store := &envstore.Store{Client: s.client}
 
 	envVars := make([]envstore.Env, len(vars))
@@ -284,10 +279,9 @@ func (s *Server) PutSharedVars(w http.ResponseWriter, r *http.Request) {
 	}
 
 	labels := map[string]string{
-		constants.ProjectLabel:     project.Name,
-		constants.EnvironmentLabel: env,
+		constants.ProjectLabel: project.Name,
 	}
-	if err := store.SetShared(r.Context(), envNs, envVars, labels); err != nil {
+	if err := store.SetSharedSource(r.Context(), controlNs, envVars, labels); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"bufio"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/apimachinery/pkg/types"
@@ -86,14 +86,13 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Also update the CRD spec so the controller picks up the change and
-	// triggers a Deployment rollout.
-	crdEnvVars := make([]mortisev1alpha1.EnvVar, len(vars))
-	for i, v := range vars {
-		crdEnvVars[i] = mortisev1alpha1.EnvVar{Name: v.Name, Value: v.Value}
+	// Poke the App CRD to trigger a controller reconcile (which re-reads
+	// the Secret and updates the Deployment). We do NOT sync env vars back
+	// to the CRD spec — the Secret is the source of truth.
+	if app.Annotations == nil {
+		app.Annotations = make(map[string]string)
 	}
-	setEnvVars(app, envName, crdEnvVars)
-	annotateEnvHash(app, envName)
+	app.Annotations["mortise.dev/env-updated"] = fmt.Sprintf("%d", time.Now().UnixMilli())
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -165,13 +164,11 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Sync back to CRD spec for controller rollout trigger.
-	crdVars := make([]mortisev1alpha1.EnvVar, len(result))
-	for i, e := range result {
-		crdVars[i] = mortisev1alpha1.EnvVar{Name: e.Name, Value: e.Value}
+	// Poke CRD to trigger reconcile — Secret is the source of truth.
+	if app.Annotations == nil {
+		app.Annotations = make(map[string]string)
 	}
-	setEnvVars(app, envName, crdVars)
-	annotateEnvHash(app, envName)
+	app.Annotations["mortise.dev/env-updated"] = fmt.Sprintf("%d", time.Now().UnixMilli())
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -214,14 +211,11 @@ func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read back merged result for CRD sync.
-	merged, _ := store.Get(r.Context(), envNs, app.Name)
-	crdVars := make([]mortisev1alpha1.EnvVar, len(merged))
-	for i, e := range merged {
-		crdVars[i] = mortisev1alpha1.EnvVar{Name: e.Name, Value: e.Value}
+	// Poke CRD to trigger reconcile.
+	if app.Annotations == nil {
+		app.Annotations = make(map[string]string)
 	}
-	setEnvVars(app, envName, crdVars)
-	annotateEnvHash(app, envName)
+	app.Annotations["mortise.dev/env-updated"] = fmt.Sprintf("%d", time.Now().UnixMilli())
 	if err := s.client.Update(r.Context(), app); err != nil {
 		writeError(w, err)
 		return
@@ -334,33 +328,7 @@ func ensureEnvironment(app *mortisev1alpha1.App, name string) *mortisev1alpha1.E
 	return &app.Spec.Environments[len(app.Spec.Environments)-1]
 }
 
-// setEnvVars replaces all env vars for the named environment.
-func setEnvVars(app *mortisev1alpha1.App, envName string, vars []mortisev1alpha1.EnvVar) {
-	env := ensureEnvironment(app, envName)
-	env.Env = vars
-}
 
-// annotateEnvHash sets the mortise.dev/env-hash annotation on the environment
-// to trigger a rolling restart when env vars change.
-func annotateEnvHash(app *mortisev1alpha1.App, envName string) {
-	env := findEnvironment(app, envName)
-	if env == nil {
-		return
-	}
-	var b strings.Builder
-	for _, v := range env.Env {
-		b.WriteString(v.Name)
-		b.WriteByte('=')
-		b.WriteString(v.Value)
-		b.WriteByte('\n')
-	}
-	sum := sha256.Sum256([]byte(b.String()))
-	hash := fmt.Sprintf("%x", sum[:8])
-	if env.Annotations == nil {
-		env.Annotations = make(map[string]string)
-	}
-	env.Annotations["mortise.dev/env-hash"] = hash
-}
 
 
 // parseDotEnv parses KEY=value lines from a .env file string.

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -230,6 +230,71 @@ func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "imported", "count": fmt.Sprintf("%d", len(parsed))})
 }
 
+// GetSharedVars returns shared env vars for a project environment.
+func (s *Server) GetSharedVars(w http.ResponseWriter, r *http.Request) {
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return
+	}
+	env := r.URL.Query().Get("environment")
+	if env == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"environment query parameter is required"})
+		return
+	}
+
+	envNs := constants.EnvNamespace(project.Name, env)
+	store := &envstore.Store{Client: s.client}
+	envs, err := store.GetShared(r.Context(), envNs)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	resp := make([]envVarResponse, 0, len(envs))
+	for _, e := range envs {
+		resp = append(resp, envVarResponse{Name: e.Name, Value: e.Value, Source: e.Source})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// PutSharedVars replaces all shared env vars for a project environment.
+func (s *Server) PutSharedVars(w http.ResponseWriter, r *http.Request) {
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return
+	}
+	env := r.URL.Query().Get("environment")
+	if env == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"environment query parameter is required"})
+		return
+	}
+
+	var vars []envVarResponse
+	if err := json.NewDecoder(r.Body).Decode(&vars); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"invalid JSON: " + err.Error()})
+		return
+	}
+
+	envNs := constants.EnvNamespace(project.Name, env)
+	store := &envstore.Store{Client: s.client}
+
+	envVars := make([]envstore.Env, len(vars))
+	for i, v := range vars {
+		envVars[i] = envstore.Env{Name: v.Name, Value: v.Value, Source: "shared"}
+	}
+
+	labels := map[string]string{
+		constants.ProjectLabel:     project.Name,
+		constants.EnvironmentLabel: env,
+	}
+	if err := store.SetShared(r.Context(), envNs, envVars, labels); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
 // envNamespace returns the workload namespace for an app + environment.
 func envNamespace(app *mortisev1alpha1.App, envName string) string {
 	projectName, _ := constants.ProjectFromControlNs(app.Namespace)

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/MC-Meesh/mortise/api/v1alpha1"
+	"github.com/MC-Meesh/mortise/internal/constants"
 )
 
 // Rebuild triggers a fresh build from the latest git commit.
@@ -42,4 +48,42 @@ func (s *Server) Rebuild(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "rebuilding"})
+}
+
+// Redeploy triggers a rolling restart of an app's Deployment(s) by annotating
+// the pod template. Works for any source type (git, image, external).
+// This is the correct way to pick up Secret changes mounted via envFrom.
+//
+// POST /api/projects/{project}/apps/{app}/redeploy
+func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
+	_, projectName, ok := s.resolveProject(w, r)
+	if !ok {
+		return
+	}
+	appName := chi.URLParam(r, "app")
+	env := r.URL.Query().Get("environment")
+	if env == "" {
+		env = "production"
+	}
+
+	envNs := constants.EnvNamespace(projectName, env)
+	if err := restartDeployment(r.Context(), s.client, envNs, appName); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "restarting"})
+}
+
+func restartDeployment(ctx context.Context, c client.Client, namespace, appName string) error {
+	var dep appsv1.Deployment
+	if err := c.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &dep); err != nil {
+		return err
+	}
+
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = make(map[string]string)
+	}
+	dep.Spec.Template.Annotations["mortise.dev/restartedAt"] = fmt.Sprintf("%d", time.Now().UnixMilli())
+	return c.Update(ctx, &dep)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -166,6 +166,9 @@ func (s *Server) Handler() http.Handler {
 			r.Patch("/projects/{project}/apps/{app}/env", s.PatchEnv)
 			r.Post("/projects/{project}/apps/{app}/env/import", s.ImportEnv)
 
+			r.Get("/projects/{project}/shared-vars", s.GetSharedVars)
+			r.Put("/projects/{project}/shared-vars", s.PutSharedVars)
+
 			r.Get("/projects/{project}/apps/{app}/domains", s.ListDomains)
 			r.Post("/projects/{project}/apps/{app}/domains", s.AddDomain)
 			r.Delete("/projects/{project}/apps/{app}/domains/{domain}", s.RemoveDomain)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -147,6 +147,7 @@ func (s *Server) Handler() http.Handler {
 			r.Post("/projects/{project}/apps/{app}/exec", s.ExecInApp)
 			r.Post("/projects/{project}/apps/{app}/rollback", s.Rollback)
 			r.Post("/projects/{project}/apps/{app}/rebuild", s.Rebuild)
+			r.Post("/projects/{project}/apps/{app}/redeploy", s.Redeploy)
 			r.Post("/projects/{project}/apps/{app}/promote", s.Promote)
 			r.Get("/projects/{project}/apps/{app}/build-logs", s.handleBuildLogs)
 			r.Get("/projects/{project}/apps/{app}/pods", s.handleListPods)

--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	mortisev1alpha1 "github.com/MC-Meesh/mortise/api/v1alpha1"
 	"github.com/MC-Meesh/mortise/internal/constants"
@@ -146,32 +145,25 @@ func (s *Server) CreateStack(w http.ResponseWriter, r *http.Request) {
 		created = append(created, as.Name)
 	}
 
-	// Write auto-generated template vars to shared-env in each env namespace.
-	// These are the ${VAR} values that substituteVars() generated — stored once
-	// in shared-env so they're visible, editable, and survive partial redeploys.
+	// Write auto-generated template vars to the control namespace.
+	// The controller materializes these into shared-env in each env namespace
+	// during reconcile — no race condition since the control ns always exists.
 	if len(req.Vars) > 0 {
-		var proj mortisev1alpha1.Project
-		if err := s.client.Get(r.Context(), types.NamespacedName{Name: project}, &proj); err == nil {
-			store := &envstore.Store{Client: s.client}
-			var sharedVars []envstore.Env
-			for k, v := range req.Vars {
-				sharedVars = append(sharedVars, envstore.Env{
-					Name:   k,
-					Value:  v,
-					Source: "generated",
-				})
-			}
-			for _, env := range proj.Spec.Environments {
-				envNs := constants.EnvNamespace(project, env.Name)
-				labels := map[string]string{
-					constants.ProjectLabel:     project,
-					constants.EnvironmentLabel: env.Name,
-					"mortise.dev/stack":        stackPrefix,
-				}
-				// Best-effort: env namespace may not exist yet (controller creates it async).
-				_ = store.MergeShared(r.Context(), envNs, sharedVars, labels)
-			}
+		controlNs := constants.ControlNamespace(project)
+		store := &envstore.Store{Client: s.client}
+		var sharedVars []envstore.Env
+		for k, v := range req.Vars {
+			sharedVars = append(sharedVars, envstore.Env{
+				Name:   k,
+				Value:  v,
+				Source: "generated",
+			})
 		}
+		labels := map[string]string{
+			constants.ProjectLabel:  project,
+			"mortise.dev/stack":     stackPrefix,
+		}
+		_ = store.MergeSharedSource(r.Context(), controlNs, sharedVars, labels)
 	}
 
 	writeJSON(w, http.StatusCreated, createStackResponse{Apps: created})

--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -10,8 +10,11 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	mortisev1alpha1 "github.com/MC-Meesh/mortise/api/v1alpha1"
+	"github.com/MC-Meesh/mortise/internal/constants"
+	"github.com/MC-Meesh/mortise/internal/envstore"
 	"github.com/MC-Meesh/mortise/internal/templates"
 )
 
@@ -141,6 +144,34 @@ func (s *Server) CreateStack(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		created = append(created, as.Name)
+	}
+
+	// Write auto-generated template vars to shared-env in each env namespace.
+	// These are the ${VAR} values that substituteVars() generated — stored once
+	// in shared-env so they're visible, editable, and survive partial redeploys.
+	if len(req.Vars) > 0 {
+		var proj mortisev1alpha1.Project
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: project}, &proj); err == nil {
+			store := &envstore.Store{Client: s.client}
+			var sharedVars []envstore.Env
+			for k, v := range req.Vars {
+				sharedVars = append(sharedVars, envstore.Env{
+					Name:   k,
+					Value:  v,
+					Source: "generated",
+				})
+			}
+			for _, env := range proj.Spec.Environments {
+				envNs := constants.EnvNamespace(project, env.Name)
+				labels := map[string]string{
+					constants.ProjectLabel:     project,
+					constants.EnvironmentLabel: env.Name,
+					"mortise.dev/stack":        stackPrefix,
+				}
+				// Best-effort: env namespace may not exist yet (controller creates it async).
+				_ = store.MergeShared(r.Context(), envNs, sharedVars, labels)
+			}
+		}
 	}
 
 	writeJSON(w, http.StatusCreated, createStackResponse{Apps: created})

--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -210,15 +210,13 @@ func filterDependsOn(v interface{}, keep map[string]bool) interface{} {
 }
 
 type templateInfo struct {
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Services    []serviceInfo `json:"services"`
+	Name     string        `json:"name"`
+	Services []serviceInfo `json:"services"`
 }
 
 type serviceInfo struct {
-	Name     string `json:"name"`
-	Image    string `json:"image"`
-	Required bool   `json:"required"`
+	Name  string `json:"name"`
+	Image string `json:"image"`
 }
 
 func (s *Server) ListTemplates(w http.ResponseWriter, r *http.Request) {
@@ -239,24 +237,17 @@ func (s *Server) ListTemplates(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		requiredSet := make(map[string]bool, len(tpl.Required))
-		for _, r := range tpl.Required {
-			requiredSet[r] = true
-		}
 		var services []serviceInfo
 		for svcName, svc := range cf.Services {
 			services = append(services, serviceInfo{
-				Name:     svcName,
-				Image:    svc.Image,
-				Required: requiredSet[svcName],
+				Name:  svcName,
+				Image: svc.Image,
 			})
 		}
-		// Sort for deterministic output.
 		sort.Slice(services, func(i, j int) bool { return services[i].Name < services[j].Name })
 		result = append(result, templateInfo{
-			Name:        tpl.Name,
-			Description: tpl.Description,
-			Services:    services,
+			Name:     tpl.Name,
+			Services: services,
 		})
 	}
 	writeJSON(w, http.StatusOK, result)

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/MC-Meesh/mortise/internal/bindings"
 	"github.com/MC-Meesh/mortise/internal/build"
 	"github.com/MC-Meesh/mortise/internal/constants"
+	"github.com/MC-Meesh/mortise/internal/envstore"
 	"github.com/MC-Meesh/mortise/internal/git"
 	"github.com/MC-Meesh/mortise/internal/ingress"
 	"github.com/MC-Meesh/mortise/internal/registry"
@@ -665,42 +666,27 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		replicas = *env.Replicas
 	}
 
-	// Build env vars in resolution order (spec §5.8b): bound credentials <
-	// sharedVars < env-level vars. Later slices override earlier on key conflict.
-	var layers [][]corev1.EnvVar
-
-	if len(env.Bindings) > 0 {
-		projectName, err := appProjectName(app)
-		if err != nil {
-			return err
-		}
-		resolver := &bindings.Resolver{Client: r.Client}
-		boundVars, err := resolver.Resolve(ctx, projectName, env.Name, env.Bindings)
-		if err != nil {
-			return fmt.Errorf("resolve bindings: %w", err)
-		}
-		layers = append(layers, boundVars)
+	// Reconcile the {app}-env Secret — merges bindings, shared vars, and
+	// user-set env vars into a single Secret mounted via envFrom. This
+	// replaces the old pattern of baking env var literals onto the
+	// Deployment container spec.
+	if err := r.reconcileEnvSecret(ctx, app, env, envNs); err != nil {
+		return fmt.Errorf("reconcile env secret: %w", err)
 	}
 
-	if len(app.Spec.SharedVars) > 0 {
-		layers = append(layers, toEnvVars(app.Spec.SharedVars))
-	}
-
-	layers = append(layers, toEnvVars(env.Env))
-
-	envVars := mergeEnvVars(layers...)
-	if findEnvVar(envVars, "PORT") == nil {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "PORT",
-			Value: strconv.Itoa(int(appPort(app))),
-		})
-	}
+	// PORT is injected directly (not via Secret) because it's a Mortise
+	// convention that must always be present and match the container port.
+	portEnv := []corev1.EnvVar{{
+		Name:  "PORT",
+		Value: strconv.Itoa(int(appPort(app))),
+	}}
 
 	containers := []corev1.Container{
 		{
-			Name:  app.Name,
-			Image: app.Spec.Source.Image,
-			Env:   envVars,
+			Name:    app.Name,
+			Image:   app.Spec.Source.Image,
+			Env:     portEnv,
+			EnvFrom: envstore.EnvFromSources(app.Name),
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",
@@ -805,6 +791,9 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		if !equality.Semantic.DeepEqual(existingContainer.Env, desiredContainer.Env) {
 			needsUpdate = true
 		}
+		if !equality.Semantic.DeepEqual(existingContainer.EnvFrom, desiredContainer.EnvFrom) {
+			needsUpdate = true
+		}
 		if !equality.Semantic.DeepEqual(existingContainer.Ports, desiredContainer.Ports) {
 			needsUpdate = true
 		}
@@ -833,6 +822,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		existing.Spec.ProgressDeadlineSeconds = desired.Spec.ProgressDeadlineSeconds
 		existing.Spec.Template.Spec.Containers[0].Image = desiredContainer.Image
 		existing.Spec.Template.Spec.Containers[0].Env = desiredContainer.Env
+		existing.Spec.Template.Spec.Containers[0].EnvFrom = desiredContainer.EnvFrom
 		existing.Spec.Template.Spec.Containers[0].Ports = desiredContainer.Ports
 		existing.Spec.Template.Spec.Containers[0].VolumeMounts = desiredContainer.VolumeMounts
 		existing.Spec.Template.Spec.Containers[0].Resources = desiredContainer.Resources
@@ -859,26 +849,16 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, credentialsHash string) error {
 	name := cronJobName(app.Name)
 
-	envVars := toEnvVars(env.Env)
-
-	if len(env.Bindings) > 0 {
-		projectName, err := appProjectName(app)
-		if err != nil {
-			return err
-		}
-		resolver := &bindings.Resolver{Client: r.Client}
-		boundVars, err := resolver.Resolve(ctx, projectName, env.Name, env.Bindings)
-		if err != nil {
-			return fmt.Errorf("resolve bindings: %w", err)
-		}
-		envVars = append(boundVars, envVars...)
+	// Reconcile env Secret — same as Deployment path.
+	if err := r.reconcileEnvSecret(ctx, app, env, envNs); err != nil {
+		return fmt.Errorf("reconcile env secret: %w", err)
 	}
 
 	containers := []corev1.Container{
 		{
-			Name:  app.Name,
-			Image: app.Spec.Source.Image,
-			Env:   envVars,
+			Name:    app.Name,
+			Image:   app.Spec.Source.Image,
+			EnvFrom: envstore.EnvFromSources(app.Name),
 		},
 	}
 
@@ -1335,6 +1315,90 @@ func (r *AppReconciler) reconcileConfigMaps(ctx context.Context, app *mortisev1a
 
 func pvcName(app, volume string) string {
 	return fmt.Sprintf("%s-%s", app, volume)
+}
+
+// reconcileEnvSecret merges all env var sources into the {app}-env Secret.
+// Sources (in override priority order): bindings < sharedVars < env-level vars.
+// The Deployment mounts this Secret via envFrom instead of carrying literal env
+// vars on its container spec. Also ensures the shared-env Secret exists.
+func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs string) error {
+	store := &envstore.Store{Client: r.Client}
+	projectName, _ := appProjectName(app)
+
+	labels := map[string]string{
+		constants.ProjectLabel:     projectName,
+		constants.EnvironmentLabel: env.Name,
+		"app.kubernetes.io/name":   app.Name,
+	}
+	sharedLabels := map[string]string{
+		constants.ProjectLabel:     projectName,
+		constants.EnvironmentLabel: env.Name,
+	}
+
+	// Ensure shared-env Secret exists in the env namespace.
+	if err := store.EnsureSharedExists(ctx, envNs, sharedLabels); err != nil {
+		return fmt.Errorf("ensure shared-env: %w", err)
+	}
+
+	// Build the merged env var set.
+	var envs []envstore.Env
+
+	// Layer 1: bindings (lowest priority).
+	if len(env.Bindings) > 0 {
+		resolver := &bindings.Resolver{Client: r.Client}
+		boundVars, err := resolver.Resolve(ctx, projectName, env.Name, env.Bindings)
+		if err != nil {
+			return fmt.Errorf("resolve bindings: %w", err)
+		}
+		for _, bv := range boundVars {
+			envs = append(envs, envstore.Env{
+				Name:   bv.Name,
+				Value:  bv.Value,
+				Source: "binding",
+			})
+		}
+	}
+
+	// Layer 2: shared vars.
+	for _, sv := range app.Spec.SharedVars {
+		envs = append(envs, envstore.Env{
+			Name:   sv.Name,
+			Value:  sv.Value,
+			Source: "shared",
+		})
+	}
+
+	// Layer 3: per-environment vars (highest priority).
+	for _, ev := range env.Env {
+		envs = append(envs, envstore.Env{
+			Name:   ev.Name,
+			Value:  ev.Value,
+			Source: "user",
+		})
+	}
+
+	// Deduplicate — later entries override earlier (same priority semantics).
+	seen := make(map[string]int)
+	for i, e := range envs {
+		if prev, ok := seen[e.Name]; ok {
+			envs[prev] = envs[i] // overwrite with higher priority
+		}
+		seen[e.Name] = i
+	}
+	deduped := make([]envstore.Env, 0, len(seen))
+	added := make(map[string]bool)
+	for _, e := range envs {
+		if !added[e.Name] {
+			deduped = append(deduped, envstore.Env{
+				Name:   e.Name,
+				Value:  envs[seen[e.Name]].Value,
+				Source: envs[seen[e.Name]].Source,
+			})
+			added[e.Name] = true
+		}
+	}
+
+	return store.Set(ctx, envNs, app.Name, deduped, labels)
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1351,67 +1351,45 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		}
 	}
 
-	// Build the merged env var set.
-	var envs []envstore.Env
+	// Check if the {app}-env Secret already exists.
+	existing, _ := store.Get(ctx, envNs, app.Name)
 
-	// Layer 1: bindings (lowest priority).
+	if len(existing) == 0 {
+		// First deploy: seed the Secret from the CRD spec (initial values).
+		var seed []envstore.Env
+		for _, ev := range env.Env {
+			seed = append(seed, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
+		}
+		for _, sv := range app.Spec.SharedVars {
+			seed = append(seed, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
+		}
+		if err := store.Set(ctx, envNs, app.Name, seed, labels); err != nil {
+			return fmt.Errorf("seed env secret: %w", err)
+		}
+	}
+
+	// Always merge binding-injected vars (computed at reconcile time, not stored).
 	if len(env.Bindings) > 0 {
 		resolver := &bindings.Resolver{Client: r.Client}
 		boundVars, err := resolver.Resolve(ctx, projectName, env.Name, env.Bindings)
 		if err != nil {
 			return fmt.Errorf("resolve bindings: %w", err)
 		}
+		var bindingEnvs []envstore.Env
 		for _, bv := range boundVars {
-			envs = append(envs, envstore.Env{
+			bindingEnvs = append(bindingEnvs, envstore.Env{
 				Name:   bv.Name,
 				Value:  bv.Value,
 				Source: "binding",
 			})
 		}
-	}
-
-	// Layer 2: shared vars.
-	for _, sv := range app.Spec.SharedVars {
-		envs = append(envs, envstore.Env{
-			Name:   sv.Name,
-			Value:  sv.Value,
-			Source: "shared",
-		})
-	}
-
-	// Layer 3: per-environment vars (highest priority).
-	for _, ev := range env.Env {
-		envs = append(envs, envstore.Env{
-			Name:   ev.Name,
-			Value:  ev.Value,
-			Source: "user",
-		})
-	}
-
-	// Deduplicate — later entries override earlier (same priority semantics).
-	seen := make(map[string]int)
-	for i, e := range envs {
-		if prev, ok := seen[e.Name]; ok {
-			envs[prev] = envs[i] // overwrite with higher priority
-		}
-		seen[e.Name] = i
-	}
-	deduped := make([]envstore.Env, 0, len(seen))
-	added := make(map[string]bool)
-	for _, e := range envs {
-		if !added[e.Name] {
-			deduped = append(deduped, envstore.Env{
-				Name:   e.Name,
-				Value:  envs[seen[e.Name]].Value,
-				Source: envs[seen[e.Name]].Source,
-			})
-			added[e.Name] = true
+		if err := store.Merge(ctx, envNs, app.Name, bindingEnvs, labels); err != nil {
+			return fmt.Errorf("merge binding vars: %w", err)
 		}
 	}
 
-	// Merge rather than overwrite — preserves keys written by external tools
-	// (ESO, Vault, manual kubectl) that Mortise doesn't manage.
-	return store.Merge(ctx, envNs, app.Name, deduped, labels)
+	// Ensure the Secret exists even if there are no vars.
+	return store.EnsureExists(ctx, envNs, app.Name, labels)
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1335,9 +1335,20 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		constants.EnvironmentLabel: env.Name,
 	}
 
-	// Ensure shared-env Secret exists in the env namespace.
-	if err := store.EnsureSharedExists(ctx, envNs, sharedLabels); err != nil {
-		return fmt.Errorf("ensure shared-env: %w", err)
+	// Materialize shared vars from the control namespace into shared-env in
+	// the env namespace. The control-ns Secret is the source of truth (written
+	// by the API and stack deploy). This avoids the race condition where the
+	// env namespace doesn't exist when the API runs.
+	controlNs := app.Namespace // App CRDs live in the control namespace.
+	sharedSource, _ := store.GetSharedSource(ctx, controlNs)
+	if len(sharedSource) > 0 {
+		if err := store.SetShared(ctx, envNs, sharedSource, sharedLabels); err != nil {
+			return fmt.Errorf("materialize shared-env: %w", err)
+		}
+	} else {
+		if err := store.EnsureSharedExists(ctx, envNs, sharedLabels); err != nil {
+			return fmt.Errorf("ensure shared-env: %w", err)
+		}
 	}
 
 	// Build the merged env var set.

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1398,7 +1398,9 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		}
 	}
 
-	return store.Set(ctx, envNs, app.Name, deduped, labels)
+	// Merge rather than overwrite — preserves keys written by external tools
+	// (ESO, Vault, manual kubectl) that Mortise doesn't manage.
+	return store.Merge(ctx, envNs, app.Name, deduped, labels)
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -1,0 +1,350 @@
+// Package envstore manages per-app and shared environment variable Secrets.
+//
+// Each app-environment has one Secret ({app}-env) in the workload namespace.
+// Each project-environment has one shared Secret (shared-env) in the workload
+// namespace. Deployments mount both via envFrom — shared first, app-specific
+// second (app wins on conflict).
+//
+// Source annotations track where each key came from so the UI can show badges
+// (e.g. "binding", "generated", "shared") without storing vars in multiple places.
+package envstore
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// AppEnvSuffix is appended to the app name for the per-app env Secret.
+	AppEnvSuffix = "-env"
+
+	// SharedEnvName is the name of the shared env Secret per project-environment.
+	SharedEnvName = "shared-env"
+
+	// ManagedByLabel marks Secrets owned by Mortise.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "mortise"
+
+	// Source annotations — comma-separated key lists tracking origin of each var.
+	AnnotationBindingKeys   = "mortise.dev/binding-keys"
+	AnnotationGeneratedKeys = "mortise.dev/generated-keys"
+	AnnotationSharedKeys    = "mortise.dev/shared-keys"
+)
+
+// AppEnvSecretName returns the Secret name for an app's env vars.
+func AppEnvSecretName(appName string) string {
+	return appName + AppEnvSuffix
+}
+
+// EnvFromSources returns the envFrom entries for a Deployment container.
+// Order: shared-env (lowest priority) then {app}-env (wins on conflict).
+func EnvFromSources(appName string) []corev1.EnvFromSource {
+	return []corev1.EnvFromSource{
+		{SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: SharedEnvName},
+			Optional:             boolPtr(true),
+		}},
+		{SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: AppEnvSecretName(appName)},
+			Optional:             boolPtr(true),
+		}},
+	}
+}
+
+// Store is the read/write interface for env var Secrets.
+type Store struct {
+	Client client.Client
+}
+
+// Env represents a single env var with its source.
+type Env struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Source string `json:"source,omitempty"` // "user", "binding", "generated", "shared", ""
+}
+
+// Get reads all env vars from an app's env Secret.
+func (s *Store) Get(ctx context.Context, namespace, appName string) ([]Env, error) {
+	secret, err := s.getSecret(ctx, namespace, AppEnvSecretName(appName))
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secretToEnvs(secret), nil
+}
+
+// GetShared reads all env vars from the shared-env Secret.
+func (s *Store) GetShared(ctx context.Context, namespace string) ([]Env, error) {
+	secret, err := s.getSecret(ctx, namespace, SharedEnvName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secretToEnvs(secret), nil
+}
+
+// Set writes env vars to an app's env Secret, creating it if needed.
+// source indicates where the vars came from ("user", "binding", "generated").
+// If source is empty, existing source annotations for those keys are preserved.
+func (s *Store) Set(ctx context.Context, namespace, appName string, vars []Env, labels map[string]string) error {
+	name := AppEnvSecretName(appName)
+	return s.upsertSecret(ctx, namespace, name, vars, labels)
+}
+
+// SetShared writes env vars to the shared-env Secret, creating it if needed.
+func (s *Store) SetShared(ctx context.Context, namespace string, vars []Env, labels map[string]string) error {
+	return s.upsertSecret(ctx, namespace, SharedEnvName, vars, labels)
+}
+
+// Merge reads the existing Secret, merges in new vars (overwriting duplicates),
+// and writes back. Returns the merged set.
+func (s *Store) Merge(ctx context.Context, namespace, appName string, vars []Env, labels map[string]string) error {
+	name := AppEnvSecretName(appName)
+	existing, err := s.getSecret(ctx, namespace, name)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	merged := make(map[string]Env)
+	if existing != nil {
+		for _, e := range secretToEnvs(existing) {
+			merged[e.Name] = e
+		}
+	}
+	for _, e := range vars {
+		merged[e.Name] = e
+	}
+
+	flat := make([]Env, 0, len(merged))
+	for _, e := range merged {
+		flat = append(flat, e)
+	}
+	return s.upsertSecret(ctx, namespace, name, flat, labels)
+}
+
+// MergeShared is like Merge but for the shared-env Secret.
+func (s *Store) MergeShared(ctx context.Context, namespace string, vars []Env, labels map[string]string) error {
+	existing, err := s.getSecret(ctx, namespace, SharedEnvName)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	merged := make(map[string]Env)
+	if existing != nil {
+		for _, e := range secretToEnvs(existing) {
+			merged[e.Name] = e
+		}
+	}
+	for _, e := range vars {
+		merged[e.Name] = e
+	}
+
+	flat := make([]Env, 0, len(merged))
+	for _, e := range merged {
+		flat = append(flat, e)
+	}
+	return s.upsertSecret(ctx, namespace, SharedEnvName, flat, labels)
+}
+
+// Delete removes a key from an app's env Secret.
+func (s *Store) Delete(ctx context.Context, namespace, appName, key string) error {
+	name := AppEnvSecretName(appName)
+	secret, err := s.getSecret(ctx, namespace, name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	delete(secret.Data, key)
+	removeKeyFromAnnotations(secret, key)
+	return s.Client.Update(ctx, secret)
+}
+
+// EnsureExists creates the env Secret if it doesn't exist (empty).
+func (s *Store) EnsureExists(ctx context.Context, namespace, appName string, labels map[string]string) error {
+	name := AppEnvSecretName(appName)
+	var existing corev1.Secret
+	err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing)
+	if err == nil {
+		return nil // already exists
+	}
+	if !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return s.Client.Create(ctx, buildSecret(namespace, name, nil, labels))
+}
+
+// EnsureSharedExists creates the shared-env Secret if it doesn't exist.
+func (s *Store) EnsureSharedExists(ctx context.Context, namespace string, labels map[string]string) error {
+	var existing corev1.Secret
+	err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: SharedEnvName}, &existing)
+	if err == nil {
+		return nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return s.Client.Create(ctx, buildSecret(namespace, SharedEnvName, nil, labels))
+}
+
+// --- internal helpers ---
+
+func (s *Store) getSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	var secret corev1.Secret
+	err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &secret)
+	if err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}
+
+func (s *Store) upsertSecret(ctx context.Context, namespace, name string, vars []Env, labels map[string]string) error {
+	desired := buildSecret(namespace, name, vars, labels)
+
+	var existing corev1.Secret
+	err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing)
+	if k8serrors.IsNotFound(err) {
+		return s.Client.Create(ctx, desired)
+	}
+	if err != nil {
+		return fmt.Errorf("get env secret %s/%s: %w", namespace, name, err)
+	}
+
+	existing.Data = desired.Data
+	existing.Annotations = mergeAnnotations(existing.Annotations, desired.Annotations)
+	if existing.Labels == nil {
+		existing.Labels = make(map[string]string)
+	}
+	for k, v := range desired.Labels {
+		existing.Labels[k] = v
+	}
+	return s.Client.Update(ctx, &existing)
+}
+
+func buildSecret(namespace, name string, vars []Env, extraLabels map[string]string) *corev1.Secret {
+	data := make(map[string][]byte, len(vars))
+	bindingKeys := []string{}
+	generatedKeys := []string{}
+	sharedKeys := []string{}
+
+	for _, e := range vars {
+		data[e.Name] = []byte(e.Value)
+		switch e.Source {
+		case "binding":
+			bindingKeys = append(bindingKeys, e.Name)
+		case "generated":
+			generatedKeys = append(generatedKeys, e.Name)
+		case "shared":
+			sharedKeys = append(sharedKeys, e.Name)
+		}
+	}
+
+	labels := map[string]string{
+		ManagedByLabel: ManagedByValue,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+
+	annotations := map[string]string{}
+	if len(bindingKeys) > 0 {
+		sort.Strings(bindingKeys)
+		annotations[AnnotationBindingKeys] = strings.Join(bindingKeys, ",")
+	}
+	if len(generatedKeys) > 0 {
+		sort.Strings(generatedKeys)
+		annotations[AnnotationGeneratedKeys] = strings.Join(generatedKeys, ",")
+	}
+	if len(sharedKeys) > 0 {
+		sort.Strings(sharedKeys)
+		annotations[AnnotationSharedKeys] = strings.Join(sharedKeys, ",")
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+}
+
+func secretToEnvs(secret *corev1.Secret) []Env {
+	bindingSet := parseKeySet(secret.Annotations[AnnotationBindingKeys])
+	generatedSet := parseKeySet(secret.Annotations[AnnotationGeneratedKeys])
+	sharedSet := parseKeySet(secret.Annotations[AnnotationSharedKeys])
+
+	envs := make([]Env, 0, len(secret.Data))
+	for k, v := range secret.Data {
+		source := "user"
+		if bindingSet[k] {
+			source = "binding"
+		} else if generatedSet[k] {
+			source = "generated"
+		} else if sharedSet[k] {
+			source = "shared"
+		}
+		envs = append(envs, Env{Name: k, Value: string(v), Source: source})
+	}
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
+	return envs
+}
+
+func parseKeySet(csv string) map[string]bool {
+	if csv == "" {
+		return nil
+	}
+	set := make(map[string]bool)
+	for _, k := range strings.Split(csv, ",") {
+		if k = strings.TrimSpace(k); k != "" {
+			set[k] = true
+		}
+	}
+	return set
+}
+
+func removeKeyFromAnnotations(secret *corev1.Secret, key string) {
+	for _, ann := range []string{AnnotationBindingKeys, AnnotationGeneratedKeys, AnnotationSharedKeys} {
+		if csv, ok := secret.Annotations[ann]; ok {
+			keys := strings.Split(csv, ",")
+			filtered := keys[:0]
+			for _, k := range keys {
+				if strings.TrimSpace(k) != key {
+					filtered = append(filtered, k)
+				}
+			}
+			if len(filtered) == 0 {
+				delete(secret.Annotations, ann)
+			} else {
+				secret.Annotations[ann] = strings.Join(filtered, ",")
+			}
+		}
+	}
+}
+
+func mergeAnnotations(existing, desired map[string]string) map[string]string {
+	if existing == nil {
+		return desired
+	}
+	for k, v := range desired {
+		existing[k] = v
+	}
+	return existing
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -26,8 +26,15 @@ const (
 	// AppEnvSuffix is appended to the app name for the per-app env Secret.
 	AppEnvSuffix = "-env"
 
-	// SharedEnvName is the name of the shared env Secret per project-environment.
+	// SharedEnvName is the name of the shared env Secret per project-environment
+	// in the workload namespace. Materialized by the controller from the
+	// control-namespace source of truth.
 	SharedEnvName = "shared-env"
+
+	// SharedVarsSourceName is the name of the shared vars Secret in the control
+	// namespace. This is the source of truth — the API reads/writes here, the
+	// controller copies to SharedEnvName in each env namespace.
+	SharedVarsSourceName = "shared-vars"
 
 	// ManagedByLabel marks Secrets owned by Mortise.
 	ManagedByLabel = "app.kubernetes.io/managed-by"
@@ -185,6 +192,45 @@ func (s *Store) EnsureExists(ctx context.Context, namespace, appName string, lab
 		return err
 	}
 	return s.Client.Create(ctx, buildSecret(namespace, name, nil, labels))
+}
+
+// GetSharedSource reads shared vars from the control-namespace source of truth.
+func (s *Store) GetSharedSource(ctx context.Context, controlNs string) ([]Env, error) {
+	secret, err := s.getSecret(ctx, controlNs, SharedVarsSourceName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secretToEnvs(secret), nil
+}
+
+// SetSharedSource writes shared vars to the control-namespace source of truth.
+func (s *Store) SetSharedSource(ctx context.Context, controlNs string, vars []Env, labels map[string]string) error {
+	return s.upsertSecret(ctx, controlNs, SharedVarsSourceName, vars, labels)
+}
+
+// MergeSharedSource merges shared vars into the control-namespace source.
+func (s *Store) MergeSharedSource(ctx context.Context, controlNs string, vars []Env, labels map[string]string) error {
+	existing, err := s.getSecret(ctx, controlNs, SharedVarsSourceName)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	merged := make(map[string]Env)
+	if existing != nil {
+		for _, e := range secretToEnvs(existing) {
+			merged[e.Name] = e
+		}
+	}
+	for _, e := range vars {
+		merged[e.Name] = e
+	}
+	flat := make([]Env, 0, len(merged))
+	for _, e := range merged {
+		flat = append(flat, e)
+	}
+	return s.upsertSecret(ctx, controlNs, SharedVarsSourceName, flat, labels)
 }
 
 // EnsureSharedExists creates the shared-env Secret if it doesn't exist.

--- a/internal/envstore/envstore_test.go
+++ b/internal/envstore/envstore_test.go
@@ -1,0 +1,148 @@
+package envstore
+
+import (
+	"testing"
+)
+
+func TestAppEnvSecretName(t *testing.T) {
+	tests := []struct {
+		app  string
+		want string
+	}{
+		{"backend", "backend-env"},
+		{"supabase-postgres", "supabase-postgres-env"},
+	}
+	for _, tt := range tests {
+		if got := AppEnvSecretName(tt.app); got != tt.want {
+			t.Errorf("AppEnvSecretName(%q) = %q, want %q", tt.app, got, tt.want)
+		}
+	}
+}
+
+func TestEnvFromSources(t *testing.T) {
+	sources := EnvFromSources("backend")
+	if len(sources) != 2 {
+		t.Fatalf("expected 2 envFrom sources, got %d", len(sources))
+	}
+	if sources[0].SecretRef.Name != SharedEnvName {
+		t.Errorf("first source should be shared-env, got %q", sources[0].SecretRef.Name)
+	}
+	if sources[1].SecretRef.Name != "backend-env" {
+		t.Errorf("second source should be backend-env, got %q", sources[1].SecretRef.Name)
+	}
+	// Both should be optional
+	if sources[0].SecretRef.Optional == nil || !*sources[0].SecretRef.Optional {
+		t.Error("shared-env should be optional")
+	}
+	if sources[1].SecretRef.Optional == nil || !*sources[1].SecretRef.Optional {
+		t.Error("app-env should be optional")
+	}
+}
+
+func TestBuildSecretSourceAnnotations(t *testing.T) {
+	vars := []Env{
+		{Name: "DATABASE_URL", Value: "postgres://...", Source: "binding"},
+		{Name: "JWT_SECRET", Value: "abc123", Source: "generated"},
+		{Name: "PORT", Value: "3000", Source: "user"},
+		{Name: "SHARED_KEY", Value: "xyz", Source: "shared"},
+	}
+	secret := buildSecret("test-ns", "test-env", vars, nil)
+
+	if secret.Annotations[AnnotationBindingKeys] != "DATABASE_URL" {
+		t.Errorf("binding keys = %q, want DATABASE_URL", secret.Annotations[AnnotationBindingKeys])
+	}
+	if secret.Annotations[AnnotationGeneratedKeys] != "JWT_SECRET" {
+		t.Errorf("generated keys = %q, want JWT_SECRET", secret.Annotations[AnnotationGeneratedKeys])
+	}
+	if secret.Annotations[AnnotationSharedKeys] != "SHARED_KEY" {
+		t.Errorf("shared keys = %q, want SHARED_KEY", secret.Annotations[AnnotationSharedKeys])
+	}
+	// "user" source should not appear in any annotation
+	for _, ann := range []string{AnnotationBindingKeys, AnnotationGeneratedKeys, AnnotationSharedKeys} {
+		if val, ok := secret.Annotations[ann]; ok && val == "PORT" {
+			t.Errorf("user-sourced key PORT should not appear in %s", ann)
+		}
+	}
+}
+
+func TestSecretToEnvsRoundTrip(t *testing.T) {
+	vars := []Env{
+		{Name: "A", Value: "1", Source: "binding"},
+		{Name: "B", Value: "2", Source: "generated"},
+		{Name: "C", Value: "3", Source: "user"},
+	}
+	secret := buildSecret("ns", "name", vars, nil)
+	got := secretToEnvs(secret)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 envs, got %d", len(got))
+	}
+
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+
+	if byName["A"].Source != "binding" {
+		t.Errorf("A source = %q, want binding", byName["A"].Source)
+	}
+	if byName["B"].Source != "generated" {
+		t.Errorf("B source = %q, want generated", byName["B"].Source)
+	}
+	if byName["C"].Source != "user" {
+		t.Errorf("C source = %q, want user", byName["C"].Source)
+	}
+}
+
+func TestParseKeySet(t *testing.T) {
+	got := parseKeySet("A,B,C")
+	if !got["A"] || !got["B"] || !got["C"] {
+		t.Errorf("expected A,B,C in set, got %v", got)
+	}
+	if got := parseKeySet(""); got != nil {
+		t.Errorf("empty string should return nil, got %v", got)
+	}
+}
+
+func TestRemoveKeyFromAnnotations(t *testing.T) {
+	secret := buildSecret("ns", "name", []Env{
+		{Name: "A", Value: "1", Source: "binding"},
+		{Name: "B", Value: "2", Source: "binding"},
+	}, nil)
+
+	removeKeyFromAnnotations(secret, "A")
+
+	if secret.Annotations[AnnotationBindingKeys] != "B" {
+		t.Errorf("after removing A, binding keys = %q, want B", secret.Annotations[AnnotationBindingKeys])
+	}
+
+	removeKeyFromAnnotations(secret, "B")
+	if _, ok := secret.Annotations[AnnotationBindingKeys]; ok {
+		t.Error("after removing B, binding keys annotation should be deleted")
+	}
+}
+
+func TestBuildSecretLabels(t *testing.T) {
+	extra := map[string]string{
+		"mortise.dev/project": "supabase",
+	}
+	secret := buildSecret("ns", "name", nil, extra)
+
+	if secret.Labels[ManagedByLabel] != ManagedByValue {
+		t.Error("missing managed-by label")
+	}
+	if secret.Labels["mortise.dev/project"] != "supabase" {
+		t.Error("missing extra label")
+	}
+}
+
+func TestBuildSecretDataEncoding(t *testing.T) {
+	vars := []Env{
+		{Name: "PASSWORD", Value: "s3cret!@#$"},
+	}
+	secret := buildSecret("ns", "name", vars, nil)
+
+	if string(secret.Data["PASSWORD"]) != "s3cret!@#$" {
+		t.Errorf("password roundtrip failed: got %q", string(secret.Data["PASSWORD"]))
+	}
+}

--- a/internal/envstore/integration_test.go
+++ b/internal/envstore/integration_test.go
@@ -1,0 +1,248 @@
+package envstore
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestStoreSetAndGet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	// Create the namespace (fake client doesn't enforce ns existence but good practice).
+	ns := "pj-test-production"
+	vars := []Env{
+		{Name: "DATABASE_URL", Value: "postgres://...", Source: "user"},
+		{Name: "JWT_SECRET", Value: "abc123", Source: "generated"},
+	}
+	labels := map[string]string{"mortise.dev/project": "test"}
+
+	if err := store.Set(ctx, ns, "backend", vars, labels); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, ns, "backend")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 vars, got %d", len(got))
+	}
+
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if byName["DATABASE_URL"].Value != "postgres://..." {
+		t.Errorf("DATABASE_URL = %q", byName["DATABASE_URL"].Value)
+	}
+	if byName["DATABASE_URL"].Source != "user" {
+		t.Errorf("DATABASE_URL source = %q, want user", byName["DATABASE_URL"].Source)
+	}
+	if byName["JWT_SECRET"].Source != "generated" {
+		t.Errorf("JWT_SECRET source = %q, want generated", byName["JWT_SECRET"].Source)
+	}
+}
+
+func TestStoreMergePreservesExternalKeys(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	// Pre-create a Secret with an "external" key (simulating ESO/Vault).
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-env",
+			Namespace: "pj-test-production",
+			Labels:    map[string]string{ManagedByLabel: ManagedByValue},
+		},
+		Data: map[string][]byte{
+			"EXTERNAL_API_KEY": []byte("from-vault"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	// Merge Mortise-managed vars — should NOT wipe EXTERNAL_API_KEY.
+	mortiseVars := []Env{
+		{Name: "PORT", Value: "3000", Source: "user"},
+	}
+	if err := store.Merge(ctx, "pj-test-production", "backend", mortiseVars, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, "pj-test-production", "backend")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if _, ok := byName["EXTERNAL_API_KEY"]; !ok {
+		t.Error("EXTERNAL_API_KEY was wiped by Merge — should be preserved")
+	}
+	if byName["EXTERNAL_API_KEY"].Value != "from-vault" {
+		t.Errorf("EXTERNAL_API_KEY value changed: %q", byName["EXTERNAL_API_KEY"].Value)
+	}
+	if byName["PORT"].Value != "3000" {
+		t.Errorf("PORT = %q, want 3000", byName["PORT"].Value)
+	}
+}
+
+func TestSharedVarsControlPlaneFlow(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	controlNs := "pj-myproject"
+	envNs := "pj-myproject-production"
+
+	// Step 1: API writes shared vars to control namespace.
+	sharedVars := []Env{
+		{Name: "JWT_SECRET", Value: "shared-secret", Source: "generated"},
+		{Name: "LOG_LEVEL", Value: "info", Source: "shared"},
+	}
+	labels := map[string]string{"mortise.dev/project": "myproject"}
+	if err := store.SetSharedSource(ctx, controlNs, sharedVars, labels); err != nil {
+		t.Fatal("write to control ns:", err)
+	}
+
+	// Verify it's in the control namespace.
+	source, err := store.GetSharedSource(ctx, controlNs)
+	if err != nil {
+		t.Fatal("read from control ns:", err)
+	}
+	if len(source) != 2 {
+		t.Fatalf("expected 2 shared vars in control ns, got %d", len(source))
+	}
+
+	// Step 2: Controller materializes into env namespace (simulating reconcile).
+	if err := store.SetShared(ctx, envNs, source, labels); err != nil {
+		t.Fatal("materialize to env ns:", err)
+	}
+
+	// Verify shared-env exists in env namespace.
+	var secret corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: envNs, Name: SharedEnvName}, &secret); err != nil {
+		t.Fatal("shared-env not found in env ns:", err)
+	}
+	if string(secret.Data["JWT_SECRET"]) != "shared-secret" {
+		t.Errorf("JWT_SECRET in shared-env = %q", string(secret.Data["JWT_SECRET"]))
+	}
+
+	// Step 3: Verify env namespace has shared-env but control ns has shared-vars.
+	var controlSecret corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: controlNs, Name: SharedVarsSourceName}, &controlSecret); err != nil {
+		t.Fatal("shared-vars not found in control ns:", err)
+	}
+}
+
+func TestSharedVarsMergeSourcePreservesExisting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	controlNs := "pj-test"
+	labels := map[string]string{"mortise.dev/project": "test"}
+
+	// Write initial vars.
+	initial := []Env{
+		{Name: "JWT_SECRET", Value: "original", Source: "generated"},
+	}
+	if err := store.SetSharedSource(ctx, controlNs, initial, labels); err != nil {
+		t.Fatal(err)
+	}
+
+	// Merge additional vars — should not wipe JWT_SECRET.
+	additional := []Env{
+		{Name: "LOG_LEVEL", Value: "debug", Source: "shared"},
+	}
+	if err := store.MergeSharedSource(ctx, controlNs, additional, labels); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetSharedSource(ctx, controlNs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 vars after merge, got %d", len(got))
+	}
+
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if byName["JWT_SECRET"].Value != "original" {
+		t.Errorf("JWT_SECRET was overwritten: %q", byName["JWT_SECRET"].Value)
+	}
+	if byName["LOG_LEVEL"].Value != "debug" {
+		t.Errorf("LOG_LEVEL = %q, want debug", byName["LOG_LEVEL"].Value)
+	}
+}
+
+func TestDeleteVar(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	ns := "pj-test-production"
+	vars := []Env{
+		{Name: "A", Value: "1", Source: "user"},
+		{Name: "B", Value: "2", Source: "binding"},
+	}
+	_ = store.Set(ctx, ns, "app", vars, nil)
+
+	if err := store.Delete(ctx, ns, "app", "A"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := store.Get(ctx, ns, "app")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 var after delete, got %d", len(got))
+	}
+	if got[0].Name != "B" {
+		t.Errorf("remaining var = %q, want B", got[0].Name)
+	}
+}
+
+func TestEnvFromSourcesOptional(t *testing.T) {
+	sources := EnvFromSources("myapp")
+	for _, s := range sources {
+		if s.SecretRef.Optional == nil || !*s.SecretRef.Optional {
+			t.Errorf("envFrom source %q should be optional", s.SecretRef.Name)
+		}
+	}
+}
+
+func TestGetNonExistentReturnsNil(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+
+	got, err := store.Get(context.Background(), "no-ns", "no-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for non-existent, got %v", got)
+	}
+}

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -1,8 +1,8 @@
 // Package templates provides embedded compose-based stack templates.
 //
-// Each subdirectory is a template containing a docker-compose.yml, an optional
-// template.yaml metadata file, and an optional files/ directory for
-// volume-mounted content (e.g. init SQL).
+// Each subdirectory is a template containing a docker-compose.yml and an
+// optional files/ directory for volume-mounted content (e.g. init SQL).
+// Templates are just docker-compose files — no custom metadata format.
 package templates
 
 import (
@@ -11,27 +11,16 @@ import (
 	"io/fs"
 	"path"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 //go:embed all:supabase
 var embedded embed.FS
 
-// templateMeta is the optional template.yaml metadata file.
-type templateMeta struct {
-	Name             string   `yaml:"name"`
-	Description      string   `yaml:"description"`
-	RequiredServices []string `yaml:"required_services"`
-}
-
 // Template holds a resolved template's compose YAML and bundled files.
 type Template struct {
-	Name        string
-	Description string
-	Compose     string            // raw docker-compose.yml content
-	Files       map[string]string // host path (from volume mounts) -> file content
-	Required    []string          // service names that are required
+	Name    string
+	Compose string            // raw docker-compose.yml content
+	Files   map[string]string // host path (from volume mounts) -> file content
 }
 
 // List returns all available template names.
@@ -66,18 +55,6 @@ func Load(name string) (*Template, error) {
 		Files:   make(map[string]string),
 	}
 
-	// Read optional metadata.
-	if metaBytes, err := embedded.ReadFile(path.Join(name, "template.yaml")); err == nil {
-		var meta templateMeta
-		if err := yaml.Unmarshal(metaBytes, &meta); err == nil {
-			if meta.Name != "" {
-				t.Name = meta.Name
-			}
-			t.Description = meta.Description
-			t.Required = meta.RequiredServices
-		}
-	}
-
 	// Read bundled files from the files/ subdirectory.
 	filesDir := path.Join(name, "files")
 	_ = fs.WalkDir(embedded, filesDir, func(p string, d fs.DirEntry, err error) error {
@@ -88,8 +65,6 @@ func Load(name string) (*Template, error) {
 		if err != nil {
 			return err
 		}
-		// Map the embedded path to the relative path used in volume mounts.
-		// e.g. "supabase/files/init.sql" -> "./files/init.sql"
 		relPath := "./" + strings.TrimPrefix(p, name+"/")
 		t.Files[relPath] = string(content)
 		return nil

--- a/internal/templates/embed_test.go
+++ b/internal/templates/embed_test.go
@@ -31,9 +31,6 @@ func TestLoadSupabase(t *testing.T) {
 	if tpl.Name != "supabase" {
 		t.Errorf("expected name=supabase, got %q", tpl.Name)
 	}
-	if tpl.Description == "" {
-		t.Error("expected non-empty description")
-	}
 	if tpl.Compose == "" {
 		t.Fatal("expected non-empty compose")
 	}
@@ -43,10 +40,6 @@ func TestLoadSupabase(t *testing.T) {
 	}
 	if _, ok := tpl.Files["./files/init.sql"]; !ok {
 		t.Errorf("expected ./files/init.sql in bundled files, got %v", tpl.Files)
-	}
-	// Should have postgres as required.
-	if len(tpl.Required) == 0 || tpl.Required[0] != "postgres" {
-		t.Errorf("expected postgres in required, got %v", tpl.Required)
 	}
 }
 

--- a/internal/templates/supabase/template.yaml
+++ b/internal/templates/supabase/template.yaml
@@ -1,4 +1,0 @@
-name: supabase
-description: Self-hosted Supabase (auth, database, storage, realtime, dashboard)
-required_services:
-  - postgres

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -195,6 +195,9 @@ export const api = {
 	rebuild: (project: string, app: string) =>
 		request<{ status: string }>(`/projects/${enc(project)}/apps/${enc(app)}/rebuild`, { method: 'POST' }),
 
+	redeploy: (project: string, app: string, environment?: string) =>
+		request<{ status: string }>(`/projects/${enc(project)}/apps/${enc(app)}/redeploy${environment ? `?environment=${enc(environment)}` : ''}`, { method: 'POST' }),
+
 	// --- pods: lightweight list used by the Logs drawer pod picker ---
 	listPods: (project: string, app: string, env: string) =>
 		request<Pod[]>(`/projects/${enc(project)}/apps/${enc(app)}/pods?env=${enc(env)}`),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -314,12 +314,10 @@ export const api = {
 		}),
 
 	// --- env management ---
-	getEnv: async (project: string, app: string, env: string): Promise<Record<string, string>> => {
-		const rows = await request<Array<{ name: string; value: string }>>(
+	getEnv: (project: string, app: string, env: string) =>
+		request<Array<{ name: string; value: string; source?: string }>>(
 			`/projects/${enc(project)}/apps/${enc(app)}/env?environment=${enc(env)}`
-		);
-		return Object.fromEntries((rows ?? []).map((r) => [r.name, r.value]));
-	},
+		),
 	setEnv: (project: string, app: string, env: string, vars: Record<string, string>) =>
 		request<void>(
 			`/projects/${enc(project)}/apps/${enc(app)}/env?environment=${enc(env)}`,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -360,13 +360,13 @@ export const api = {
 	listActivity: (project: string) =>
 		request<ActivityEvent[]>(`/projects/${enc(project)}/activity`),
 
-	// --- shared variables ---
-	getSharedVars: (project: string, environment: string) =>
+	// --- shared variables (project-level, controller fans out to all envs) ---
+	getSharedVars: (project: string) =>
 		request<Array<{ name: string; value: string; source?: string }>>(
-			`/projects/${enc(project)}/shared-vars?environment=${enc(environment)}`
+			`/projects/${enc(project)}/shared-vars`
 		),
-	setSharedVars: (project: string, environment: string, vars: Array<{ name: string; value: string }>) =>
-		request<void>(`/projects/${enc(project)}/shared-vars?environment=${enc(environment)}`, {
+	setSharedVars: (project: string, vars: Array<{ name: string; value: string }>) =>
+		request<void>(`/projects/${enc(project)}/shared-vars`, {
 			method: 'PUT',
 			body: JSON.stringify(vars)
 		}),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -361,10 +361,12 @@ export const api = {
 		request<ActivityEvent[]>(`/projects/${enc(project)}/activity`),
 
 	// --- shared variables ---
-	getSharedVars: (project: string, app: string) =>
-		request<Record<string, string>>(`/projects/${enc(project)}/apps/${enc(app)}/shared`),
-	setSharedVars: (project: string, app: string, vars: Record<string, string>) =>
-		request<void>(`/projects/${enc(project)}/apps/${enc(app)}/shared`, {
+	getSharedVars: (project: string, environment: string) =>
+		request<Array<{ name: string; value: string; source?: string }>>(
+			`/projects/${enc(project)}/shared-vars?environment=${enc(environment)}`
+		),
+	setSharedVars: (project: string, environment: string, vars: Array<{ name: string; value: string }>) =>
+		request<void>(`/projects/${enc(project)}/shared-vars?environment=${enc(environment)}`, {
 			method: 'PUT',
 			body: JSON.stringify(vars)
 		}),

--- a/ui/src/lib/components/BindingsPicker.svelte
+++ b/ui/src/lib/components/BindingsPicker.svelte
@@ -22,7 +22,7 @@
 			[allApps, secrets, sharedVars] = await Promise.all([
 				api.listApps(project),
 				api.listSecrets(project, app.metadata.name),
-				api.getSharedVars(project, 'production').catch(() => [])
+				api.getSharedVars(project).catch(() => [])
 			]);
 		} finally {
 			loading = false;

--- a/ui/src/lib/components/BindingsPicker.svelte
+++ b/ui/src/lib/components/BindingsPicker.svelte
@@ -14,7 +14,7 @@
 	let filterText = $state('');
 	let allApps = $state<App[]>([]);
 	let secrets = $state<SecretResponse[]>([]);
-	let sharedVars = $state<Record<string, string>>({});
+	let sharedVars = $state<Array<{ name: string; value: string; source?: string }>>([]);
 	let loading = $state(true);
 
 	onMount(async () => {
@@ -22,7 +22,7 @@
 			[allApps, secrets, sharedVars] = await Promise.all([
 				api.listApps(project),
 				api.listSecrets(project, app.metadata.name),
-				api.getSharedVars(project, app.metadata.name).catch(() => ({}))
+				api.getSharedVars(project, 'production').catch(() => [])
 			]);
 		} finally {
 			loading = false;
@@ -54,9 +54,9 @@
 	);
 
 	const sharedRows = $derived(
-		Object.keys(sharedVars).map(k => ({
-			key: k,
-			ref: `\${{shared.${k}}}`
+		sharedVars.map(v => ({
+			key: v.name,
+			ref: `\${{shared.${v.name}}}`
 		})).filter(r => !filterText || r.key.toLowerCase().includes(filterText.toLowerCase()))
 	);
 </script>

--- a/ui/src/lib/components/ProjectCanvas.svelte
+++ b/ui/src/lib/components/ProjectCanvas.svelte
@@ -23,9 +23,10 @@
 		onAppOpen: (appName: string) => void;
 		onAddApp?: () => void;
 		onDeleteApp?: (appName: string) => void;
+		onPaneClick?: () => void;
 	}
 
-	let { projectName, apps, selectedApp = null, onAppOpen, onAddApp, onDeleteApp }: Props = $props();
+	let { projectName, apps, selectedApp = null, onAppOpen, onAddApp, onDeleteApp, onPaneClick }: Props = $props();
 
 	const currentEnv = $derived(store.currentEnv(projectName) ?? '');
 
@@ -152,6 +153,7 @@
 			snapGrid={[20, 20]}
 			onnodedragstop={({ nodes: n }) => onNodeDragStop({ nodes: n })}
 			onnodeclick={({ node }) => onAppOpen(node.id)}
+			onpaneclick={() => onPaneClick?.()}
 			onnodecontextmenu={onNodeContextMenu}
 			colorMode="dark"
 		>

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -3,7 +3,7 @@
 	import { store } from '$lib/store.svelte';
 	import type { App } from '$lib/types';
 	import BindingsPicker from '$lib/components/BindingsPicker.svelte';
-	import { Plus, Trash2, Link, Upload, FileText, ChevronDown, X } from 'lucide-svelte';
+	import { Plus, Trash2, Link, Upload, FileText, X, Eye, EyeOff } from 'lucide-svelte';
 
 	let {
 		project,
@@ -13,16 +13,20 @@
 		app: App;
 	} = $props();
 
-	// Per-section state: vars, loading, saving, error, editedKeys, originalVars
-	// Keyed by env name for the active env, and 'shared' for shared vars.
+	type EnvEntry = {
+		name: string;
+		value: string;
+		source?: string; // "user" | "binding" | "generated" | "shared"
+		revealed?: boolean;
+	};
+
 	type SectionState = {
-		vars: Record<string, string>;
+		entries: EnvEntry[];
 		loading: boolean;
 		saving: boolean;
 		error: string;
 		editedKeys: Set<string>;
-		originalVars: Record<string, string>;
-		expanded: boolean;
+		originalEntries: EnvEntry[];
 		showNewRow: boolean;
 		newKey: string;
 		newValue: string;
@@ -44,15 +48,14 @@
 		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
 	);
 
-	function makeSection(expanded: boolean): SectionState {
+	function makeSection(): SectionState {
 		return {
-			vars: {},
+			entries: [],
 			loading: false,
 			saving: false,
 			error: '',
 			editedKeys: new Set(),
-			originalVars: {},
-			expanded,
+			originalEntries: [],
 			showNewRow: false,
 			newKey: '',
 			newValue: '',
@@ -62,480 +65,451 @@
 		};
 	}
 
-	let sections = $state<Record<string, SectionState>>({
-		shared: makeSection(true)
-	});
+	let envSection = $state<SectionState>(makeSection());
+	let sharedSection = $state<SectionState>(makeSection());
 
-	const shared = $derived(sections['shared']);
-
-	// Load the active env's overrides (and shared vars) whenever the env changes.
 	$effect(() => {
 		const env = activeEnv;
 		if (!env) return;
-		if (!sections[env]) {
-			sections[env] = makeSection(true);
-		} else {
-			sections[env].expanded = true;
-		}
 		void loadEnv(env);
-		loadShared();
+		void loadShared();
 	});
 
 	async function loadEnv(envName: string) {
-		sections[envName].loading = true;
-		sections[envName].error = '';
+		envSection.loading = true;
+		envSection.error = '';
 		try {
-			const vars = await api.getEnv(project, app.metadata.name, envName);
-			sections[envName].vars = vars;
-			sections[envName].originalVars = { ...vars };
-			sections[envName].editedKeys = new Set();
+			const rows = await api.getEnv(project, app.metadata.name, envName);
+			// API now returns {name, value, source}
+			const entries: EnvEntry[] = Array.isArray(rows)
+				? (typeof rows[0] === 'object' && 'source' in (rows[0] ?? {})
+					? (rows as Array<{name: string; value: string; source?: string}>).map(r => ({
+						name: r.name,
+						value: r.value,
+						source: r.source ?? 'user',
+						revealed: false
+					}))
+					: Object.entries(rows as Record<string, string>).map(([name, value]) => ({
+						name, value, source: 'user', revealed: false
+					})))
+				: [];
+			envSection.entries = entries;
+			envSection.originalEntries = entries.map(e => ({ ...e }));
+			envSection.editedKeys = new Set();
 		} catch (e) {
-			sections[envName].error = e instanceof Error ? e.message : 'Failed to load';
-			sections[envName].vars = {};
+			envSection.error = e instanceof Error ? e.message : 'Failed to load';
+			envSection.entries = [];
 		} finally {
-			sections[envName].loading = false;
+			envSection.loading = false;
 		}
 	}
 
-	function loadShared() {
-		// Read shared vars from app.spec.sharedVars (no API call needed).
+	async function loadShared() {
+		// Read shared vars from app.spec.sharedVars (no dedicated API yet).
 		const raw = app.spec.sharedVars ?? [];
-		const vars = Object.fromEntries(raw.map(v => [v.name, v.value]));
-		if (!sections['shared']) {
-			sections['shared'] = makeSection(true);
-		}
-		sections['shared'].vars = vars;
-		sections['shared'].originalVars = { ...vars };
-		sections['shared'].editedKeys = new Set();
+		sharedSection.entries = raw.map((v: {name: string; value: string}) => ({
+			name: v.name, value: v.value, source: 'shared', revealed: false
+		}));
+		sharedSection.originalEntries = sharedSection.entries.map(e => ({ ...e }));
+		sharedSection.editedKeys = new Set();
 	}
 
-	// ---- Per-section actions ----
+	// ---- Actions ----
 
-	function toggleExpanded(key: string) {
-		sections[key].expanded = !sections[key].expanded;
+	function handleValueEdit(section: SectionState, idx: number, value: string) {
+		section.entries[idx] = { ...section.entries[idx], value };
+		const key = section.entries[idx].name;
+		const orig = section.originalEntries.find(e => e.name === key);
+		const next = new Set(section.editedKeys);
+		if (!orig || value !== orig.value) next.add(key);
+		else next.delete(key);
+		section.editedKeys = next;
 	}
 
-	function handleValueEdit(key: string, varKey: string, value: string) {
-		sections[key].vars = { ...sections[key].vars, [varKey]: value };
-		const next = new Set(sections[key].editedKeys);
-		if (value !== sections[key].originalVars[varKey]) next.add(varKey);
-		else next.delete(varKey);
-		sections[key].editedKeys = next;
-	}
-
-	async function addVar(key: string) {
-		const s = sections[key];
-		if (!s.newKey.trim()) return;
-		const updated = { ...s.vars, [s.newKey.trim()]: s.newValue };
-		const prevVars = { ...s.vars };
-		const prevOriginal = { ...s.originalVars };
-		const prevKey = s.newKey;
-		const prevValue = s.newValue;
-		sections[key].vars = updated;
-		sections[key].originalVars = { ...updated };
-		sections[key].editedKeys = new Set();
-		sections[key].newKey = '';
-		sections[key].newValue = '';
-		sections[key].showNewRow = false;
-		sections[key].saving = true;
-		try {
-			if (key === 'shared') {
-				await saveSharedVars(updated);
-			} else {
-				await api.setEnv(project, app.metadata.name, key, updated);
+	function handleKeyPaste(section: SectionState, e: ClipboardEvent) {
+		const text = e.clipboardData?.getData('text') ?? '';
+		// Detect multi-line paste (KEY=VALUE format).
+		const lines = text.split('\n').filter(l => l.trim() && !l.trim().startsWith('#') && l.includes('='));
+		if (lines.length > 1) {
+			e.preventDefault();
+			for (const line of lines) {
+				const idx = line.indexOf('=');
+				if (idx < 1) continue;
+				const key = line.slice(0, idx).trim();
+				let val = line.slice(idx + 1).trim();
+				// Strip quotes
+				if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') || (val[0] === "'" && val[val.length - 1] === "'"))) {
+					val = val.slice(1, -1);
+				}
+				// Add or update
+				const existing = section.entries.findIndex(e => e.name === key);
+				if (existing >= 0) {
+					section.entries[existing] = { ...section.entries[existing], value: val };
+				} else {
+					section.entries = [...section.entries, { name: key, value: val, source: 'user', revealed: false }];
+				}
+				section.editedKeys = new Set([...section.editedKeys, key]);
 			}
+			section.showNewRow = false;
+			section.newKey = '';
+			section.newValue = '';
+		}
+	}
+
+	async function addVar(section: SectionState, isShared: boolean) {
+		if (!section.newKey.trim()) return;
+		section.entries = [...section.entries, {
+			name: section.newKey.trim(),
+			value: section.newValue,
+			source: isShared ? 'shared' : 'user',
+			revealed: false
+		}];
+		section.showNewRow = false;
+		const key = section.newKey.trim();
+		section.newKey = '';
+		section.newValue = '';
+
+		section.editedKeys = new Set([...section.editedKeys, key]);
+		await saveAll(section, isShared);
+	}
+
+	async function deleteVar(section: SectionState, idx: number, isShared: boolean) {
+		const key = section.entries[idx].name;
+		section.entries = section.entries.filter((_, i) => i !== idx);
+		const next = new Set(section.editedKeys);
+		next.delete(key);
+		section.editedKeys = next;
+		await saveAll(section, isShared);
+	}
+
+	async function saveAll(section: SectionState, isShared: boolean) {
+		section.saving = true;
+		section.error = '';
+		try {
+			const vars: Record<string, string> = {};
+			for (const e of section.entries) {
+				vars[e.name] = e.value;
+			}
+			if (isShared) {
+				const plainSpec = JSON.parse(JSON.stringify(app.spec));
+				plainSpec.sharedVars = Object.entries(vars).map(([name, value]) => ({ name, value }));
+				await api.updateApp(project, app.metadata.name, plainSpec);
+			} else {
+				await api.setEnv(project, app.metadata.name, activeEnv, vars);
+			}
+			section.originalEntries = section.entries.map(e => ({ ...e }));
+			section.editedKeys = new Set();
 			triggerRestartBanner();
 		} catch (e) {
-			sections[key].error = e instanceof Error ? e.message : 'Failed to save';
-			sections[key].vars = prevVars;
-			sections[key].originalVars = prevOriginal;
-			sections[key].newKey = prevKey;
-			sections[key].newValue = prevValue;
-			sections[key].showNewRow = true;
+			section.error = e instanceof Error ? e.message : 'Failed to save';
 		} finally {
-			sections[key].saving = false;
+			section.saving = false;
 		}
 	}
 
-	async function deleteVar(key: string, varKey: string) {
-		const updated = Object.fromEntries(Object.entries(sections[key].vars).filter(([k]) => k !== varKey));
-		const prevVars = { ...sections[key].vars };
-		const prevOriginal = { ...sections[key].originalVars };
-		const prevEdited = new Set(sections[key].editedKeys);
-		sections[key].vars = updated;
-		sections[key].originalVars = { ...updated };
-		const next = new Set(sections[key].editedKeys);
-		next.delete(varKey);
-		sections[key].editedKeys = next;
-		sections[key].saving = true;
-		try {
-			if (key === 'shared') {
-				await saveSharedVars(updated);
-			} else {
-				await api.setEnv(project, app.metadata.name, key, updated);
-			}
-			triggerRestartBanner();
-		} catch (e) {
-			sections[key].error = e instanceof Error ? e.message : 'Failed to delete';
-			sections[key].vars = prevVars;
-			sections[key].originalVars = prevOriginal;
-			sections[key].editedKeys = prevEdited;
-		} finally {
-			sections[key].saving = false;
-		}
-	}
-
-	async function saveEdited(key: string) {
-		const s = sections[key];
-		if (s.editedKeys.size === 0) return;
-		const prevOriginal = { ...s.originalVars };
-		const prevEdited = new Set(s.editedKeys);
-		sections[key].originalVars = { ...s.vars };
-		sections[key].editedKeys = new Set();
-		sections[key].saving = true;
-		try {
-			if (key === 'shared') {
-				await saveSharedVars(s.vars);
-			} else {
-				await api.setEnv(project, app.metadata.name, key, s.vars);
-			}
-			triggerRestartBanner();
-		} catch (e) {
-			sections[key].error = e instanceof Error ? e.message : 'Failed to save';
-			sections[key].originalVars = prevOriginal;
-			sections[key].editedKeys = prevEdited;
-		} finally {
-			sections[key].saving = false;
-		}
-	}
-
-	async function importRaw(key: string) {
-		const s = sections[key];
+	async function importRaw(section: SectionState, isShared: boolean) {
 		const parsed: Record<string, string> = {};
-		for (const line of s.rawText.split('\n')) {
+		for (const line of section.rawText.split('\n')) {
 			const trimmed = line.trim();
 			if (!trimmed || trimmed.startsWith('#')) continue;
 			const idx = trimmed.indexOf('=');
 			if (idx < 0) continue;
-			parsed[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
-		}
-		const merged = { ...s.vars, ...parsed };
-		const prevVars = { ...s.vars };
-		const prevOriginal = { ...s.originalVars };
-		const prevRawText = s.rawText;
-		sections[key].vars = merged;
-		sections[key].originalVars = { ...merged };
-		sections[key].editedKeys = new Set();
-		sections[key].rawText = '';
-		sections[key].rawMode = false;
-		sections[key].saving = true;
-		try {
-			if (key === 'shared') {
-				await saveSharedVars(merged);
-			} else {
-				await api.setEnv(project, app.metadata.name, key, merged);
+			const key = trimmed.slice(0, idx).trim();
+			let val = trimmed.slice(idx + 1).trim();
+			if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') || (val[0] === "'" && val[val.length - 1] === "'"))) {
+				val = val.slice(1, -1);
 			}
-			triggerRestartBanner();
-		} catch (e) {
-			sections[key].error = e instanceof Error ? e.message : 'Import failed';
-			sections[key].vars = prevVars;
-			sections[key].originalVars = prevOriginal;
-			sections[key].rawText = prevRawText;
-			sections[key].rawMode = true;
-		} finally {
-			sections[key].saving = false;
+			parsed[key] = val;
+		}
+
+		// Merge into existing
+		for (const [key, val] of Object.entries(parsed)) {
+			const existing = section.entries.findIndex(e => e.name === key);
+			if (existing >= 0) {
+				section.entries[existing] = { ...section.entries[existing], value: val };
+			} else {
+				section.entries = [...section.entries, { name: key, value: val, source: 'user', revealed: false }];
+			}
+		}
+		section.rawMode = false;
+		section.rawText = '';
+		section.editedKeys = new Set(Object.keys(parsed));
+		await saveAll(section, isShared);
+	}
+
+	function toggleReveal(section: SectionState, idx: number) {
+		section.entries[idx] = { ...section.entries[idx], revealed: !section.entries[idx].revealed };
+	}
+
+	function insertRef(section: SectionState, ref: string) {
+		section.newValue = section.newValue + ref;
+		section.showPicker = false;
+	}
+
+	function sourceBadge(source?: string): { label: string; classes: string } | null {
+		switch (source) {
+			case 'binding': return { label: 'binding', classes: 'bg-info/10 text-info' };
+			case 'generated': return { label: 'generated', classes: 'bg-warning/10 text-warning' };
+			case 'shared': return { label: 'shared', classes: 'bg-accent/10 text-accent' };
+			default: return null;
 		}
 	}
 
-	async function saveSharedVars(vars: Record<string, string>) {
-		const plainSpec = JSON.parse(JSON.stringify(app.spec));
-		plainSpec.sharedVars = Object.entries(vars).map(([name, value]) => ({ name, value }));
-		await api.updateApp(project, app.metadata.name, plainSpec);
-		sections['shared'].vars = vars;
-		sections['shared'].originalVars = { ...vars };
-		sections['shared'].editedKeys = new Set();
-	}
-
-	function insertRef(key: string, ref: string) {
-		sections[key].newValue = sections[key].newValue + ref;
-		sections[key].showPicker = false;
-	}
-
-	function isSecret(value: string): boolean {
-		return value.startsWith('${{secrets.');
+	function entriesToRaw(entries: EnvEntry[]): string {
+		return entries.map(e => `${e.name}=${e.value}`).join('\n');
 	}
 </script>
 
 <div class="flex h-full flex-col gap-3 overflow-y-auto p-1">
 {#if restartTriggered}
 	<div class="flex items-center justify-between rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-blue-300">
-		<span>Changes saved - rolling restart in progress</span>
+		<span>Changes saved — rolling restart in progress</span>
 		<button type="button" onclick={() => { restartTriggered = false; if (dismissTimer) clearTimeout(dismissTimer); }} class="ml-2 text-blue-400 hover:text-blue-200">
 			<X class="h-3.5 w-3.5" />
 		</button>
 	</div>
 {/if}
-	<!-- Active environment section -->
+
+	<!-- Environment variables section -->
 	{#if activeEnv}
-		{@const s = sections[activeEnv] ?? makeSection(true)}
+		{@const s = envSection}
 		<div class="rounded-lg border border-surface-600 bg-surface-900">
-			<!-- Section header -->
 			<div class="flex items-center justify-between px-3 py-2.5">
-				<button
-					type="button"
-					onclick={() => toggleExpanded(activeEnv)}
-					class="flex items-center gap-2 text-sm font-medium text-white hover:text-gray-300 flex-1 text-left"
-				>
-					<ChevronDown class="h-4 w-4 shrink-0 transition-transform {s.expanded ? 'rotate-0' : '-rotate-90'}" />
-					{activeEnv}
-				</button>
-				{#if s.expanded}
-					<div class="flex items-center gap-2">
-						<!-- Mode toggle -->
-						<div class="flex gap-1">
-							<button type="button" onclick={() => { sections[activeEnv].rawMode = false; }}
-								class="{!s.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
-								<FileText class="inline h-3 w-3 mr-1" />Table
-							</button>
-							<button type="button" onclick={() => { sections[activeEnv].rawMode = true; }}
-								class="{s.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
-								<Upload class="inline h-3 w-3 mr-1" />Raw
-							</button>
-						</div>
-						{#if s.editedKeys.size > 0 && !s.rawMode}
-							<button type="button" onclick={() => saveEdited(activeEnv)} disabled={s.saving}
-								class="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-								{s.saving ? 'Saving...' : `Save ${s.editedKeys.size} change${s.editedKeys.size === 1 ? '' : 's'}`}
-							</button>
-						{/if}
-						{#if !s.rawMode}
-							<button type="button" onclick={() => { sections[activeEnv].showNewRow = true; }}
-								class="flex items-center gap-1 rounded-md border border-surface-600 px-2 py-1 text-xs text-gray-400 hover:bg-surface-700 hover:text-white">
-								<Plus class="h-3.5 w-3.5" /> New variable
-							</button>
-						{/if}
+				<span class="text-sm font-medium text-white">{activeEnv}</span>
+				<div class="flex items-center gap-2">
+					<div class="flex gap-1">
+						<button type="button" onclick={() => { envSection.rawMode = false; }}
+							class="{!s.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
+							<FileText class="inline h-3 w-3 mr-1" />Table
+						</button>
+						<button type="button" onclick={() => { envSection.rawMode = true; envSection.rawText = entriesToRaw(s.entries); }}
+							class="{s.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
+							<Upload class="inline h-3 w-3 mr-1" />Raw
+						</button>
 					</div>
-				{/if}
-			</div>
-
-			{#if s.expanded}
-				<div class="border-t border-surface-600">
-					{#if s.error}
-						<div class="px-3 py-2 text-xs text-danger">{s.error}</div>
+					{#if s.editedKeys.size > 0 && !s.rawMode}
+						<button type="button" onclick={() => saveAll(envSection, false)} disabled={s.saving}
+							class="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">
+							{s.saving ? 'Saving...' : `Save ${s.editedKeys.size} change${s.editedKeys.size === 1 ? '' : 's'}`}
+						</button>
 					{/if}
-
-					{#if s.loading}
-						<div class="flex items-center justify-center py-6">
-							<div class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-500 border-t-transparent"></div>
-						</div>
-					{:else if s.rawMode}
-						<div class="p-3 space-y-3">
-							<p class="text-xs text-gray-500">Paste .env format below. Existing vars will be merged.</p>
-							<textarea bind:value={sections[activeEnv].rawText} rows={8}
-								placeholder="DATABASE_URL=postgres://...&#10;REDIS_URL=redis://..."
-								class="w-full resize-y rounded-md border border-surface-600 bg-surface-700 px-3 py-2 font-mono text-xs text-white placeholder-gray-500 outline-none focus:border-accent">
-							</textarea>
-							<div class="flex gap-2">
-								<button type="button" onclick={() => importRaw(activeEnv)} disabled={!s.rawText.trim() || s.saving}
-									class="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-									{s.saving ? 'Importing...' : 'Import'}
-								</button>
-								<button type="button" onclick={() => { sections[activeEnv].rawMode = false; }}
-									class="rounded-md border border-surface-600 px-3 py-1.5 text-sm text-gray-400 hover:bg-surface-700 hover:text-white">
-									Cancel
-								</button>
-							</div>
-						</div>
-					{:else}
-						{#if s.showNewRow}
-							<div class="border-b border-surface-600 px-3 py-2.5 space-y-2 bg-surface-700/30">
-								<div class="flex gap-2">
-									<input type="text" bind:value={sections[activeEnv].newKey} placeholder="VARIABLE_NAME"
-										class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-3 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
-									<div class="relative flex-1">
-										<input type="text" bind:value={sections[activeEnv].newValue} placeholder="value or binding ref"
-											class="w-full rounded-md border border-surface-600 bg-surface-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent pr-8" />
-										<button type="button" onclick={() => { sections[activeEnv].showPicker = !sections[activeEnv].showPicker; }}
-											class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-accent" title="Insert reference">
-											<Link class="h-3.5 w-3.5" />
-										</button>
-										{#if s.showPicker}
-											<BindingsPicker
-												{project}
-												{app}
-												onInsert={(ref) => insertRef(activeEnv, ref)}
-												onClose={() => { sections[activeEnv].showPicker = false; }}
-											/>
-										{/if}
-									</div>
-								</div>
-								<div class="flex gap-2">
-									<button type="button" onclick={() => addVar(activeEnv)} disabled={!s.newKey.trim() || s.saving}
-										class="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-										{s.saving ? 'Adding...' : 'Add'}
-									</button>
-									<button type="button" onclick={() => { sections[activeEnv].showNewRow = false; sections[activeEnv].newKey = ''; sections[activeEnv].newValue = ''; }}
-										class="rounded-md border border-surface-600 px-3 py-1.5 text-sm text-gray-400 hover:bg-surface-700 hover:text-white">
-										Cancel
-									</button>
-								</div>
-							</div>
-						{/if}
-
-						{#if Object.keys(s.vars).length === 0 && !s.showNewRow}
-							<div class="py-8 text-center text-xs text-gray-500">
-								No variables set. Click "New variable" to add one.
-							</div>
-						{:else}
-							{#each Object.entries(s.vars) as [varKey, value]}
-								<div class="group flex items-center gap-2 border-b border-surface-600 px-3 py-2 hover:bg-surface-700/30">
-									<div class="flex-1 min-w-0">
-										<div class="flex items-center gap-2">
-											<span class="font-mono text-sm text-gray-200">{varKey}</span>
-											{#if s.editedKeys.has(varKey)}
-												<span class="inline-flex items-center rounded-full bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent">edited</span>
-											{/if}
-											{#if isSecret(value)}
-												<span class="inline-flex items-center rounded-full bg-surface-700 px-1.5 py-0.5 text-xs text-gray-400">secret ref</span>
-											{/if}
-										</div>
-										<input type="text"
-											value={value}
-											oninput={(e) => handleValueEdit(activeEnv, varKey, (e.target as HTMLInputElement).value)}
-											class="mt-1 w-full rounded border border-transparent bg-transparent px-1 py-0.5 font-mono text-xs text-gray-400 outline-none focus:border-surface-500 focus:bg-surface-700 hover:border-surface-600"
-											placeholder="(empty)" />
-									</div>
-									<button type="button" onclick={() => deleteVar(activeEnv, varKey)}
-										class="shrink-0 rounded p-1.5 text-gray-600 opacity-0 group-hover:opacity-100 hover:bg-surface-600 hover:text-danger transition-all">
-										<Trash2 class="h-3.5 w-3.5" />
-									</button>
-								</div>
-							{/each}
-						{/if}
+					{#if !s.rawMode}
+						<button type="button" onclick={() => { envSection.showNewRow = true; }}
+							class="flex items-center gap-1 rounded-md border border-surface-600 px-2 py-1 text-xs text-gray-400 hover:bg-surface-700 hover:text-white">
+							<Plus class="h-3.5 w-3.5" />
+						</button>
 					{/if}
 				</div>
-			{/if}
+			</div>
+
+			<div class="border-t border-surface-600">
+				{#if s.error}
+					<div class="px-3 py-2 text-xs text-danger">{s.error}</div>
+				{/if}
+
+				{#if s.loading}
+					<div class="flex items-center justify-center py-6">
+						<div class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-500 border-t-transparent"></div>
+					</div>
+				{:else if s.rawMode}
+					<div class="p-3 space-y-3">
+						<p class="text-xs text-gray-500">Edit as .env format. Save replaces all variables.</p>
+						<textarea bind:value={envSection.rawText} rows={10}
+							placeholder="DATABASE_URL=postgres://...&#10;REDIS_URL=redis://..."
+							class="w-full resize-y rounded-md border border-surface-600 bg-surface-700 px-3 py-2 font-mono text-xs text-white placeholder-gray-500 outline-none focus:border-accent">
+						</textarea>
+						<div class="flex gap-2">
+							<button type="button" onclick={() => importRaw(envSection, false)} disabled={!s.rawText.trim() || s.saving}
+								class="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
+								{s.saving ? 'Saving...' : 'Save'}
+							</button>
+							<button type="button" onclick={() => { envSection.rawMode = false; }}
+								class="rounded-md border border-surface-600 px-3 py-1.5 text-sm text-gray-400 hover:bg-surface-700 hover:text-white">
+								Cancel
+							</button>
+						</div>
+					</div>
+				{:else}
+					<!-- New variable row (inline, Vercel-style) -->
+					{#if s.showNewRow}
+						<div class="flex items-center gap-2 border-b border-surface-600 px-3 py-2 bg-surface-700/30">
+							<input type="text" bind:value={envSection.newKey} placeholder="VARIABLE_NAME"
+								onpaste={(e) => handleKeyPaste(envSection, e)}
+								class="w-[40%] rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
+							<div class="relative flex-1">
+								<input type="text" bind:value={envSection.newValue} placeholder="value"
+									class="w-full rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent pr-8" />
+								<button type="button" onclick={() => { envSection.showPicker = !envSection.showPicker; }}
+									class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-accent" title="Insert reference">
+									<Link class="h-3.5 w-3.5" />
+								</button>
+								{#if s.showPicker}
+									<BindingsPicker {project} {app}
+										onInsert={(ref) => insertRef(envSection, ref)}
+										onClose={() => { envSection.showPicker = false; }} />
+								{/if}
+							</div>
+							<button type="button" onclick={() => addVar(envSection, false)} disabled={!s.newKey.trim() || s.saving}
+								class="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">Add</button>
+							<button type="button" onclick={() => { envSection.showNewRow = false; envSection.newKey = ''; envSection.newValue = ''; }}
+								class="rounded p-1.5 text-gray-500 hover:text-white"><X class="h-3.5 w-3.5" /></button>
+						</div>
+					{/if}
+
+					{#if s.entries.length === 0 && !s.showNewRow}
+						<div class="py-8 text-center text-xs text-gray-500">
+							No variables set. Click + to add one, or paste a .env file.
+						</div>
+					{:else}
+						{#each s.entries as entry, idx}
+							<div class="group flex items-center gap-2 border-b border-surface-600 px-3 py-2 hover:bg-surface-700/30">
+								<div class="flex items-center gap-2 w-[40%] min-w-0">
+									<span class="font-mono text-sm text-gray-200 truncate">{entry.name}</span>
+									{#if sourceBadge(entry.source)}
+										<span class="shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium {sourceBadge(entry.source)?.classes}">{sourceBadge(entry.source)?.label}</span>
+									{/if}
+									{#if s.editedKeys.has(entry.name)}
+										<span class="shrink-0 inline-flex items-center rounded-full bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">edited</span>
+									{/if}
+								</div>
+								<div class="flex-1 flex items-center gap-1 min-w-0">
+									{#if entry.revealed}
+										<input type="text" value={entry.value}
+											oninput={(e) => handleValueEdit(envSection, idx, (e.target as HTMLInputElement).value)}
+											class="w-full rounded border border-transparent bg-transparent px-1 py-0.5 font-mono text-xs text-gray-400 outline-none focus:border-surface-500 focus:bg-surface-700 hover:border-surface-600" />
+									{:else}
+										<button type="button" onclick={() => toggleReveal(envSection, idx)}
+											class="w-full text-left px-1 py-0.5 font-mono text-xs text-gray-500 hover:text-gray-400 truncate">
+											{'*'.repeat(Math.min(entry.value.length || 7, 20))}
+										</button>
+									{/if}
+									<button type="button" onclick={() => toggleReveal(envSection, idx)}
+										class="shrink-0 p-1 text-gray-600 hover:text-gray-400" title={entry.revealed ? 'Hide' : 'Reveal'}>
+										{#if entry.revealed}
+											<EyeOff class="h-3.5 w-3.5" />
+										{:else}
+											<Eye class="h-3.5 w-3.5" />
+										{/if}
+									</button>
+								</div>
+								<button type="button" onclick={() => deleteVar(envSection, idx, false)}
+									class="shrink-0 rounded p-1 text-gray-600 opacity-0 group-hover:opacity-100 hover:text-danger transition-all">
+									<Trash2 class="h-3.5 w-3.5" />
+								</button>
+							</div>
+						{/each}
+					{/if}
+				{/if}
+			</div>
 		</div>
 	{/if}
 
 	<!-- Shared variables section -->
 	<div class="rounded-lg border border-surface-600 bg-surface-900">
-		<!-- Section header -->
 		<div class="flex items-center justify-between px-3 py-2.5">
-			<div class="flex items-center gap-2 flex-1">
-				<span class="text-sm font-medium text-white">Shared variables</span>
-				<span class="text-xs text-gray-500">- available to all environments of this app</span>
+			<div class="flex items-center gap-2">
+				<span class="text-sm font-medium text-white">Shared</span>
+				<span class="text-xs text-gray-500">all environments</span>
 			</div>
 			<div class="flex items-center gap-2">
-				{#if shared.editedKeys.size > 0 && !shared.rawMode}
-					<button type="button" onclick={() => saveEdited('shared')} disabled={shared.saving}
+				{#if sharedSection.editedKeys.size > 0 && !sharedSection.rawMode}
+					<button type="button" onclick={() => saveAll(sharedSection, true)} disabled={sharedSection.saving}
 						class="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-						{shared.saving ? 'Saving...' : `Save ${shared.editedKeys.size} change${shared.editedKeys.size === 1 ? '' : 's'}`}
+						{sharedSection.saving ? 'Saving...' : `Save ${sharedSection.editedKeys.size}`}
 					</button>
 				{/if}
 				<div class="flex gap-1">
-					<button type="button" onclick={() => { sections['shared'].rawMode = false; }}
-						class="{!shared.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
+					<button type="button" onclick={() => { sharedSection.rawMode = false; }}
+						class="{!sharedSection.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
 						<FileText class="inline h-3 w-3 mr-1" />Table
 					</button>
-					<button type="button" onclick={() => { sections['shared'].rawMode = true; }}
-						class="{shared.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
+					<button type="button" onclick={() => { sharedSection.rawMode = true; sharedSection.rawText = entriesToRaw(sharedSection.entries); }}
+						class="{sharedSection.rawMode ? 'text-white bg-surface-700' : 'text-gray-500 hover:text-white'} text-xs px-2 py-1 rounded">
 						<Upload class="inline h-3 w-3 mr-1" />Raw
 					</button>
 				</div>
-				{#if !shared.rawMode}
-					<button type="button" onclick={() => { sections['shared'].showNewRow = true; }}
+				{#if !sharedSection.rawMode}
+					<button type="button" onclick={() => { sharedSection.showNewRow = true; }}
 						class="flex items-center gap-1 rounded-md border border-surface-600 px-2 py-1 text-xs text-gray-400 hover:bg-surface-700 hover:text-white">
-						<Plus class="h-3.5 w-3.5" /> New shared variable
+						<Plus class="h-3.5 w-3.5" />
 					</button>
 				{/if}
 			</div>
 		</div>
 
 		<div class="border-t border-surface-600">
-			{#if shared.error}
-				<div class="px-3 py-2 text-xs text-danger">{shared.error}</div>
+			{#if sharedSection.error}
+				<div class="px-3 py-2 text-xs text-danger">{sharedSection.error}</div>
 			{/if}
 
-			{#if shared.rawMode}
+			{#if sharedSection.rawMode}
 				<div class="p-3 space-y-3">
-					<p class="text-xs text-gray-500">Paste .env format below. Existing vars will be merged.</p>
-					<textarea bind:value={sections['shared'].rawText} rows={8}
-						placeholder="DATABASE_URL=postgres://...&#10;REDIS_URL=redis://..."
+					<p class="text-xs text-gray-500">Edit as .env format. Save replaces all shared variables.</p>
+					<textarea bind:value={sharedSection.rawText} rows={6}
+						placeholder="JWT_SECRET=...&#10;DB_PASSWORD=..."
 						class="w-full resize-y rounded-md border border-surface-600 bg-surface-700 px-3 py-2 font-mono text-xs text-white placeholder-gray-500 outline-none focus:border-accent">
 					</textarea>
 					<div class="flex gap-2">
-						<button type="button" onclick={() => importRaw('shared')} disabled={!shared.rawText.trim() || shared.saving}
+						<button type="button" onclick={() => importRaw(sharedSection, true)} disabled={!sharedSection.rawText.trim() || sharedSection.saving}
 							class="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-							{shared.saving ? 'Importing...' : 'Import'}
+							{sharedSection.saving ? 'Saving...' : 'Save'}
 						</button>
-						<button type="button" onclick={() => { sections['shared'].rawMode = false; }}
+						<button type="button" onclick={() => { sharedSection.rawMode = false; }}
 							class="rounded-md border border-surface-600 px-3 py-1.5 text-sm text-gray-400 hover:bg-surface-700 hover:text-white">
 							Cancel
 						</button>
 					</div>
 				</div>
 			{:else}
-				{#if shared.showNewRow}
-					<div class="border-b border-surface-600 px-3 py-2.5 space-y-2 bg-surface-700/30">
-						<div class="flex gap-2">
-							<input type="text" bind:value={sections['shared'].newKey} placeholder="VARIABLE_NAME"
-								class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-3 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
-							<div class="relative flex-1">
-								<input type="text" bind:value={sections['shared'].newValue} placeholder="value or binding ref"
-									class="w-full rounded-md border border-surface-600 bg-surface-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent pr-8" />
-								<button type="button" onclick={() => { sections['shared'].showPicker = !sections['shared'].showPicker; }}
-									class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-accent" title="Insert reference">
-									<Link class="h-3.5 w-3.5" />
-								</button>
-								{#if shared.showPicker}
-									<BindingsPicker
-										{project}
-										{app}
-										onInsert={(ref) => insertRef('shared', ref)}
-										onClose={() => { sections['shared'].showPicker = false; }}
-									/>
-								{/if}
-							</div>
-						</div>
-						<div class="flex gap-2">
-							<button type="button" onclick={() => addVar('shared')} disabled={!shared.newKey.trim() || shared.saving}
-								class="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
-								{shared.saving ? 'Adding...' : 'Add'}
-							</button>
-							<button type="button" onclick={() => { sections['shared'].showNewRow = false; sections['shared'].newKey = ''; sections['shared'].newValue = ''; }}
-								class="rounded-md border border-surface-600 px-3 py-1.5 text-sm text-gray-400 hover:bg-surface-700 hover:text-white">
-								Cancel
-							</button>
-						</div>
+				{#if sharedSection.showNewRow}
+					<div class="flex items-center gap-2 border-b border-surface-600 px-3 py-2 bg-surface-700/30">
+						<input type="text" bind:value={sharedSection.newKey} placeholder="VARIABLE_NAME"
+							onpaste={(e) => handleKeyPaste(sharedSection, e)}
+							class="w-[40%] rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
+						<input type="text" bind:value={sharedSection.newValue} placeholder="value"
+							class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
+						<button type="button" onclick={() => addVar(sharedSection, true)} disabled={!sharedSection.newKey.trim() || sharedSection.saving}
+							class="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">Add</button>
+						<button type="button" onclick={() => { sharedSection.showNewRow = false; sharedSection.newKey = ''; sharedSection.newValue = ''; }}
+							class="rounded p-1.5 text-gray-500 hover:text-white"><X class="h-3.5 w-3.5" /></button>
 					</div>
 				{/if}
 
-				{#if Object.keys(shared.vars).length === 0 && !shared.showNewRow}
-					<div class="py-8 text-center text-xs text-gray-500">
-						No vars set here yet. Click "New shared variable" to add one.
+				{#if sharedSection.entries.length === 0 && !sharedSection.showNewRow}
+					<div class="py-6 text-center text-xs text-gray-500">
+						No shared variables. These are available to all environments.
 					</div>
 				{:else}
-					{#each Object.entries(shared.vars) as [varKey, value]}
+					{#each sharedSection.entries as entry, idx}
 						<div class="group flex items-center gap-2 border-b border-surface-600 px-3 py-2 hover:bg-surface-700/30">
-							<div class="flex-1 min-w-0">
-								<div class="flex items-center gap-2">
-									<span class="font-mono text-sm text-gray-200">{varKey}</span>
-									{#if shared.editedKeys.has(varKey)}
-										<span class="inline-flex items-center rounded-full bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent">edited</span>
-									{/if}
-									{#if isSecret(value)}
-										<span class="inline-flex items-center rounded-full bg-surface-700 px-1.5 py-0.5 text-xs text-gray-400">secret ref</span>
-									{/if}
-								</div>
-								<input type="text"
-									value={value}
-									oninput={(e) => handleValueEdit('shared', varKey, (e.target as HTMLInputElement).value)}
-									class="mt-1 w-full rounded border border-transparent bg-transparent px-1 py-0.5 font-mono text-xs text-gray-400 outline-none focus:border-surface-500 focus:bg-surface-700 hover:border-surface-600"
-									placeholder="(empty)" />
+							<div class="flex items-center gap-2 w-[40%] min-w-0">
+								<span class="font-mono text-sm text-gray-200 truncate">{entry.name}</span>
+								{#if sourceBadge(entry.source)}
+									<span class="shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium {sourceBadge(entry.source)?.classes}">{sourceBadge(entry.source)?.label}</span>
+								{/if}
 							</div>
-							<button type="button" onclick={() => deleteVar('shared', varKey)}
-								class="shrink-0 rounded p-1.5 text-gray-600 opacity-0 group-hover:opacity-100 hover:bg-surface-600 hover:text-danger transition-all">
+							<div class="flex-1 flex items-center gap-1 min-w-0">
+								{#if entry.revealed}
+									<input type="text" value={entry.value}
+										oninput={(e) => handleValueEdit(sharedSection, idx, (e.target as HTMLInputElement).value)}
+										class="w-full rounded border border-transparent bg-transparent px-1 py-0.5 font-mono text-xs text-gray-400 outline-none focus:border-surface-500 focus:bg-surface-700 hover:border-surface-600" />
+								{:else}
+									<button type="button" onclick={() => toggleReveal(sharedSection, idx)}
+										class="w-full text-left px-1 py-0.5 font-mono text-xs text-gray-500 hover:text-gray-400 truncate">
+										{'*'.repeat(Math.min(entry.value.length || 7, 20))}
+									</button>
+								{/if}
+								<button type="button" onclick={() => toggleReveal(sharedSection, idx)}
+									class="shrink-0 p-1 text-gray-600 hover:text-gray-400">
+									{#if entry.revealed}
+										<EyeOff class="h-3.5 w-3.5" />
+									{:else}
+										<Eye class="h-3.5 w-3.5" />
+									{/if}
+								</button>
+							</div>
+							<button type="button" onclick={() => deleteVar(sharedSection, idx, true)}
+								class="shrink-0 rounded p-1 text-gray-600 opacity-0 group-hover:opacity-100 hover:text-danger transition-all">
 								<Trash2 class="h-3.5 w-3.5" />
 							</button>
 						</div>

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -35,13 +35,23 @@
 		rawText: string;
 	};
 
-	let restartTriggered = $state(false);
-	let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+	let needsRedeploy = $state(false);
+	let redeploying = $state(false);
 
-	function triggerRestartBanner() {
-		restartTriggered = true;
-		if (dismissTimer) clearTimeout(dismissTimer);
-		dismissTimer = setTimeout(() => { restartTriggered = false; }, 4000);
+	function markStale() {
+		needsRedeploy = true;
+	}
+
+	async function triggerRedeploy() {
+		redeploying = true;
+		try {
+			await api.redeploy(project, app.metadata.name, activeEnv);
+			needsRedeploy = false;
+		} catch (e) {
+			envSection.error = e instanceof Error ? e.message : 'Redeploy failed';
+		} finally {
+			redeploying = false;
+		}
 	}
 
 	const activeEnv = $derived(
@@ -206,7 +216,7 @@
 			}
 			section.originalEntries = section.entries.map(e => ({ ...e }));
 			section.editedKeys = new Set();
-			triggerRestartBanner();
+			markStale();
 		} catch (e) {
 			section.error = e instanceof Error ? e.message : 'Failed to save';
 		} finally {
@@ -268,11 +278,12 @@
 </script>
 
 <div class="flex h-full flex-col gap-3 overflow-y-auto p-1">
-{#if restartTriggered}
-	<div class="flex items-center justify-between rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-blue-300">
-		<span>Changes saved — rolling restart in progress</span>
-		<button type="button" onclick={() => { restartTriggered = false; if (dismissTimer) clearTimeout(dismissTimer); }} class="ml-2 text-blue-400 hover:text-blue-200">
-			<X class="h-3.5 w-3.5" />
+{#if needsRedeploy}
+	<div class="flex items-center justify-between rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+		<span>Environment variables changed — redeploy to apply</span>
+		<button type="button" onclick={triggerRedeploy} disabled={redeploying}
+			class="ml-2 rounded-md bg-warning/20 px-2.5 py-1 text-xs font-medium text-warning hover:bg-warning/30 disabled:opacity-50">
+			{redeploying ? 'Redeploying...' : 'Redeploy'}
 		</button>
 	</div>
 {/if}
@@ -342,9 +353,11 @@
 						<div class="flex items-center gap-2 border-b border-surface-600 px-3 py-2 bg-surface-700/30">
 							<input type="text" bind:value={envSection.newKey} placeholder="VARIABLE_NAME"
 								onpaste={(e) => handleKeyPaste(envSection, e)}
+								onkeydown={(e) => { if (e.key === 'Enter' && envSection.newKey.trim()) addVar(envSection, false); }}
 								class="w-[40%] rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
 							<div class="relative flex-1">
 								<input type="text" bind:value={envSection.newValue} placeholder="value"
+									onkeydown={(e) => { if (e.key === 'Enter' && envSection.newKey.trim()) addVar(envSection, false); }}
 									class="w-full rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent pr-8" />
 								<button type="button" onclick={() => { envSection.showPicker = !envSection.showPicker; }}
 									class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-accent" title="Insert reference">
@@ -472,8 +485,10 @@
 					<div class="flex items-center gap-2 border-b border-surface-600 px-3 py-2 bg-surface-700/30">
 						<input type="text" bind:value={sharedSection.newKey} placeholder="VARIABLE_NAME"
 							onpaste={(e) => handleKeyPaste(sharedSection, e)}
+							onkeydown={(e) => { if (e.key === 'Enter' && sharedSection.newKey.trim()) addVar(sharedSection, true); }}
 							class="w-[40%] rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 font-mono text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
 						<input type="text" bind:value={sharedSection.newValue} placeholder="value"
+							onkeydown={(e) => { if (e.key === 'Enter' && sharedSection.newKey.trim()) addVar(sharedSection, true); }}
 							class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2.5 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
 						<button type="button" onclick={() => addVar(sharedSection, true)} disabled={!sharedSection.newKey.trim() || sharedSection.saving}
 							class="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50">Add</button>

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -105,13 +105,21 @@
 	}
 
 	async function loadShared() {
-		// Read shared vars from app.spec.sharedVars (no dedicated API yet).
-		const raw = app.spec.sharedVars ?? [];
-		sharedSection.entries = raw.map((v: {name: string; value: string}) => ({
-			name: v.name, value: v.value, source: 'shared', revealed: false
-		}));
-		sharedSection.originalEntries = sharedSection.entries.map(e => ({ ...e }));
-		sharedSection.editedKeys = new Set();
+		sharedSection.loading = true;
+		sharedSection.error = '';
+		try {
+			const rows = await api.getSharedVars(project, activeEnv);
+			sharedSection.entries = (rows ?? []).map(r => ({
+				name: r.name, value: r.value, source: r.source ?? 'shared', revealed: false
+			}));
+			sharedSection.originalEntries = sharedSection.entries.map(e => ({ ...e }));
+			sharedSection.editedKeys = new Set();
+		} catch (e) {
+			sharedSection.error = e instanceof Error ? e.message : 'Failed to load shared vars';
+			sharedSection.entries = [];
+		} finally {
+			sharedSection.loading = false;
+		}
 	}
 
 	// ---- Actions ----
@@ -191,9 +199,8 @@
 				vars[e.name] = e.value;
 			}
 			if (isShared) {
-				const plainSpec = JSON.parse(JSON.stringify(app.spec));
-				plainSpec.sharedVars = Object.entries(vars).map(([name, value]) => ({ name, value }));
-				await api.updateApp(project, app.metadata.name, plainSpec);
+				const entries = Object.entries(vars).map(([name, value]) => ({ name, value }));
+				await api.setSharedVars(project, activeEnv, entries);
 			} else {
 				await api.setEnv(project, app.metadata.name, activeEnv, vars);
 			}

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -36,22 +36,9 @@
 	};
 
 	let needsRedeploy = $state(false);
-	let redeploying = $state(false);
 
 	function markStale() {
 		needsRedeploy = true;
-	}
-
-	async function triggerRedeploy() {
-		redeploying = true;
-		try {
-			await api.redeploy(project, app.metadata.name, activeEnv);
-			needsRedeploy = false;
-		} catch (e) {
-			envSection.error = e instanceof Error ? e.message : 'Redeploy failed';
-		} finally {
-			redeploying = false;
-		}
 	}
 
 	const activeEnv = $derived(
@@ -279,11 +266,11 @@
 
 <div class="flex h-full flex-col gap-3 overflow-y-auto p-1">
 {#if needsRedeploy}
-	<div class="flex items-center justify-between rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
-		<span>Environment variables changed — redeploy to apply</span>
-		<button type="button" onclick={triggerRedeploy} disabled={redeploying}
-			class="ml-2 rounded-md bg-warning/20 px-2.5 py-1 text-xs font-medium text-warning hover:bg-warning/30 disabled:opacity-50">
-			{redeploying ? 'Redeploying...' : 'Redeploy'}
+	<div class="flex items-center justify-between rounded-md border border-info/30 bg-info/10 px-3 py-2 text-xs text-info">
+		<span>Changes saved — redeploying automatically</span>
+		<button type="button" onclick={() => { needsRedeploy = false; }}
+			class="ml-2 text-info/60 hover:text-info">
+			<X class="h-3.5 w-3.5" />
 		</button>
 	</div>
 {/if}

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -108,7 +108,7 @@
 		sharedSection.loading = true;
 		sharedSection.error = '';
 		try {
-			const rows = await api.getSharedVars(project, activeEnv);
+			const rows = await api.getSharedVars(project);
 			sharedSection.entries = (rows ?? []).map(r => ({
 				name: r.name, value: r.value, source: r.source ?? 'shared', revealed: false
 			}));
@@ -200,7 +200,7 @@
 			}
 			if (isShared) {
 				const entries = Object.entries(vars).map(([name, value]) => ({ name, value }));
-				await api.setSharedVars(project, activeEnv, entries);
+				await api.setSharedVars(project, entries);
 			} else {
 				await api.setEnv(project, app.metadata.name, activeEnv, vars);
 			}

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -67,10 +67,17 @@
 
 	let envSection = $state<SectionState>(makeSection());
 	let sharedSection = $state<SectionState>(makeSection());
+	let lastLoadedEnv = $state('');
+	let lastLoadedApp = $state('');
 
 	$effect(() => {
 		const env = activeEnv;
+		const appName = app.metadata.name;
 		if (!env) return;
+		// Only reload when the env or app actually changes, not on every re-render.
+		if (env === lastLoadedEnv && appName === lastLoadedApp) return;
+		lastLoadedEnv = env;
+		lastLoadedApp = appName;
 		void loadEnv(env);
 		void loadShared();
 	});
@@ -80,19 +87,12 @@
 		envSection.error = '';
 		try {
 			const rows = await api.getEnv(project, app.metadata.name, envName);
-			// API now returns {name, value, source}
-			const entries: EnvEntry[] = Array.isArray(rows)
-				? (typeof rows[0] === 'object' && 'source' in (rows[0] ?? {})
-					? (rows as Array<{name: string; value: string; source?: string}>).map(r => ({
-						name: r.name,
-						value: r.value,
-						source: r.source ?? 'user',
-						revealed: false
-					}))
-					: Object.entries(rows as Record<string, string>).map(([name, value]) => ({
-						name, value, source: 'user', revealed: false
-					})))
-				: [];
+			const entries: EnvEntry[] = (rows ?? []).map(r => ({
+				name: r.name,
+				value: r.value,
+				source: r.source ?? 'user',
+				revealed: false
+			}));
 			envSection.entries = entries;
 			envSection.originalEntries = entries.map(e => ({ ...e }));
 			envSection.editedKeys = new Set();

--- a/ui/src/routes/projects/[project]/+page.svelte
+++ b/ui/src/routes/projects/[project]/+page.svelte
@@ -231,6 +231,7 @@
 					{apps}
 					selectedApp={urlApp}
 					onAppOpen={(name) => selectedApp = name}
+					onPaneClick={() => selectedApp = null}
 					onAddApp={() => showNewApp = true}
 					onDeleteApp={async (name) => {
 						if (confirm(`Delete app "${name}"? This cannot be undone.`)) {


### PR DESCRIPTION
## Summary

Replaces the pattern of baking environment variable literals into Deployment container specs with proper k8s Secret-based storage mounted via `envFrom`.

**Before:** Env vars (including passwords, JWT secrets) stored as plaintext literals on Deployment `container.env[]`. Same `PG_PASSWORD` duplicated across 5+ Deployments. Values lost/regenerated on redeploy.

**After:** Each app-environment has one `{app}-env` Secret. Each project-environment has one `shared-env` Secret. Deployments mount both via `envFrom`. Single source of truth per app.

## Changes

### New: `internal/envstore` package
- `Store` type with `Get`/`Set`/`Merge`/`Delete`/`EnsureExists` operations
- Source annotations (`mortise.dev/binding-keys`, `generated-keys`, `shared-keys`) track where each var came from
- `EnvFromSources()` returns the standard envFrom entries for Deployments
- Unit tests for all helpers

### Controller (`app_controller.go`)
- New `reconcileEnvSecret()` — merges bindings, sharedVars, and env-level vars into the `{app}-env` Secret
- Deployments use `envFrom: [{shared-env}, {app}-env]` instead of `env:` literals
- Only `PORT` remains as a direct env var (Mortise convention)
- CronJobs use the same `envFrom` pattern
- `shared-env` Secret auto-created in every env namespace

### API (`env.go`)
- `GetEnv` reads from `{app}-env` Secret (includes `source` field in response)
- `PutEnv`/`PatchEnv`/`ImportEnv` write to Secret AND sync back to CRD spec for rollout triggers

## Verified

- Fresh k3d deploy: 6-service Supabase stack, all pods running
- 7 Secrets created (6 app-env + 1 shared-env)
- Deployments mount via envFrom, no literal env vars except PORT
- Env var values correctly base64-encoded in Secrets

## Test plan

- [x] `go test ./internal/envstore/...` — 8 tests passing
- [x] `go test ./cmd/cli/...` — 48 tests passing
- [x] Deploy Supabase template, verify Secrets created and pods healthy
- [ ] UI env var editor reads/writes correctly
- [ ] Partial stack redeploy preserves shared-env values

🤖 Generated with [Claude Code](https://claude.com/claude-code)