### PR TITLE
Add x-mortise extension for typed variable generation

### DIFF
--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -303,17 +303,31 @@ func generateRandomHex(n int) (string, error) {
 }
 
 // substituteVars replaces ${VAR_NAME} placeholders in the compose YAML.
-// Any unresolved variables are auto-generated as random 32-char hex strings.
-// This means templates "just work" without requiring the user to provide secrets.
+// If the compose contains an x-mortise.variables block, those specs drive
+// generation (e.g. jwt, hex with custom length). Any remaining unresolved
+// variables are auto-generated as random 32-char hex strings. User-provided
+// vars always take precedence over generators.
 func substituteVars(tpl string, vars map[string]string) (string, error) {
 	if vars == nil {
 		vars = make(map[string]string)
 	}
+
+	ext, cleaned, err := parseMortiseExtension(tpl)
+	if err != nil {
+		return "", fmt.Errorf("parse x-mortise: %w", err)
+	}
+	if ext != nil {
+		if err := resolveVarSpecs(ext, vars); err != nil {
+			return "", err
+		}
+		tpl = cleaned
+	}
+
 	result := tpl
 	for k, v := range vars {
 		result = strings.ReplaceAll(result, "${"+k+"}", v)
 	}
-	// Auto-generate any remaining unresolved variables.
+	// Auto-generate any remaining unresolved variables as random hex.
 	for {
 		idx := strings.Index(result, "${")
 		if idx == -1 {

--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -290,17 +289,9 @@ func (s *Server) ListTemplates(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// randReader is the entropy source for generateRandomHex. Tests swap it
+// randReader is the entropy source for generateHex. Tests swap it
 // via export_test.go to inject deterministic or failing readers.
 var randReader io.Reader = rand.Reader
-
-func generateRandomHex(n int) (string, error) {
-	b := make([]byte, n)
-	if _, err := io.ReadFull(randReader, b); err != nil {
-		return "", fmt.Errorf("generating random hex: %w", err)
-	}
-	return hex.EncodeToString(b), nil
-}
 
 // substituteVars replaces ${VAR_NAME} placeholders in the compose YAML.
 // If the compose contains an x-mortise.variables block, those specs drive
@@ -338,7 +329,7 @@ func substituteVars(tpl string, vars map[string]string) (string, error) {
 			break
 		}
 		varName := result[idx+2 : idx+end]
-		generated, err := generateRandomHex(16)
+		generated, err := generateHex(32, randReader)
 		if err != nil {
 			return "", err
 		}

--- a/internal/api/stacks_rng_test.go
+++ b/internal/api/stacks_rng_test.go
@@ -12,16 +12,16 @@ func (failingReader) Read(p []byte) (int, error) {
 	return 0, errors.New("simulated rng failure")
 }
 
-// TestGenerateRandomHexErrorPropagation verifies that a failing RNG causes
+// TestGenerateHexErrorPropagation verifies that a failing RNG causes
 // substituteVars to return an error (instead of silently producing an empty
 // or broken secret).
-func TestGenerateRandomHexErrorPropagation(t *testing.T) {
+func TestGenerateHexErrorPropagation(t *testing.T) {
 	orig := randReader
 	randReader = failingReader{}
 	t.Cleanup(func() { randReader = orig })
 
-	t.Run("generateRandomHex returns the rng error", func(t *testing.T) {
-		if _, err := generateRandomHex(16); err == nil {
+	t.Run("generateHex returns the rng error", func(t *testing.T) {
+		if _, err := generateHex(32, randReader); err == nil {
 			t.Fatal("expected error from failing rng, got nil")
 		}
 	})

--- a/internal/api/vargen.go
+++ b/internal/api/vargen.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// VarSpec describes how a template variable should be generated.
+type VarSpec struct {
+	Generate string         `yaml:"generate"`
+	Length   int            `yaml:"length,omitempty"`
+	Claims   map[string]any `yaml:"claims,omitempty"`
+	SignWith string         `yaml:"sign_with,omitempty"`
+}
+
+// MortiseExtension is the x-mortise block in a compose file.
+type MortiseExtension struct {
+	Variables map[string]VarSpec `yaml:"variables"`
+}
+
+// parseMortiseExtension extracts the x-mortise block from raw compose YAML
+// and returns the extension plus the YAML with x-mortise stripped out.
+func parseMortiseExtension(composeYAML string) (*MortiseExtension, string, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(composeYAML), &raw); err != nil {
+		return nil, composeYAML, nil
+	}
+
+	xm, ok := raw["x-mortise"]
+	if !ok {
+		return nil, composeYAML, nil
+	}
+
+	// Re-marshal the x-mortise block to decode into our struct.
+	xmBytes, err := yaml.Marshal(xm)
+	if err != nil {
+		return nil, composeYAML, fmt.Errorf("marshal x-mortise: %w", err)
+	}
+	var ext MortiseExtension
+	if err := yaml.Unmarshal(xmBytes, &ext); err != nil {
+		return nil, composeYAML, fmt.Errorf("parse x-mortise: %w", err)
+	}
+
+	delete(raw, "x-mortise")
+	cleaned, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, composeYAML, fmt.Errorf("re-marshal compose: %w", err)
+	}
+
+	return &ext, string(cleaned), nil
+}
+
+// resolveVarSpecs generates values for variables defined in x-mortise.variables,
+// respecting dependency order (sign_with). User-provided vars take precedence.
+func resolveVarSpecs(ext *MortiseExtension, vars map[string]string) error {
+	if ext == nil || len(ext.Variables) == 0 {
+		return nil
+	}
+
+	order, err := topoSortVars(ext.Variables)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range order {
+		if _, provided := vars[name]; provided {
+			continue
+		}
+
+		spec := ext.Variables[name]
+		val, err := generateVar(spec, vars)
+		if err != nil {
+			return fmt.Errorf("generate %s: %w", name, err)
+		}
+		vars[name] = val
+	}
+	return nil
+}
+
+// topoSortVars returns variable names in dependency order (dependencies first).
+func topoSortVars(specs map[string]VarSpec) ([]string, error) {
+	visited := make(map[string]bool)
+	onStack := make(map[string]bool)
+	var order []string
+
+	var visit func(name string) error
+	visit = func(name string) error {
+		if onStack[name] {
+			return fmt.Errorf("circular dependency on variable %q", name)
+		}
+		if visited[name] {
+			return nil
+		}
+		onStack[name] = true
+		if dep := specs[name].SignWith; dep != "" {
+			if _, ok := specs[dep]; ok {
+				if err := visit(dep); err != nil {
+					return err
+				}
+			}
+		}
+		onStack[name] = false
+		visited[name] = true
+		order = append(order, name)
+		return nil
+	}
+
+	for name := range specs {
+		if err := visit(name); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}
+
+func generateVar(spec VarSpec, resolved map[string]string) (string, error) {
+	switch spec.Generate {
+	case "hex", "":
+		n := spec.Length
+		if n <= 0 {
+			n = 32
+		}
+		return generateHex(n, randReader)
+
+	case "jwt":
+		if spec.SignWith == "" {
+			return "", fmt.Errorf("jwt generator requires sign_with")
+		}
+		secret, ok := resolved[spec.SignWith]
+		if !ok {
+			return "", fmt.Errorf("sign_with references unresolved variable %q", spec.SignWith)
+		}
+		return generateJWT(spec.Claims, []byte(secret))
+
+	default:
+		return "", fmt.Errorf("unknown generator %q", spec.Generate)
+	}
+}
+
+func generateHex(length int, reader io.Reader) (string, error) {
+	nBytes := (length + 1) / 2
+	b := make([]byte, nBytes)
+	if _, err := io.ReadFull(reader, b); err != nil {
+		return "", fmt.Errorf("generating hex: %w", err)
+	}
+	return hex.EncodeToString(b)[:length], nil
+}
+
+func generateJWT(claims map[string]any, secret []byte) (string, error) {
+	mc := jwt.MapClaims{
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(10 * 365 * 24 * time.Hour).Unix(),
+	}
+	for k, v := range claims {
+		mc[k] = v
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, mc)
+	return token.SignedString(secret)
+}

--- a/internal/api/vargen_test.go
+++ b/internal/api/vargen_test.go
@@ -1,0 +1,535 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/mortise-org/mortise/internal/templates"
+)
+
+func TestParseMortiseExtensionPresent(t *testing.T) {
+	yml := `x-mortise:
+  variables:
+    JWT_SECRET:
+      generate: hex
+      length: 64
+    ANON_KEY:
+      generate: jwt
+      claims:
+        role: anon
+      sign_with: JWT_SECRET
+services:
+  web:
+    image: nginx
+`
+	ext, cleaned, err := parseMortiseExtension(yml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext == nil {
+		t.Fatal("expected extension, got nil")
+	}
+	if len(ext.Variables) != 2 {
+		t.Fatalf("expected 2 variables, got %d", len(ext.Variables))
+	}
+	if ext.Variables["JWT_SECRET"].Generate != "hex" {
+		t.Errorf("JWT_SECRET generate = %q, want hex", ext.Variables["JWT_SECRET"].Generate)
+	}
+	if ext.Variables["JWT_SECRET"].Length != 64 {
+		t.Errorf("JWT_SECRET length = %d, want 64", ext.Variables["JWT_SECRET"].Length)
+	}
+	if ext.Variables["ANON_KEY"].Generate != "jwt" {
+		t.Errorf("ANON_KEY generate = %q, want jwt", ext.Variables["ANON_KEY"].Generate)
+	}
+	if ext.Variables["ANON_KEY"].SignWith != "JWT_SECRET" {
+		t.Errorf("ANON_KEY sign_with = %q, want JWT_SECRET", ext.Variables["ANON_KEY"].SignWith)
+	}
+	if strings.Contains(cleaned, "x-mortise") {
+		t.Errorf("cleaned YAML should not contain x-mortise, got:\n%s", cleaned)
+	}
+	if !strings.Contains(cleaned, "services:") {
+		t.Errorf("cleaned YAML should still contain services")
+	}
+}
+
+func TestParseMortiseExtensionAbsent(t *testing.T) {
+	yml := `services:
+  web:
+    image: nginx
+`
+	ext, cleaned, err := parseMortiseExtension(yml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext != nil {
+		t.Fatal("expected nil extension for vanilla compose")
+	}
+	if !strings.Contains(cleaned, "services:") {
+		t.Error("cleaned should be original YAML")
+	}
+}
+
+func TestTopoSortVarsOrdering(t *testing.T) {
+	specs := map[string]VarSpec{
+		"ANON_KEY":         {Generate: "jwt", SignWith: "JWT_SECRET"},
+		"JWT_SECRET":       {Generate: "hex", Length: 64},
+		"SERVICE_ROLE_KEY": {Generate: "jwt", SignWith: "JWT_SECRET"},
+	}
+	order, err := topoSortVars(specs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	idx := make(map[string]int, len(order))
+	for i, name := range order {
+		idx[name] = i
+	}
+	if idx["JWT_SECRET"] >= idx["ANON_KEY"] {
+		t.Errorf("JWT_SECRET should come before ANON_KEY: %v", order)
+	}
+	if idx["JWT_SECRET"] >= idx["SERVICE_ROLE_KEY"] {
+		t.Errorf("JWT_SECRET should come before SERVICE_ROLE_KEY: %v", order)
+	}
+}
+
+func TestTopoSortVarsCircularDependency(t *testing.T) {
+	specs := map[string]VarSpec{
+		"A": {Generate: "jwt", SignWith: "B"},
+		"B": {Generate: "jwt", SignWith: "A"},
+	}
+	_, err := topoSortVars(specs)
+	if err == nil {
+		t.Fatal("expected circular dependency error")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Errorf("error should mention circular, got: %v", err)
+	}
+}
+
+func TestGenerateVarHex(t *testing.T) {
+	spec := VarSpec{Generate: "hex", Length: 16}
+	val, err := generateVar(spec, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(val) != 16 {
+		t.Errorf("expected 16-char hex, got %d chars: %q", len(val), val)
+	}
+}
+
+func TestGenerateVarHexDefaultLength(t *testing.T) {
+	spec := VarSpec{Generate: "hex"}
+	val, err := generateVar(spec, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(val) != 32 {
+		t.Errorf("expected 32-char default hex, got %d chars: %q", len(val), val)
+	}
+}
+
+func TestGenerateVarJWT(t *testing.T) {
+	secret := "test-secret-key-for-jwt-signing"
+	resolved := map[string]string{"JWT_SECRET": secret}
+	spec := VarSpec{
+		Generate: "jwt",
+		Claims:   map[string]any{"role": "anon", "iss": "supabase"},
+		SignWith: "JWT_SECRET",
+	}
+	tokenStr, err := generateVar(spec, resolved)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Parse and validate the token.
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			t.Fatalf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		t.Fatalf("failed to parse generated JWT: %v", err)
+	}
+	if !token.Valid {
+		t.Fatal("generated JWT is not valid")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("could not cast claims to MapClaims")
+	}
+	if claims["role"] != "anon" {
+		t.Errorf("role claim = %v, want anon", claims["role"])
+	}
+	if claims["iss"] != "supabase" {
+		t.Errorf("iss claim = %v, want supabase", claims["iss"])
+	}
+	if _, ok := claims["exp"]; !ok {
+		t.Error("expected exp claim")
+	}
+	if _, ok := claims["iat"]; !ok {
+		t.Error("expected iat claim")
+	}
+}
+
+func TestGenerateVarJWTMissingSignWith(t *testing.T) {
+	spec := VarSpec{Generate: "jwt", Claims: map[string]any{"role": "anon"}}
+	_, err := generateVar(spec, nil)
+	if err == nil {
+		t.Fatal("expected error for jwt without sign_with")
+	}
+}
+
+func TestGenerateVarJWTUnresolvedDep(t *testing.T) {
+	spec := VarSpec{Generate: "jwt", SignWith: "MISSING", Claims: map[string]any{"role": "anon"}}
+	_, err := generateVar(spec, map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for unresolved sign_with")
+	}
+}
+
+func TestGenerateVarUnknownType(t *testing.T) {
+	spec := VarSpec{Generate: "rsa"}
+	_, err := generateVar(spec, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown generator type")
+	}
+}
+
+func TestResolveVarSpecsUserProvidedTakesPrecedence(t *testing.T) {
+	ext := &MortiseExtension{
+		Variables: map[string]VarSpec{
+			"JWT_SECRET": {Generate: "hex", Length: 64},
+			"ANON_KEY":   {Generate: "jwt", Claims: map[string]any{"role": "anon"}, SignWith: "JWT_SECRET"},
+		},
+	}
+	vars := map[string]string{
+		"JWT_SECRET": "user-provided-secret",
+		"ANON_KEY":   "user-provided-key",
+	}
+	if err := resolveVarSpecs(ext, vars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vars["JWT_SECRET"] != "user-provided-secret" {
+		t.Errorf("JWT_SECRET should not be overwritten, got %q", vars["JWT_SECRET"])
+	}
+	if vars["ANON_KEY"] != "user-provided-key" {
+		t.Errorf("ANON_KEY should not be overwritten, got %q", vars["ANON_KEY"])
+	}
+}
+
+func TestResolveVarSpecsNilExtension(t *testing.T) {
+	vars := map[string]string{}
+	if err := resolveVarSpecs(nil, vars); err != nil {
+		t.Fatalf("unexpected error for nil ext: %v", err)
+	}
+}
+
+func TestSubstituteVarsWithMortiseExtension(t *testing.T) {
+	yml := `x-mortise:
+  variables:
+    JWT_SECRET:
+      generate: hex
+      length: 32
+    ANON_KEY:
+      generate: jwt
+      claims:
+        role: anon
+        iss: supabase
+      sign_with: JWT_SECRET
+services:
+  web:
+    image: nginx
+    environment:
+      SECRET: ${JWT_SECRET}
+      KEY: ${ANON_KEY}
+      OTHER: ${RANDOM_VAR}
+`
+	vars := make(map[string]string)
+	result, err := substituteVars(yml, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// JWT_SECRET should be 32-char hex.
+	if len(vars["JWT_SECRET"]) != 32 {
+		t.Errorf("JWT_SECRET length = %d, want 32", len(vars["JWT_SECRET"]))
+	}
+
+	// ANON_KEY should be a valid JWT.
+	token, err := jwt.Parse(vars["ANON_KEY"], func(token *jwt.Token) (any, error) {
+		return []byte(vars["JWT_SECRET"]), nil
+	})
+	if err != nil {
+		t.Fatalf("ANON_KEY is not a valid JWT: %v", err)
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["role"] != "anon" {
+		t.Errorf("ANON_KEY role = %v, want anon", claims["role"])
+	}
+
+	// RANDOM_VAR should be auto-generated hex (no x-mortise spec).
+	if vars["RANDOM_VAR"] == "" {
+		t.Error("RANDOM_VAR should be auto-generated")
+	}
+
+	// Result should not contain any ${} placeholders.
+	if strings.Contains(result, "${") {
+		t.Errorf("result still contains unresolved placeholders:\n%s", result)
+	}
+
+	// Result should not contain x-mortise.
+	if strings.Contains(result, "x-mortise") {
+		t.Errorf("result should not contain x-mortise block")
+	}
+}
+
+func TestSupabaseTemplateMortiseIntegration(t *testing.T) {
+	tpl, err := templates.Load("supabase")
+	if err != nil {
+		t.Fatalf("failed to load supabase template: %v", err)
+	}
+
+	// Verify x-mortise block is present in raw template.
+	if !strings.Contains(tpl.Compose, "x-mortise") {
+		t.Fatal("supabase template should contain x-mortise block")
+	}
+
+	// Run substituteVars with an empty vars map (all generated).
+	vars := make(map[string]string)
+	result, err := substituteVars(tpl.Compose, vars)
+	if err != nil {
+		t.Fatalf("substituteVars failed: %v", err)
+	}
+
+	// 1. JWT_SECRET should be a 64-char hex string.
+	jwtSecret := vars["JWT_SECRET"]
+	if len(jwtSecret) != 64 {
+		t.Errorf("JWT_SECRET length = %d, want 64", len(jwtSecret))
+	}
+	for _, c := range jwtSecret {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("JWT_SECRET contains non-hex char %q", c)
+			break
+		}
+	}
+
+	// 2. ANON_KEY should be a valid JWT signed with JWT_SECRET.
+	anonToken, err := jwt.Parse(vars["ANON_KEY"], func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(jwtSecret), nil
+	})
+	if err != nil {
+		t.Fatalf("ANON_KEY is not a valid JWT: %v", err)
+	}
+	if !anonToken.Valid {
+		t.Error("ANON_KEY JWT is not valid")
+	}
+	anonClaims := anonToken.Claims.(jwt.MapClaims)
+	if anonClaims["role"] != "anon" {
+		t.Errorf("ANON_KEY role = %v, want anon", anonClaims["role"])
+	}
+	if anonClaims["iss"] != "supabase" {
+		t.Errorf("ANON_KEY iss = %v, want supabase", anonClaims["iss"])
+	}
+	if _, ok := anonClaims["exp"]; !ok {
+		t.Error("ANON_KEY missing exp claim")
+	}
+	if _, ok := anonClaims["iat"]; !ok {
+		t.Error("ANON_KEY missing iat claim")
+	}
+
+	// 3. SERVICE_ROLE_KEY should be a valid JWT signed with JWT_SECRET.
+	svcToken, err := jwt.Parse(vars["SERVICE_ROLE_KEY"], func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(jwtSecret), nil
+	})
+	if err != nil {
+		t.Fatalf("SERVICE_ROLE_KEY is not a valid JWT: %v", err)
+	}
+	if !svcToken.Valid {
+		t.Error("SERVICE_ROLE_KEY JWT is not valid")
+	}
+	svcClaims := svcToken.Claims.(jwt.MapClaims)
+	if svcClaims["role"] != "service_role" {
+		t.Errorf("SERVICE_ROLE_KEY role = %v, want service_role", svcClaims["role"])
+	}
+	if svcClaims["iss"] != "supabase" {
+		t.Errorf("SERVICE_ROLE_KEY iss = %v, want supabase", svcClaims["iss"])
+	}
+
+	// 4. PG_PASSWORD and SECRET_KEY_BASE should be auto-generated as 32-char hex.
+	for _, name := range []string{"PG_PASSWORD", "SECRET_KEY_BASE"} {
+		v := vars[name]
+		if v == "" {
+			t.Errorf("%s should be auto-generated, got empty string", name)
+			continue
+		}
+		if len(v) != 32 {
+			t.Errorf("%s length = %d, want 32", name, len(v))
+		}
+	}
+
+	// 5. x-mortise should be stripped from output.
+	if strings.Contains(result, "x-mortise") {
+		t.Error("result should not contain x-mortise block")
+	}
+
+	// 6. No unresolved ${} placeholders.
+	if strings.Contains(result, "${") {
+		t.Errorf("result still contains unresolved placeholders:\n%s", result)
+	}
+
+	// 7. The resulting YAML should be parseable by parseCompose.
+	cf, err := parseCompose(result)
+	if err != nil {
+		t.Fatalf("result is not valid compose YAML: %v", err)
+	}
+
+	// Sanity check: all expected services are present.
+	expectedServices := []string{"postgres", "auth", "rest", "storage", "realtime", "meta", "studio"}
+	for _, svc := range expectedServices {
+		if _, ok := cf.Services[svc]; !ok {
+			t.Errorf("missing expected service %q in parsed compose", svc)
+		}
+	}
+
+	// 8. Verify the generated values are actually substituted into the YAML.
+	if !strings.Contains(result, jwtSecret) {
+		t.Error("result YAML does not contain the generated JWT_SECRET value")
+	}
+	if !strings.Contains(result, vars["PG_PASSWORD"]) {
+		t.Error("result YAML does not contain the generated PG_PASSWORD value")
+	}
+}
+
+func TestSupabaseTemplateMortiseUserOverride(t *testing.T) {
+	tpl, err := templates.Load("supabase")
+	if err != nil {
+		t.Fatalf("failed to load supabase template: %v", err)
+	}
+
+	// User provides their own JWT_SECRET; JWTs should be signed with it.
+	userSecret := "my-custom-secret-that-is-definitely-not-random-at-all-seriously"
+	vars := map[string]string{
+		"JWT_SECRET": userSecret,
+	}
+	result, err := substituteVars(tpl.Compose, vars)
+	if err != nil {
+		t.Fatalf("substituteVars failed: %v", err)
+	}
+
+	// JWT_SECRET should be the user-provided value.
+	if vars["JWT_SECRET"] != userSecret {
+		t.Errorf("JWT_SECRET = %q, want user-provided value", vars["JWT_SECRET"])
+	}
+
+	// ANON_KEY should still be generated and signed with the user's secret.
+	anonToken, err := jwt.Parse(vars["ANON_KEY"], func(token *jwt.Token) (any, error) {
+		return []byte(userSecret), nil
+	})
+	if err != nil {
+		t.Fatalf("ANON_KEY is not a valid JWT signed with user secret: %v", err)
+	}
+	if !anonToken.Valid {
+		t.Error("ANON_KEY JWT is not valid")
+	}
+
+	// SERVICE_ROLE_KEY should be signed with user's secret too.
+	svcToken, err := jwt.Parse(vars["SERVICE_ROLE_KEY"], func(token *jwt.Token) (any, error) {
+		return []byte(userSecret), nil
+	})
+	if err != nil {
+		t.Fatalf("SERVICE_ROLE_KEY is not a valid JWT signed with user secret: %v", err)
+	}
+	if !svcToken.Valid {
+		t.Error("SERVICE_ROLE_KEY JWT is not valid")
+	}
+
+	// Output should still be valid compose.
+	if _, err := parseCompose(result); err != nil {
+		t.Fatalf("result is not valid compose YAML: %v", err)
+	}
+}
+
+func TestTopoSortVarsChainABC(t *testing.T) {
+	// Test a chain: C depends on B depends on A.
+	specs := map[string]VarSpec{
+		"C": {Generate: "jwt", SignWith: "B"},
+		"B": {Generate: "jwt", SignWith: "A"},
+		"A": {Generate: "hex", Length: 32},
+	}
+	order, err := topoSortVars(specs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	idx := make(map[string]int, len(order))
+	for i, name := range order {
+		idx[name] = i
+	}
+	if idx["A"] >= idx["B"] {
+		t.Errorf("A should come before B: %v", order)
+	}
+	if idx["B"] >= idx["C"] {
+		t.Errorf("B should come before C: %v", order)
+	}
+}
+
+func TestTopoSortVarsNoDeps(t *testing.T) {
+	specs := map[string]VarSpec{
+		"X": {Generate: "hex", Length: 16},
+		"Y": {Generate: "hex", Length: 32},
+		"Z": {Generate: "hex", Length: 64},
+	}
+	order, err := topoSortVars(specs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(order) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(order))
+	}
+}
+
+func TestTopoSortVarsSingleItem(t *testing.T) {
+	specs := map[string]VarSpec{
+		"ONLY": {Generate: "hex", Length: 8},
+	}
+	order, err := topoSortVars(specs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(order) != 1 || order[0] != "ONLY" {
+		t.Errorf("expected [ONLY], got %v", order)
+	}
+}
+
+func TestSubstituteVarsVanillaComposeUnchanged(t *testing.T) {
+	yml := `services:
+  web:
+    image: nginx
+    environment:
+      SECRET: ${MY_SECRET}
+`
+	vars := make(map[string]string)
+	result, err := substituteVars(yml, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "${") {
+		t.Errorf("result still contains unresolved placeholders")
+	}
+	if vars["MY_SECRET"] == "" {
+		t.Error("MY_SECRET should be auto-generated")
+	}
+	if len(vars["MY_SECRET"]) != 32 {
+		t.Errorf("auto-generated var should be 32 chars, got %d", len(vars["MY_SECRET"]))
+	}
+}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -819,9 +819,13 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		}
 		desired.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
 	}
-	// When autoRedeploy is off, freeze the deployed env-hash so the new
-	// hash doesn't trigger a rolling update. Users redeploy manually.
-	if !autoRedeploy {
+	// When autoRedeploy is off and the Deployment has already reached steady
+	// state, freeze the deployed env-hash so env var changes don't trigger a
+	// rolling update. Allow the hash to flow through on initial rollout so
+	// binding resolution and shared-env materialization settle without
+	// producing a false "needs redeploy" indicator.
+	deploymentReady := existing.Status.ReadyReplicas > 0
+	if !autoRedeploy && deploymentReady {
 		if v, ok := existing.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
 			if desired.Spec.Template.Annotations == nil {
 				desired.Spec.Template.Annotations = make(map[string]string)
@@ -1025,7 +1029,8 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		}
 		desired.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
 	}
-	if !autoRedeploy {
+	cronReady := existing.Status.LastScheduleTime != nil
+	if !autoRedeploy && cronReady {
 		if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
 			if desired.Spec.JobTemplate.Spec.Template.Annotations == nil {
 				desired.Spec.JobTemplate.Spec.Template.Annotations = make(map[string]string)

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -819,13 +819,9 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		}
 		desired.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
 	}
-	// When autoRedeploy is off and the Deployment has already reached steady
-	// state, freeze the deployed env-hash so env var changes don't trigger a
-	// rolling update. Allow the hash to flow through on initial rollout so
-	// binding resolution and shared-env materialization settle without
-	// producing a false "needs redeploy" indicator.
-	deploymentReady := existing.Status.ReadyReplicas > 0
-	if !autoRedeploy && deploymentReady {
+	// When autoRedeploy is off, freeze the deployed env-hash so the new
+	// hash doesn't trigger a rolling update. Users redeploy manually.
+	if !autoRedeploy {
 		if v, ok := existing.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
 			if desired.Spec.Template.Annotations == nil {
 				desired.Spec.Template.Annotations = make(map[string]string)
@@ -1029,8 +1025,7 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		}
 		desired.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/restartedAt"] = v
 	}
-	cronReady := existing.Status.LastScheduleTime != nil
-	if !autoRedeploy && cronReady {
+	if !autoRedeploy {
 		if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
 			if desired.Spec.JobTemplate.Spec.Template.Annotations == nil {
 				desired.Spec.JobTemplate.Spec.Template.Annotations = make(map[string]string)

--- a/internal/templates/supabase/docker-compose.yml
+++ b/internal/templates/supabase/docker-compose.yml
@@ -1,3 +1,17 @@
+x-mortise:
+  variables:
+    JWT_SECRET:
+      generate: hex
+      length: 64
+    ANON_KEY:
+      generate: jwt
+      claims: { role: anon, iss: supabase }
+      sign_with: JWT_SECRET
+    SERVICE_ROLE_KEY:
+      generate: jwt
+      claims: { role: service_role, iss: supabase }
+      sign_with: JWT_SECRET
+
 services:
   postgres:
     image: supabase/postgres:15.6.1.143
@@ -47,9 +61,6 @@ services:
     environment:
       DATABASE_URL: postgres://supabase_admin:${PG_PASSWORD}@supabase-postgres:5432/supabase
       PGRST_JWT_SECRET: ${JWT_SECRET}
-      # ANON_KEY and SERVICE_KEY must be JWTs signed with JWT_SECRET.
-      # substituteVars auto-generates placeholder values; replace them with
-      # real Supabase JWTs for a working setup (see https://supabase.com/docs/guides/self-hosting#api-keys).
       ANON_KEY: ${ANON_KEY}
       SERVICE_KEY: ${SERVICE_ROLE_KEY}
       STORAGE_BACKEND: file


### PR DESCRIPTION
## Summary
- Adds `x-mortise.variables` extension block to docker-compose templates for declaring how variables should be generated (hex with configurable length, JWT with custom claims)
- Supabase template now generates proper HS256 JWTs for `ANON_KEY` and `SERVICE_ROLE_KEY` signed with the generated `JWT_SECRET`, instead of broken random hex placeholders
- Variables with `sign_with` dependencies are resolved in topological order; circular deps are detected and rejected
- Vanilla compose files (no `x-mortise`) and user-provided vars continue to work exactly as before
- Consolidated duplicate hex generation into single `generateHex` function

## Test plan
- [x] 19 unit tests covering: extension parsing, topo sort (ordering, cycles, chains), hex/jwt generators, user override precedence, full Supabase template integration
- [x] Full test suite passes (655 tests across 20 packages)
- [x] Manual: deploy Supabase stack, verify ANON_KEY/SERVICE_ROLE_KEY are accepted by GoTrue and PostgREST

Closes #99