### PR TITLE
Unify env var rollout: configurable auto vs manual redeploy

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -463,6 +463,12 @@ type AppStatus struct {
 	// +optional
 	DetectedPort int32 `json:"detectedPort,omitempty"`
 
+	// PendingEnvHash is the hash of the current env Secret state. When
+	// AutoRedeploy is disabled and this differs from the hash on the running
+	// pod template, the app has unapplied env changes.
+	// +optional
+	PendingEnvHash string `json:"pendingEnvHash,omitempty"`
+
 	// +listType=map
 	// +listMapKey=type
 	// +optional

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -98,10 +98,13 @@ type ProjectSpec struct {
 	// +optional
 	Preview *PreviewConfig `json:"preview,omitempty"`
 
-	// Future fields (v2+):
-	// - Quota     Quota   — CPU/memory/storage caps per project
-	// - DomainSuffix string — override platform default domain
-	// - Retention Retention — preview env / build cache retention policy
+	// AutoRedeploy controls whether env var changes automatically trigger
+	// pod rollouts. When false (default), users must manually redeploy
+	// after changing variables. When true, the controller stamps a hash
+	// of the env Secret onto the pod template, triggering an automatic
+	// rolling update on any change.
+	// +optional
+	AutoRedeploy bool `json:"autoRedeploy,omitempty"`
 }
 
 // ProjectPhase represents the lifecycle phase of a Project.

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -646,6 +646,12 @@ spec:
                   LastBuiltSHA is the git commit SHA of the most recently completed build.
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
                 type: string
+              pendingEnvHash:
+                description: |-
+                  PendingEnvHash is the hash of the current env Secret state. When
+                  AutoRedeploy is disabled and this differs from the hash on the running
+                  pod template, the app has unapplied env changes.
+                type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.
                 enum:

--- a/charts/mortise-core/crds/mortise.mortise.dev_projects.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_projects.yaml
@@ -59,6 +59,14 @@ spec:
               declared environment (`pj-{metadata.name}-{env}`) which holds the running
               workloads.
             properties:
+              autoRedeploy:
+                description: |-
+                  AutoRedeploy controls whether env var changes automatically trigger
+                  pod rollouts. When false (default), users must manually redeploy
+                  after changing variables. When true, the controller stamps a hash
+                  of the env Secret onto the pod template, triggering an automatic
+                  rolling update on any change.
+                type: boolean
               description:
                 description: Description is a short, human-readable note about the
                   project.

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -646,6 +646,12 @@ spec:
                   LastBuiltSHA is the git commit SHA of the most recently completed build.
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
                 type: string
+              pendingEnvHash:
+                description: |-
+                  PendingEnvHash is the hash of the current env Secret state. When
+                  AutoRedeploy is disabled and this differs from the hash on the running
+                  pod template, the app has unapplied env changes.
+                type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.
                 enum:

--- a/config/crd/bases/mortise.mortise.dev_projects.yaml
+++ b/config/crd/bases/mortise.mortise.dev_projects.yaml
@@ -59,6 +59,14 @@ spec:
               declared environment (`pj-{metadata.name}-{env}`) which holds the running
               workloads.
             properties:
+              autoRedeploy:
+                description: |-
+                  AutoRedeploy controls whether env var changes automatically trigger
+                  pod rollouts. When false (default), users must manually redeploy
+                  after changing variables. When true, the controller stamps a hash
+                  of the env Secret onto the pod template, triggering an automatic
+                  rolling update on any change.
+                type: boolean
               description:
                 description: Description is a short, human-readable note about the
                   project.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1140,6 +1140,13 @@ definitions:
           The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
           +optional
         type: string
+      pendingEnvHash:
+        description: |-
+          PendingEnvHash is the hash of the current env Secret state. When
+          AutoRedeploy is disabled and this differs from the hash on the running
+          pod template, the app has unapplied env changes.
+          +optional
+        type: string
       phase:
         $ref: '#/definitions/v1alpha1.AppPhase'
     type: object

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1140,6 +1140,13 @@ definitions:
           The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
           +optional
         type: string
+      pendingEnvHash:
+        description: |-
+          PendingEnvHash is the hash of the current env Secret state. When
+          AutoRedeploy is disabled and this differs from the hash on the running
+          pod template, the app has unapplied env changes.
+          +optional
+        type: string
       phase:
         $ref: '#/definitions/v1alpha1.AppPhase'
     type: object

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -52,12 +52,13 @@ type createProjectRequest struct {
 // stable subset of the CRD — callers shouldn't need to understand Kubernetes
 // metadata layout to read back a project.
 type projectResponse struct {
-	Name        string                       `json:"name"`
-	Description string                       `json:"description,omitempty"`
-	Namespace   string                       `json:"namespace"`
-	Phase       mortisev1alpha1.ProjectPhase `json:"phase,omitempty"`
-	AppCount    int32                        `json:"appCount"`
-	CreatedAt   string                       `json:"createdAt,omitempty"`
+	Name         string                       `json:"name"`
+	Description  string                       `json:"description,omitempty"`
+	Namespace    string                       `json:"namespace"`
+	Phase        mortisev1alpha1.ProjectPhase `json:"phase,omitempty"`
+	AppCount     int32                        `json:"appCount"`
+	AutoRedeploy bool                         `json:"autoRedeploy"`
+	CreatedAt    string                       `json:"createdAt,omitempty"`
 }
 
 func toProjectResponse(p *mortisev1alpha1.Project) projectResponse {
@@ -66,11 +67,12 @@ func toProjectResponse(p *mortisev1alpha1.Project) projectResponse {
 		ns = projectNamespace(p.Name)
 	}
 	resp := projectResponse{
-		Name:        p.Name,
-		Description: p.Spec.Description,
-		Namespace:   ns,
-		Phase:       p.Status.Phase,
-		AppCount:    p.Status.AppCount,
+		Name:         p.Name,
+		Description:  p.Spec.Description,
+		Namespace:    ns,
+		Phase:        p.Status.Phase,
+		AppCount:     p.Status.AppCount,
+		AutoRedeploy: p.Spec.AutoRedeploy,
 	}
 	if !p.CreationTimestamp.IsZero() {
 		resp.CreatedAt = p.CreationTimestamp.UTC().Format("2006-01-02T15:04:05Z")
@@ -261,6 +263,58 @@ func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, name, "delete", "project", name, "Deleted project "+name, "")
 
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "terminating", "project": name})
+}
+
+type updateProjectRequest struct {
+	Description  *string `json:"description,omitempty"`
+	AutoRedeploy *bool   `json:"autoRedeploy,omitempty"`
+}
+
+// @Summary Update a project
+// @Description Updates mutable Project fields. Admin or project owner only.
+// @Tags projects
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param body body updateProjectRequest true "Fields to update"
+// @Success 200 {object} projectResponse
+// @Failure 400 {object} errorResponse
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project} [patch]
+func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request) {
+	projectName := chi.URLParam(r, "project")
+	if !s.authorize(w, r, authz.Resource{Kind: "project", Project: projectName}, authz.ActionUpdate) {
+		return
+	}
+
+	var req updateProjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"invalid JSON: " + err.Error()})
+		return
+	}
+
+	var project mortisev1alpha1.Project
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: projectName}, &project); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	if req.Description != nil {
+		project.Spec.Description = *req.Description
+	}
+	if req.AutoRedeploy != nil {
+		project.Spec.AutoRedeploy = *req.AutoRedeploy
+	}
+
+	if err := s.client.Update(r.Context(), &project); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toProjectResponse(&project))
 }
 
 // resolveProject is called at the top of every app/secret/log/deploy handler

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -97,13 +97,14 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 	env := envFromQuery(r)
 
 	envNs := constants.EnvNamespace(projectName, env)
