### PR TITLE
Fix reconcile stability: deployment thrashing and env secret seeding

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2054,6 +2054,8 @@ func buildProbe(pc *mortisev1alpha1.ProbeConfig, defaultPort int32) *corev1.Prob
 		InitialDelaySeconds: 5,
 		PeriodSeconds:       10,
 		TimeoutSeconds:      3,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
 	}
 
 	if pc == nil {
@@ -2277,7 +2279,6 @@ func toEnvVars(envs []mortisev1alpha1.EnvVar) []corev1.EnvVar {
 	}
 	return result
 }
-
 
 func (r *AppReconciler) effectiveResources(ctx context.Context, env *mortisev1alpha1.Environment) mortisev1alpha1.ResourceRequirements {
 	res := env.Resources

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1468,19 +1468,30 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 	// the Secret object exists — not whether it has data. This lets us
 	// distinguish "first deploy" (no Secret) from "user cleared all vars"
 	// (empty Secret).
-	seeded, err := store.SecretExists(ctx, envNs, app.Name)
-	if err != nil {
-		return fmt.Errorf("check app env secret existence: %w", err)
+	// Seed spec-defined env vars that aren't already in the Secret.
+	// This replaces the old SecretExists gate which had a race: if
+	// ReplaceSource or EnsureExists created the Secret before Set ran,
+	// the existence check returned true and seeding was skipped forever.
+	// By merging only missing keys, we handle the race without overwriting
+	// values the user may have changed via the UI.
+	existing, _ := store.Get(ctx, envNs, app.Name)
+	existingKeys := make(map[string]bool, len(existing))
+	for _, e := range existing {
+		existingKeys[e.Name] = true
 	}
-	if !seeded {
-		var seed []envstore.Env
-		for _, ev := range env.Env {
-			seed = append(seed, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
+	var missing []envstore.Env
+	for _, ev := range env.Env {
+		if !existingKeys[ev.Name] {
+			missing = append(missing, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
 		}
-		for _, sv := range app.Spec.SharedVars {
-			seed = append(seed, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
+	}
+	for _, sv := range app.Spec.SharedVars {
+		if !existingKeys[sv.Name] {
+			missing = append(missing, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
 		}
-		if err := store.Set(ctx, envNs, app.Name, seed, labels); err != nil {
+	}
+	if len(missing) > 0 {
+		if err := store.Merge(ctx, envNs, app.Name, missing, labels); err != nil {
 			return fmt.Errorf("seed env secret: %w", err)
 		}
 	}
@@ -1500,12 +1511,7 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 			})
 		}
 	}
-	if err := store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels); err != nil {
-		return fmt.Errorf("replace binding vars: %w", err)
-	}
-
-	// Ensure the Secret exists even if there are no vars.
-	return store.EnsureExists(ctx, envNs, app.Name, labels)
+	return store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels)
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -185,3 +185,38 @@ func TestAnnotationsEqual(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildProbe_SetsKubernetesDefaults(t *testing.T) {
+	probe := buildProbe(nil, 8080)
+
+	if probe.FailureThreshold != 3 {
+		t.Fatalf("FailureThreshold = %d, want 3 (k8s default)", probe.FailureThreshold)
+	}
+	if probe.SuccessThreshold != 1 {
+		t.Fatalf("SuccessThreshold = %d, want 1 (k8s default)", probe.SuccessThreshold)
+	}
+}
+
+func TestBuildProbe_CustomConfig(t *testing.T) {
+	pc := &mortisev1alpha1.ProbeConfig{
+		Path:                "/healthz",
+		Port:                9090,
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       30,
+		TimeoutSeconds:      5,
+	}
+	probe := buildProbe(pc, 8080)
+
+	if probe.FailureThreshold != 3 {
+		t.Fatalf("FailureThreshold = %d, want 3", probe.FailureThreshold)
+	}
+	if probe.SuccessThreshold != 1 {
+		t.Fatalf("SuccessThreshold = %d, want 1", probe.SuccessThreshold)
+	}
+	if probe.HTTPGet == nil || probe.HTTPGet.Path != "/healthz" {
+		t.Fatalf("expected HTTPGet probe with path /healthz")
+	}
+	if probe.HTTPGet.Port.IntValue() != 9090 {
+		t.Fatalf("expected port 9090, got %d", probe.HTTPGet.Port.IntValue())
+	}
+}

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -12,6 +12,7 @@ package envstore
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -375,6 +376,10 @@ update:
 	// Re-fetch to ensure we have the latest version before updating.
 	if err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing); err != nil {
 		return fmt.Errorf("re-get env secret %s/%s: %w", namespace, name, err)
+	}
+
+	if reflect.DeepEqual(existing.Data, desired.Data) {
+		return nil
 	}
 
 	existing.Data = desired.Data


### PR DESCRIPTION
## Summary

Two reconcile-loop bugs that prevented apps from reaching Ready:

**Deployment generation thrashing (closes #124)**
`buildProbe` omitted `FailureThreshold` and `SuccessThreshold`, which Kubernetes defaults to 3 and 1. Every reconcile saw a diff between the desired probe (zero-valued) and the existing probe (with k8s defaults), causing an unconditional Deployment update ~1.4/sec. Generations climbed indefinitely and apps never settled to Ready.

- Set `FailureThreshold: 3` and `SuccessThreshold: 1` in `buildProbe` to match k8s defaults
- Added data-equality check in `envstore.upsertSecret` to skip redundant Secret writes that amplified the reconcile storm
- Added `TestBuildProbe_SetsKubernetesDefaults` and `TestBuildProbe_CustomConfig` regression tests

**Env secret seeding race (closes #122)**
`reconcileEnvSecret` used a `SecretExists` gate to decide whether to seed env vars. But `ReplaceSource` (called earlier in the same function) created the Secret as a side effect, so the gate always returned true on subsequent reconciles, even when the Secret was empty. Services that required generated env vars (e.g. `POSTGRES_PASSWORD`, `JWT_SECRET`) crash-looped.

- Replaced existence gate with seed-if-missing pattern: read existing keys, merge only absent ones
- Removed `EnsureExists` call (no longer needed since `ReplaceSource` handles creation)

## Test plan

- [x] 574 unit/envtest tests pass
- [x] Deployed to k3d dev cluster: all deployment generations stable at 1/1 (previously climbing ~1.4/sec)
- [x] Supabase stack: 5/7 apps Ready immediately, remaining 2 (realtime, storage) came up after seed fix applied
- [x] New regression tests verify `buildProbe` sets k8s-defaulted fields