### PR TITLE
Fix drawer refresh, persistent redeploy indicator, canvas chip

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -463,11 +463,14 @@ type AppStatus struct {
 	// +optional
 	DetectedPort int32 `json:"detectedPort,omitempty"`
 
-	// PendingEnvHash is the hash of the current env Secret state. When
-	// AutoRedeploy is disabled and this differs from the hash on the running
-	// pod template, the app has unapplied env changes.
+	// PendingEnvHash is the hash of the current env Secret state.
 	// +optional
 	PendingEnvHash string `json:"pendingEnvHash,omitempty"`
+
+	// DeployedEnvHash is the env hash currently on the running pod template.
+	// When it differs from PendingEnvHash, the app has unapplied env changes.
+	// +optional
+	DeployedEnvHash string `json:"deployedEnvHash,omitempty"`
 
 	// +listType=map
 	// +listMapKey=type

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -575,6 +575,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              deployedEnvHash:
+                description: |-
+                  DeployedEnvHash is the env hash currently on the running pod template.
+                  When it differs from PendingEnvHash, the app has unapplied env changes.
+                type: string
               detectedPort:
                 description: |-
                   DetectedPort is the container port auto-detected from EXPOSE directives
@@ -647,10 +652,8 @@ spec:
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
                 type: string
               pendingEnvHash:
-                description: |-
-                  PendingEnvHash is the hash of the current env Secret state. When
-                  AutoRedeploy is disabled and this differs from the hash on the running
-                  pod template, the app has unapplied env changes.
+                description: PendingEnvHash is the hash of the current env Secret
+                  state.
                 type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -575,6 +575,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              deployedEnvHash:
+                description: |-
+                  DeployedEnvHash is the env hash currently on the running pod template.
+                  When it differs from PendingEnvHash, the app has unapplied env changes.
+                type: string
               detectedPort:
                 description: |-
                   DetectedPort is the container port auto-detected from EXPOSE directives
@@ -647,10 +652,8 @@ spec:
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
                 type: string
               pendingEnvHash:
-                description: |-
-                  PendingEnvHash is the hash of the current env Secret state. When
-                  AutoRedeploy is disabled and this differs from the hash on the running
-                  pod template, the app has unapplied env changes.
+                description: PendingEnvHash is the hash of the current env Secret
+                  state.
                 type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -411,6 +411,8 @@ definitions:
     properties:
       appCount:
         type: integer
+      autoRedeploy:
+        type: boolean
       createdAt:
         type: string
       description:
@@ -494,6 +496,13 @@ definitions:
   api.updateMemberRequest:
     properties:
       role:
+        type: string
+    type: object
+  api.updateProjectRequest:
+    properties:
+      autoRedeploy:
+        type: boolean
+      description:
         type: string
     type: object
   api.updateUserRoleRequest:
@@ -1117,6 +1126,12 @@ definitions:
         items:
           $ref: '#/definitions/v1.Condition'
         type: array
+      deployedEnvHash:
+        description: |-
+          DeployedEnvHash is the env hash currently on the running pod template.
+          When it differs from PendingEnvHash, the app has unapplied env changes.
+          +optional
+        type: string
       detectedPort:
         description: |-
           DetectedPort is the container port auto-detected from EXPOSE directives
@@ -1142,9 +1157,7 @@ definitions:
         type: string
       pendingEnvHash:
         description: |-
-          PendingEnvHash is the hash of the current env Secret state. When
-          AutoRedeploy is disabled and this differs from the hash on the running
-          pod template, the app has unapplied env changes.
+          PendingEnvHash is the hash of the current env Secret state.
           +optional
         type: string
       phase:
@@ -2330,6 +2343,50 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a project
+      tags:
+      - projects
+    patch:
+      consumes:
+      - application/json
+      description: Updates mutable Project fields. Admin or project owner only.
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: Fields to update
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.updateProjectRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.projectResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update a project
       tags:
       - projects
   /projects/{project}/activity:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -411,6 +411,8 @@ definitions:
     properties:
       appCount:
         type: integer
+      autoRedeploy:
+        type: boolean
       createdAt:
         type: string
       description:
@@ -494,6 +496,13 @@ definitions:
   api.updateMemberRequest:
     properties:
       role:
+        type: string
+    type: object
+  api.updateProjectRequest:
+    properties:
+      autoRedeploy:
+        type: boolean
+      description:
         type: string
     type: object
   api.updateUserRoleRequest:
@@ -1117,6 +1126,12 @@ definitions:
         items:
           $ref: '#/definitions/v1.Condition'
         type: array
+      deployedEnvHash:
+        description: |-
+          DeployedEnvHash is the env hash currently on the running pod template.
+          When it differs from PendingEnvHash, the app has unapplied env changes.
+          +optional
+        type: string
       detectedPort:
         description: |-
           DetectedPort is the container port auto-detected from EXPOSE directives
@@ -1142,9 +1157,7 @@ definitions:
         type: string
       pendingEnvHash:
         description: |-
-          PendingEnvHash is the hash of the current env Secret state. When
-          AutoRedeploy is disabled and this differs from the hash on the running
-          pod template, the app has unapplied env changes.
+          PendingEnvHash is the hash of the current env Secret state.
           +optional
         type: string
       phase:
@@ -2330,6 +2343,50 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a project
+      tags:
+      - projects
+    patch:
+      consumes:
+      - application/json
+      description: Updates mutable Project fields. Admin or project owner only.
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: Fields to update
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.updateProjectRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.projectResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update a project
       tags:
       - projects
   /projects/{project}/activity:

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -803,6 +803,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	var existing appsv1.Deployment
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
 	if errors.IsNotFound(err) {
+		app.Status.DeployedEnvHash = envHash
 		return r.Create(ctx, desired)
 	}
 	if err != nil {
@@ -1009,10 +1010,28 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 	var existing batchv1.CronJob
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
 	if errors.IsNotFound(err) {
+		app.Status.DeployedEnvHash = envHash
 		return r.Create(ctx, desired)
 	}
 	if err != nil {
 		return err
+	}
+
+	app.Status.DeployedEnvHash = existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]
+
+	if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/restartedAt"]; ok {
+		if desired.Spec.JobTemplate.Spec.Template.Annotations == nil {
+			desired.Spec.JobTemplate.Spec.Template.Annotations = make(map[string]string)
+		}
+		desired.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
+	}
+	if !autoRedeploy {
+		if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
+			if desired.Spec.JobTemplate.Spec.Template.Annotations == nil {
+				desired.Spec.JobTemplate.Spec.Template.Annotations = make(map[string]string)
+			}
+			desired.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"] = v
+		}
 	}
 
 	existing.Annotations = desired.Annotations

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1441,14 +1441,8 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 	if err != nil {
 		return fmt.Errorf("get shared vars from control ns: %w", err)
 	}