-	if err := restartDeployment(r.Context(), s.client, envNs, appName); err != nil {
+
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
 		writeError(w, err)
 		return
 	}
 
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+	if err := restartDeployment(r.Context(), s.client, envNs, appName, app.Status.PendingEnvHash); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -136,7 +137,7 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "restarting"})
 }
 
-func restartDeployment(ctx context.Context, c client.Client, namespace, appName string) error {
+func restartDeployment(ctx context.Context, c client.Client, namespace, appName, pendingEnvHash string) error {
 	var dep appsv1.Deployment
 	if err := c.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &dep); err != nil {
 		return err
@@ -146,5 +147,8 @@ func restartDeployment(ctx context.Context, c client.Client, namespace, appName 
 		dep.Spec.Template.Annotations = make(map[string]string)
 	}
 	dep.Spec.Template.Annotations["mortise.dev/restartedAt"] = fmt.Sprintf("%d", time.Now().UnixMilli())
+	if pendingEnvHash != "" {
+		dep.Spec.Template.Annotations["mortise.dev/env-hash"] = pendingEnvHash
+	}
 	return c.Update(ctx, &dep)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -178,6 +178,7 @@ func (s *Server) Handler() http.Handler {
 			r.Post("/projects", s.CreateProject)
 			r.Get("/projects", s.ListProjects)
 			r.Get("/projects/{project}", s.GetProject)
+			r.Patch("/projects/{project}", s.UpdateProject)
 			r.Delete("/projects/{project}", s.DeleteProject)
 
 			// Project member management

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -195,6 +195,8 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, fmt.Errorf("reconcile credentials secret for env %s: %w", env.Name, err)
 		}
 
+		autoRedeploy := project != nil && project.Spec.AutoRedeploy
+
 		if app.Spec.Kind == mortisev1alpha1.AppKindCron {
 			// Cron envs without a schedule can't produce a valid CronJob.
 			// Auto-membership in a project env doesn't imply a schedule, so
@@ -202,13 +204,13 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if env.Schedule == "" {
 				continue
 			}
-			if err := r.reconcileCronJob(ctx, &app, env, envNs, credentialsHash); err != nil {
+			if err := r.reconcileCronJob(ctx, &app, env, envNs, credentialsHash, autoRedeploy); err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile cronjob for env %s: %w", env.Name, err)
 			}
 			continue
 		}
 
-		if err := r.reconcileDeployment(ctx, &app, env, envNs, credentialsHash); err != nil {
+		if err := r.reconcileDeployment(ctx, &app, env, envNs, credentialsHash, autoRedeploy); err != nil {
 			return ctrl.Result{}, fmt.Errorf("reconcile deployment for env %s: %w", env.Name, err)
 		}
 
@@ -684,7 +686,7 @@ func (r *AppReconciler) setFailedCondition(ctx context.Context, app *mortisev1al
 	return fmt.Errorf("%s: %s", reason, msg)
 }
 
-func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, credentialsHash string) error {
+func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, credentialsHash string, autoRedeploy bool) error {
 	name := deploymentName(app.Name)
 	replicas := int32(1)
 	if env.Replicas != nil {
@@ -752,13 +754,15 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	// rollout triggers. The credentials hash forces a pod restart when the
 	// materialised {app}-credentials Secret changes — kubelet won't otherwise
 	// pick up Secret rotation for env-var mounts without a pod recreate.
+	app.Status.PendingEnvHash = envHash
+
 	podAnno := userAnno
 	if credentialsHash != "" {
 		podAnno = mergeAnnotations(podAnno, map[string]string{
 			"mortise.dev/credentials-hash": credentialsHash,
 		})
 	}
-	if envHash != "" {
+	if autoRedeploy && envHash != "" {
 		podAnno = mergeAnnotations(podAnno, map[string]string{
 			"mortise.dev/env-hash": envHash,
 		})
@@ -902,7 +906,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	return nil
 }
 
-func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, credentialsHash string) error {
+func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, credentialsHash string, autoRedeploy bool) error {
 	name := cronJobName(app.Name)
 
 	// Reconcile env Secret — same as Deployment path.
@@ -931,6 +935,8 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		containers[0].VolumeMounts = mounts
 	}
 
+	app.Status.PendingEnvHash = envHash
+
 	userAnno := mergeAnnotations(nil, env.Annotations)
 
 	podAnno := userAnno
@@ -939,7 +945,7 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 			"mortise.dev/credentials-hash": credentialsHash,
 		})
 	}
-	if envHash != "" {
+	if autoRedeploy && envHash != "" {
 		podAnno = mergeAnnotations(podAnno, map[string]string{
 			"mortise.dev/env-hash": envHash,
 		})
@@ -1964,6 +1970,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 	fresh.Status.Environments = envStatuses
 	fresh.Status.LastBuiltSHA = app.Status.LastBuiltSHA
 	fresh.Status.LastBuiltImage = app.Status.LastBuiltImage
+	fresh.Status.PendingEnvHash = app.Status.PendingEnvHash
 	fresh.Status.Conditions = app.Status.Conditions
 	return r.Status().Update(ctx, &fresh)
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -355,7 +355,7 @@ export const api = {
 		}),
 
 	// --- project settings ---
-	updateProject: (name: string, body: { description?: string }) =>
+	updateProject: (name: string, body: { description?: string; autoRedeploy?: boolean }) =>
 		request<Project>(`/projects/${enc(name)}`, {
 			method: 'PATCH',
 			body: JSON.stringify(body)

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -158,6 +158,7 @@ export interface Project {
 	namespace: string;
 	phase?: ProjectPhase;
 	appCount: number;
+	autoRedeploy: boolean;
 	createdAt?: string;
 }
 

--- a/ui/src/routes/projects/[project]/settings/+page.svelte
+++ b/ui/src/routes/projects/[project]/settings/+page.svelte
@@ -371,6 +371,26 @@ if (tab === 'danger' && projectApps.length === 0 && !loadingApps) await loadApps
             </button>
           </div>
         </div>
+
+        <div class="border-t border-surface-600 pt-5">
+          <h2 class="mb-3 text-sm font-medium text-white">Deploy Behavior</h2>
+          <div class="flex items-start justify-between rounded-md border border-surface-600 p-4">
+            <div>
+              <p class="text-sm font-medium text-white">Auto-redeploy on variable changes</p>
+              <p class="mt-1 text-xs text-gray-500">When enabled, changing environment variables automatically triggers a rolling restart. When disabled, you must manually redeploy after saving changes.</p>
+            </div>
+            <button type="button" role="switch" aria-checked={project?.autoRedeploy ?? false} aria-label="Toggle auto-redeploy"
+              onclick={async () => {
+                if (!project) return;
+                const next = !project.autoRedeploy;
+                project = { ...project, autoRedeploy: next };
+                try { project = await api.updateProject(projectName, { autoRedeploy: next }); } catch { project = { ...project, autoRedeploy: !next }; }
+              }}
+              class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors {project?.autoRedeploy ? 'bg-accent' : 'bg-surface-600'}">
+              <span class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform {project?.autoRedeploy ? 'translate-x-4.5' : 'translate-x-0.5'}"></span>
+            </button>
+          </div>
+        </div>
       </div>
 
     {:else if activeTab === 'environments'}


### PR DESCRIPTION
## Summary

- Adds `autoRedeploy` boolean to ProjectSpec (default: false). When disabled, env var changes do not automatically trigger pod rollouts. When enabled, the controller stamps `mortise.dev/env-hash` on the pod template to trigger rolling updates.
- Adds `PATCH /projects/{project}` endpoint for updating project settings (description, autoRedeploy)
- Adds `pendingEnvHash` to AppStatus so API consumers and UI can detect unapplied env changes
- Redeploy endpoint now stamps the pending env hash on the pod template alongside `restartedAt`, acknowledging the current env state
- Project settings UI gets a "Deploy Behavior" toggle section

## Verified on dev cluster

### Manual mode (autoRedeploy: false)
1. Set env var `FOO=bar` -> pendingEnvHash changed, pod stayed the same, no `env-hash` annotation on pod template
2. Called `POST /redeploy` -> new pod created, rollout triggered via `restartedAt`

### Auto mode (autoRedeploy: true)
1. Enabled via `PATCH /projects/{project}` with `{"autoRedeploy": true}`
2. Set env var `AUTO_TEST=works` -> `env-hash` stamped on pod template, automatic rollout, new pod created

## Test plan

- [x] 636 unit + envtest tests pass
- [x] Manual mode: env change does not trigger rollout, redeploy does
- [x] Auto mode: env change triggers automatic rollout
- [x] PATCH /projects/{project} toggles autoRedeploy correctly
- [x] pendingEnvHash populated on App status after env change
- [x] UI builds without errors

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)