### PR TITLE
Map compose named volumes to PVC storage specs

### DIFF
--- a/internal/api/compose.go
+++ b/internal/api/compose.go
@@ -6,9 +6,13 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"gopkg.in/yaml.v3"
 )
+
+const defaultVolumeSize = "1Gi"
 
 // ComposeFile is the top-level docker-compose.yml structure.
 type ComposeFile struct {
@@ -84,8 +88,9 @@ func composeToAppSpecs(compose *ComposeFile, stackPrefix string, bundledFiles ma
 		envVars := parseEnvironment(svc.Environment)
 
 		// Parse volume mounts. If the host path is in bundledFiles, create
-		// a ConfigFile mount (ConfigMap). Otherwise treat as a PVC or skip.
+		// a ConfigFile mount (ConfigMap). Named volumes become PVC storage specs.
 		var configFiles []mortisev1alpha1.ConfigFile
+		var storage []mortisev1alpha1.VolumeSpec
 		for _, vol := range svc.Volumes {
 			parts := strings.SplitN(vol, ":", 2)
 			if len(parts) != 2 {
@@ -100,9 +105,16 @@ func composeToAppSpecs(compose *ComposeFile, stackPrefix string, bundledFiles ma
 					Path:    containerPath,
 					Content: content,
 				})
+				continue
 			}
-			// Named volumes or unresolved file paths are skipped for now.
-			// Future: PVC for named volumes, git repo lookup for file paths.
+
+			if isNamedVolume(hostPath) {
+				storage = append(storage, mortisev1alpha1.VolumeSpec{
+					Name:      hostPath,
+					MountPath: containerPath,
+					Size:      resource.MustParse(defaultVolumeSize),
+				})
+			}
 		}
 
 		as.Spec = mortisev1alpha1.AppSpec{
@@ -114,6 +126,7 @@ func composeToAppSpecs(compose *ComposeFile, stackPrefix string, bundledFiles ma
 				Public: false,
 				Port:   port,
 			},
+			Storage:     storage,
 			ConfigFiles: configFiles,
 			Environments: []mortisev1alpha1.Environment{{
 				Name: "production",
@@ -249,4 +262,14 @@ func topoSort(specs map[string]*appSpec) ([]appSpec, error) {
 		}
 	}
 	return result, nil
+}
+
+// isNamedVolume returns true if the host part of a compose volume mount
+// is a named volume rather than a bind-mount path. Named volumes are bare
+// identifiers (e.g. "db_data"), while bind mounts start with "/", "./", or "../".
+func isNamedVolume(hostPath string) bool {
+	return hostPath != "" &&
+		!strings.HasPrefix(hostPath, "/") &&
+		!strings.HasPrefix(hostPath, "./") &&
+		!strings.HasPrefix(hostPath, "../")
 }

--- a/internal/api/stacks_test.go
+++ b/internal/api/stacks_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // TestParsePortRejectsMalformed verifies that malformed port specs are
@@ -39,5 +41,148 @@ func TestComposeToAppSpecsRejectsMalformedPort(t *testing.T) {
 	}
 	if _, err := composeToAppSpecs(cf, "stack", nil); err == nil {
 		t.Fatal("expected composeToAppSpecs to reject malformed port, got nil")
+	}
+}
+
+func TestIsNamedVolume(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"db_data", true},
+		{"redis-cache", true},
+		{"./data", false},
+		{"../data", false},
+		{"/var/lib/data", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := isNamedVolume(tc.input); got != tc.want {
+				t.Errorf("isNamedVolume(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComposeNamedVolumesCreateStorage(t *testing.T) {
+	yml := `services:
+  db:
+    image: postgres:16
+    ports: ["5432:5432"]
+    volumes:
+      - db_data:/var/lib/postgresql/data
+`
+	cf, err := parseCompose(yml)
+	if err != nil {
+		t.Fatalf("parseCompose: %v", err)
+	}
+	specs, err := composeToAppSpecs(cf, "mystack", nil)
+	if err != nil {
+		t.Fatalf("composeToAppSpecs: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(specs))
+	}
+	storage := specs[0].Spec.Storage
+	if len(storage) != 1 {
+		t.Fatalf("expected 1 storage entry, got %d", len(storage))
+	}
+	if storage[0].Name != "db_data" {
+		t.Errorf("storage name = %q, want %q", storage[0].Name, "db_data")
+	}
+	if storage[0].MountPath != "/var/lib/postgresql/data" {
+		t.Errorf("mountPath = %q, want %q", storage[0].MountPath, "/var/lib/postgresql/data")
+	}
+	expectedSize := resource.MustParse("1Gi")
+	if storage[0].Size.Cmp(expectedSize) != 0 {
+		t.Errorf("size = %s, want %s", storage[0].Size.String(), expectedSize.String())
+	}
+}
+
+func TestComposeBundledFileNotDuplicatedAsVolume(t *testing.T) {
+	yml := `services:
+  db:
+    image: postgres:16
+    ports: ["5432:5432"]
+    volumes:
+      - ./files/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - db_data:/var/lib/postgresql/data
+`
+	bundled := map[string]string{
+		"./files/init.sql": "CREATE TABLE t();",
+	}
+	cf, err := parseCompose(yml)
+	if err != nil {
+		t.Fatalf("parseCompose: %v", err)
+	}
+	specs, err := composeToAppSpecs(cf, "stack", bundled)
+	if err != nil {
+		t.Fatalf("composeToAppSpecs: %v", err)
+	}
+	spec := specs[0].Spec
+	if len(spec.ConfigFiles) != 1 {
+		t.Fatalf("expected 1 configFile, got %d", len(spec.ConfigFiles))
+	}
+	if len(spec.Storage) != 1 {
+		t.Fatalf("expected 1 storage, got %d", len(spec.Storage))
+	}
+	if spec.Storage[0].Name != "db_data" {
+		t.Errorf("storage name = %q, want %q", spec.Storage[0].Name, "db_data")
+	}
+}
+
+func TestComposeMultipleNamedVolumes(t *testing.T) {
+	yml := `services:
+  app:
+    image: myapp:latest
+    ports: ["8080:8080"]
+    volumes:
+      - app_data:/data
+      - app_cache:/cache
+`
+	cf, err := parseCompose(yml)
+	if err != nil {
+		t.Fatalf("parseCompose: %v", err)
+	}
+	specs, err := composeToAppSpecs(cf, "stack", nil)
+	if err != nil {
+		t.Fatalf("composeToAppSpecs: %v", err)
+	}
+	storage := specs[0].Spec.Storage
+	if len(storage) != 2 {
+		t.Fatalf("expected 2 storage entries, got %d", len(storage))
+	}
+	names := map[string]string{}
+	for _, s := range storage {
+		names[s.Name] = s.MountPath
+	}
+	if names["app_data"] != "/data" {
+		t.Errorf("app_data mountPath = %q, want %q", names["app_data"], "/data")
+	}
+	if names["app_cache"] != "/cache" {
+		t.Errorf("app_cache mountPath = %q, want %q", names["app_cache"], "/cache")
+	}
+}
+
+func TestComposeBindMountPathsSkipped(t *testing.T) {
+	yml := `services:
+  web:
+    image: nginx:1.25
+    ports: ["80:80"]
+    volumes:
+      - /host/path:/container/path
+      - ../relative:/other
+`
+	cf, err := parseCompose(yml)
+	if err != nil {
+		t.Fatalf("parseCompose: %v", err)
+	}
+	specs, err := composeToAppSpecs(cf, "stack", nil)
+	if err != nil {
+		t.Fatalf("composeToAppSpecs: %v", err)
+	}
+	if len(specs[0].Spec.Storage) != 0 {
+		t.Errorf("expected no storage for bind mounts, got %d", len(specs[0].Spec.Storage))
 	}
 }


### PR DESCRIPTION
## Summary

- Compose parser now detects named volumes (e.g. `db_data:/var/lib/postgresql/data`) and converts them to `VolumeSpec` entries in the App CRD with a 1Gi default size
- The controller's existing `reconcilePVCs` creates real Kubernetes PVCs from these specs — no controller changes needed
- Bundled file mounts (ConfigMap) continue to work and are correctly distinguished from named volumes via `isNamedVolume()` helper

## Test plan

- [x] `TestIsNamedVolume` — verifies detection of named volumes vs bind mounts
- [x] `TestComposeNamedVolumesCreateStorage` — single named volume produces correct `VolumeSpec`
- [x] `TestComposeBundledFileNotDuplicatedAsVolume` — bundled files become ConfigFiles, named volumes become Storage, no overlap
- [x] `TestComposeMultipleNamedVolumes` — multiple volumes on one service
- [x] `TestComposeBindMountPathsSkipped` — absolute and relative bind mount paths are not treated as named volumes
- [x] Full test suite (595 tests) passes

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)