-	if len(sharedSource) > 0 {
-		if err := store.SetShared(ctx, envNs, sharedSource, sharedLabels); err != nil {
-			return fmt.Errorf("materialize shared-env: %w", err)
-		}
-	} else {
-		if err := store.EnsureSharedExists(ctx, envNs, sharedLabels); err != nil {
-			return fmt.Errorf("ensure shared-env: %w", err)
-		}
+	if err := store.SetShared(ctx, envNs, sharedSource, sharedLabels); err != nil {
+		return fmt.Errorf("materialize shared-env: %w", err)
 	}
 
 	// Check if the {app}-env Secret has been seeded by testing whether

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -762,7 +762,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 			"mortise.dev/credentials-hash": credentialsHash,
 		})
 	}
-	if autoRedeploy && envHash != "" {
+	if envHash != "" {
 		podAnno = mergeAnnotations(podAnno, map[string]string{
 			"mortise.dev/env-hash": envHash,
 		})
@@ -809,12 +809,24 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		return err
 	}
 
-	// Preserve the API-set restart annotation so the controller doesn't strip it.
+	app.Status.DeployedEnvHash = existing.Spec.Template.Annotations["mortise.dev/env-hash"]
+
+	// Preserve API-set annotations so the controller doesn't strip them.
 	if v, ok := existing.Spec.Template.Annotations["mortise.dev/restartedAt"]; ok {
 		if desired.Spec.Template.Annotations == nil {
 			desired.Spec.Template.Annotations = make(map[string]string)
 		}
 		desired.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
+	}
+	// When autoRedeploy is off, freeze the deployed env-hash so the new
+	// hash doesn't trigger a rolling update. Users redeploy manually.
+	if !autoRedeploy {
+		if v, ok := existing.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
+			if desired.Spec.Template.Annotations == nil {
+				desired.Spec.Template.Annotations = make(map[string]string)
+			}
+			desired.Spec.Template.Annotations["mortise.dev/env-hash"] = v
+		}
 	}
 
 	desiredContainer := desired.Spec.Template.Spec.Containers[0]
@@ -945,7 +957,7 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 			"mortise.dev/credentials-hash": credentialsHash,
 		})
 	}
-	if autoRedeploy && envHash != "" {
+	if envHash != "" {
 		podAnno = mergeAnnotations(podAnno, map[string]string{
 			"mortise.dev/env-hash": envHash,
 		})
@@ -1971,6 +1983,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 	fresh.Status.LastBuiltSHA = app.Status.LastBuiltSHA
 	fresh.Status.LastBuiltImage = app.Status.LastBuiltImage
 	fresh.Status.PendingEnvHash = app.Status.PendingEnvHash
+	fresh.Status.DeployedEnvHash = app.Status.DeployedEnvHash
 	fresh.Status.Conditions = app.Status.Conditions
 	return r.Status().Update(ctx, &fresh)
 }

--- a/ui/src/lib/components/AppNode.svelte
+++ b/ui/src/lib/components/AppNode.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import type { NodeProps } from '@xyflow/svelte';
 	import { Handle, Position } from '@xyflow/svelte';
-	import { GitBranch, Container, Cloud, Clock, HardDrive } from 'lucide-svelte';
+	import { GitBranch, Container, Cloud, Clock, HardDrive, RotateCw } from 'lucide-svelte';
 	import type { App, AppPhase } from '$lib/types';
 
 	interface AppNodeData {
@@ -38,6 +38,12 @@
 		Failed: 'bg-danger/10 text-danger',
 		Pending: 'bg-info/10 text-info'
 	};
+
+	const needsRedeploy = $derived(
+		!!app.status?.pendingEnvHash &&
+		!!app.status?.deployedEnvHash &&
+		app.status.pendingEnvHash !== app.status.deployedEnvHash
+	);
 
 	const domain = $derived(envEntry?.domain ?? null);
 	const replicas = $derived(envEntry?.replicas ?? 1);
@@ -133,6 +139,13 @@
 		</div>
 	{#if (phase === 'Failed' || phase === 'CrashLooping') && errorMsg}
 		<span class="line-clamp-2 text-xs text-danger/80">{errorMsg}</span>
+	{/if}
+
+	{#if needsRedeploy && enabled}
+		<span class="flex items-center gap-1 text-xs font-medium text-warning">
+			<RotateCw class="h-3 w-3" />
+			Needs redeploy
+		</span>
 	{/if}
 
 	<!-- Domain or Private label -->

--- a/ui/src/lib/components/AppNode.svelte
+++ b/ui/src/lib/components/AppNode.svelte
@@ -3,6 +3,7 @@
 	import type { NodeProps } from '@xyflow/svelte';
 	import { Handle, Position } from '@xyflow/svelte';
 	import { GitBranch, Container, Cloud, Clock, HardDrive, RotateCw } from 'lucide-svelte';
+	import { appNeedsRedeploy } from '$lib/types';
 	import type { App, AppPhase } from '$lib/types';
 
 	interface AppNodeData {
@@ -39,11 +40,7 @@
 		Pending: 'bg-info/10 text-info'
 	};
 
-	const needsRedeploy = $derived(
-		!!app.status?.pendingEnvHash &&
-		!!app.status?.deployedEnvHash &&
-		app.status.pendingEnvHash !== app.status.deployedEnvHash
-	);
+	const needsRedeploy = $derived(appNeedsRedeploy(app));
 
 	const domain = $derived(envEntry?.domain ?? null);
 	const replicas = $derived(envEntry?.replicas ?? 1);

--- a/ui/src/lib/components/drawer/DeploymentsTab.svelte
+++ b/ui/src/lib/components/drawer/DeploymentsTab.svelte
@@ -2,6 +2,7 @@
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
 	import type { App } from '$lib/types';
+	import { RotateCw } from 'lucide-svelte';
 
 	let {
 		project,
@@ -26,6 +27,27 @@
 	);
 
 	const phase = $derived(phaseProp ?? app.status?.phase ?? 'Pending');
+
+	const needsRedeploy = $derived(
+		!!app.status?.pendingEnvHash &&
+		!!app.status?.deployedEnvHash &&
+		app.status.pendingEnvHash !== app.status.deployedEnvHash
+	);
+
+	async function doRedeploy() {
+		errorMsg = '';
+		reloading = true;
+		const prevPhase = app.status?.phase;
+		onOptimisticPhase?.('Deploying');
+		try {
+			await api.redeploy(project, app.metadata.name, selectedEnv);
+		} catch (e) {
+			errorMsg = e instanceof Error ? e.message : 'Redeploy failed';
+			if (prevPhase) onOptimisticPhase?.(prevPhase);
+		} finally {
+			reloading = false;
+		}
+	}
 
 	const phaseChip: Record<string, string> = {
 		Ready: 'bg-success/10 text-success',
@@ -86,6 +108,19 @@
 		<div class="rounded-md bg-danger/10 px-3 py-2 text-xs text-danger">{errorMsg}</div>
 	{/if}
 
+	{#if needsRedeploy}
+		<div class="flex items-center justify-between rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+			<span class="flex items-center gap-1.5">
+				<RotateCw class="h-3 w-3" />
+				Environment variables changed. Redeploy to apply.
+			</span>
+			<button type="button" onclick={doRedeploy} disabled={reloading || phase === 'Building' || phase === 'Deploying'}
+				class="rounded bg-warning/20 px-2 py-0.5 font-medium text-warning hover:bg-warning/30 disabled:opacity-50">
+				{reloading ? 'Redeploying...' : 'Redeploy'}
+			</button>
+		</div>
+	{/if}
+
 	<!-- Current deploy -->
 	<div class="rounded-lg border border-surface-600 bg-surface-900 p-3">
 		<div class="flex items-center justify-between">
@@ -98,6 +133,14 @@
 				{/if}
 			</div>
 			<div class="flex items-center gap-2">
+				<button
+					type="button"
+					onclick={doRedeploy}
+					disabled={reloading || phase === 'Building' || phase === 'Deploying' || phase === 'Pending'}
+					class="rounded-md bg-surface-700 px-2 py-1 text-xs text-gray-300 transition-colors hover:bg-surface-600 hover:text-white disabled:opacity-40"
+				>
+					Redeploy
+				</button>
 				{#if (envStatus?.deployHistory?.length ?? 0) > 1}
 					<button
 						type="button"

--- a/ui/src/lib/components/drawer/DeploymentsTab.svelte
+++ b/ui/src/lib/components/drawer/DeploymentsTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
+	import { appNeedsRedeploy } from '$lib/types';
 	import type { App } from '$lib/types';
 	import { RotateCw } from 'lucide-svelte';
 
@@ -28,11 +29,7 @@
 
 	const phase = $derived(phaseProp ?? app.status?.phase ?? 'Pending');
 
-	const needsRedeploy = $derived(
-		!!app.status?.pendingEnvHash &&
-		!!app.status?.deployedEnvHash &&
-		app.status.pendingEnvHash !== app.status.deployedEnvHash
-	);
+	const needsRedeploy = $derived(appNeedsRedeploy(app));
 
 	async function doRedeploy() {
 		errorMsg = '';

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
+	import { appNeedsRedeploy } from '$lib/types';
 	import type { App } from '$lib/types';
 	import BindingsPicker from '$lib/components/BindingsPicker.svelte';
 	import { Plus, Trash2, Link, Upload, FileText, X, Eye, EyeOff, Loader2, ChevronDown } from 'lucide-svelte';
@@ -35,11 +36,7 @@
 		rawText: string;
 	};
 
-	const serverNeedsRedeploy = $derived(
-		!!app.status?.pendingEnvHash &&
-		!!app.status?.deployedEnvHash &&
-		app.status.pendingEnvHash !== app.status.deployedEnvHash
-	);
+	const serverNeedsRedeploy = $derived(appNeedsRedeploy(app));
 	let localStale = $state(false);
 	$effect(() => {
 		if (!serverNeedsRedeploy) localStale = false;
@@ -56,8 +53,6 @@
 		try {
 			await api.redeploy(project, app.metadata.name, activeEnv);
 			localStale = false;
-		} catch {
-			redeploying = false;
 		} finally {
 			redeploying = false;
 		}
@@ -481,11 +476,11 @@
 
 <div class="flex h-full flex-col gap-3 overflow-y-auto p-1">
 {#if needsRedeploy}
-	<div class="flex items-center justify-between rounded-md border border-info/30 bg-info/10 px-3 py-2 text-xs text-info">
+	<div class="flex items-center justify-between rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
 		<span>Changes saved — redeploy to apply</span>
 		<div class="flex items-center gap-1.5">
 			<button type="button" onclick={handleRedeploy} disabled={redeploying}
-				class="rounded bg-info/20 px-2 py-0.5 font-medium text-info hover:bg-info/30 disabled:opacity-50">
+				class="rounded bg-warning/20 px-2 py-0.5 font-medium text-warning hover:bg-warning/30 disabled:opacity-50">
 				{#if redeploying}
 					<Loader2 class="inline h-3 w-3 animate-spin" />
 				{:else}
@@ -493,7 +488,7 @@
 				{/if}
 			</button>
 			<button type="button" onclick={() => { localStale = false; }}
-				class="text-info/60 hover:text-info">
+				class="text-warning/60 hover:text-warning">
 				<X class="h-3.5 w-3.5" />
 			</button>
 		</div>

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -35,18 +35,24 @@
 		rawText: string;
 	};
 
-	let needsRedeploy = $state(false);
+	const serverNeedsRedeploy = $derived(
+		!!app.status?.pendingEnvHash &&
+		!!app.status?.deployedEnvHash &&
+		app.status.pendingEnvHash !== app.status.deployedEnvHash
+	);
+	let localStale = $state(false);
+	const needsRedeploy = $derived(localStale || serverNeedsRedeploy);
 	let redeploying = $state(false);
 
 	function markStale() {
-		needsRedeploy = true;
+		localStale = true;
 	}
 
 	async function handleRedeploy() {
 		redeploying = true;
 		try {
 			await api.redeploy(project, app.metadata.name, activeEnv);
-			needsRedeploy = false;
+			localStale = false;
 		} catch {
 			redeploying = false;
 		} finally {
@@ -483,7 +489,7 @@
 					Redeploy
 				{/if}
 			</button>
-			<button type="button" onclick={() => { needsRedeploy = false; }}
+			<button type="button" onclick={() => { localStale = false; }}
 				class="text-info/60 hover:text-info">
 				<X class="h-3.5 w-3.5" />
 			</button>

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -41,6 +41,9 @@
 		app.status.pendingEnvHash !== app.status.deployedEnvHash
 	);
 	let localStale = $state(false);
+	$effect(() => {
+		if (!serverNeedsRedeploy) localStale = false;
+	});
 	const needsRedeploy = $derived(localStale || serverNeedsRedeploy);
 	let redeploying = $state(false);
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -132,6 +132,8 @@ export interface Condition {
 export interface AppStatus {
 	phase?: AppPhase;
 	environments?: EnvironmentStatus[];
+	pendingEnvHash?: string;
+	deployedEnvHash?: string;
 	conditions?: Condition[];
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -147,6 +147,14 @@ export interface App {
 	status?: AppStatus;
 }
 
+export function appNeedsRedeploy(app: App): boolean {
+	return (
+		!!app.status?.pendingEnvHash &&
+		!!app.status?.deployedEnvHash &&
+		app.status.pendingEnvHash !== app.status.deployedEnvHash
+	);
+}
+
 export interface SecretResponse {
 	name: string;
 	keys: string[];

--- a/ui/src/routes/projects/[project]/+page.svelte
+++ b/ui/src/routes/projects/[project]/+page.svelte
@@ -10,7 +10,7 @@
 	import NewAppModal from '$lib/components/NewAppModal.svelte';
 	import AppDrawer from '$lib/components/AppDrawer.svelte';
 	import ViewModeToggle from '$lib/components/ViewModeToggle.svelte';
-	import { Plus, GitBranch, Container, Cloud, Clock } from 'lucide-svelte';
+	import { Plus, GitBranch, Container, Cloud, Clock, RotateCw, Loader2 } from 'lucide-svelte';
 
 	const projectName = $derived(page.params.project ?? '');
 	// App name from URL (e.g. /projects/foo/apps/bar → 'bar')
@@ -139,6 +139,38 @@
 		eventStream?.close();
 	});
 
+	const selectedEnv = $derived(store.currentEnv(projectName) || 'production');
+
+	const staleApps = $derived(
+		apps.filter(a =>
+			!!a.status?.pendingEnvHash &&
+			!!a.status?.deployedEnvHash &&
+			a.status.pendingEnvHash !== a.status.deployedEnvHash
+		)
+	);
+
+	let redeployingApps = $state<Set<string>>(new Set());
+	let redeployAllRunning = $state(false);
+
+	async function redeployOne(appName: string) {
+		redeployingApps = new Set([...redeployingApps, appName]);
+		try {
+			await api.redeploy(projectName, appName, selectedEnv);
+		} catch { /* error surfaces via SSE phase update */ }
+		finally {
+			const next = new Set(redeployingApps);
+			next.delete(appName);
+			redeployingApps = next;
+		}
+	}
+
+	async function redeployAllStale() {
+		redeployAllRunning = true;
+		const names = staleApps.map(a => a.metadata.name);
+		await Promise.allSettled(names.map(n => redeployOne(n)));
+		redeployAllRunning = false;
+	}
+
 	function lastDeploy(app: App): string {
 		const envs = app.status?.environments;
 		if (!envs?.length) return '-';
@@ -261,6 +293,35 @@
 						}
 					}}
 				/>
+
+				{#if staleApps.length > 0}
+					<div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-3 rounded-lg border border-warning/30 bg-surface-800/95 backdrop-blur px-4 py-2.5 shadow-lg">
+						<RotateCw class="h-4 w-4 shrink-0 text-warning" />
+						<div class="flex items-center gap-2 text-xs">
+							{#each staleApps as app}
+								<button
+									type="button"
+									onclick={() => redeployOne(app.metadata.name)}
+									disabled={redeployingApps.has(app.metadata.name)}
+									class="rounded-md border border-surface-600 bg-surface-700 px-2 py-1 font-medium text-white hover:bg-surface-600 disabled:opacity-50 transition-colors"
+								>
+									{#if redeployingApps.has(app.metadata.name)}
+										<Loader2 class="inline h-3 w-3 animate-spin mr-1" />
+									{/if}
+									{app.metadata.name}
+								</button>
+							{/each}
+						</div>
+						<button
+							type="button"
+							onclick={redeployAllStale}
+							disabled={redeployAllRunning}
+							class="rounded-md bg-warning/20 px-3 py-1 text-xs font-medium text-warning hover:bg-warning/30 disabled:opacity-50 transition-colors"
+						>
+							{redeployAllRunning ? 'Redeploying...' : `Redeploy all (${staleApps.length})`}
+						</button>
+					</div>
+				{/if}
 			</div>
 		{:else}
 			<!-- List view -->

--- a/ui/src/routes/projects/[project]/+page.svelte
+++ b/ui/src/routes/projects/[project]/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
+	import { appNeedsRedeploy } from '$lib/types';
 	import type { App, AppPhase, Project, BuildLogsResponse } from '$lib/types';
 	import { connectProjectEvents } from '$lib/projectEvents';
 	import ProjectCanvas from '$lib/components/ProjectCanvas.svelte';
@@ -141,13 +142,7 @@
 
 	const selectedEnv = $derived(store.currentEnv(projectName) || 'production');
 
-	const staleApps = $derived(
-		apps.filter(a =>
-			!!a.status?.pendingEnvHash &&
-			!!a.status?.deployedEnvHash &&
-			a.status.pendingEnvHash !== a.status.deployedEnvHash
-		)
-	);
+	const staleApps = $derived(apps.filter(a => appNeedsRedeploy(a)));
 
 	let redeployingApps = $state<Set<string>>(new Set());
 	let redeployAllRunning = $state(false);

--- a/ui/src/routes/projects/[project]/+page.svelte
+++ b/ui/src/routes/projects/[project]/+page.svelte
@@ -28,15 +28,9 @@
 
 	// SSE-fed state for build logs
 	let buildLogs = $state<Map<string, BuildLogsResponse>>(new Map());
-	let drawerApp = $state<App | null>(null);
-	$effect(() => {
-		if (selectedApp) {
-			const found = apps.find(a => a.metadata.name === selectedApp) ?? null;
-			if (found && !drawerApp) drawerApp = found;
-		} else {
-			drawerApp = null;
-		}
-	});
+	const drawerApp = $derived(
+		selectedApp ? apps.find(a => a.metadata.name === selectedApp) ?? null : null
+	);
 
 	let eventStream: ReturnType<typeof connectProjectEvents> | null = null;
 
@@ -94,9 +88,6 @@
 					apps = apps;
 				} else {
 					apps = [...apps, app];
-				}
-				if (app.metadata.name === selectedApp) {
-					drawerApp = app;
 				}
 			},
 			onAppDeleted: (name) => {


### PR DESCRIPTION
## Summary
- **Drawer tab refresh**: Switching apps on the canvas now correctly refreshes tab content (Variables, Metrics, etc.), not just the title. Root cause was a `$effect` with a stale guard preventing updates; replaced with `$derived`.
- **Persistent redeploy indicator**: The "needs redeploy" banner now derives from server-side `pendingEnvHash` vs `deployedEnvHash` comparison instead of ephemeral `$state`, so it survives page refreshes and component destruction.
- **Canvas indicator**: AppNode cards show a warning "Needs redeploy" chip when env hashes diverge, visible even with the drawer closed.
- **Deployments tab**: Added always-available Redeploy button and env-change banner to DeploymentsTab.
- **Backend fix**: Controller now always stamps `env-hash` annotation on pod templates and preserves existing hash when `autoRedeploy` is false, ensuring `deployedEnvHash` is populated for comparison.

## Test plan
- [x] Go tests pass (553 tests)
- [x] UI builds successfully
- [x] Verified on dev cluster: env var update causes hash divergence, manual redeploy syncs hashes back
- [ ] Visual check: open canvas, change env var, confirm "Needs redeploy" chip on node and banner in Variables/Deployments tabs
- [ ] Visual check: page refresh retains the redeploy indicator
- [ ] Visual check: switching between apps refreshes all tab content