### PR TITLE
Add comprehensive test coverage for envstore, bindings, and reconcileEnvSecret

### DIFF
--- a/internal/bindings/resolver_test.go
+++ b/internal/bindings/resolver_test.go
@@ -449,3 +449,288 @@ func findVar(vars []bindings.ResolvedVar, name string) *bindings.ResolvedVar {
 	}
 	return nil
 }
+
+func TestInternalPortZeroDefaultsTo8080(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 0}, // zero — should default to 8080
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "svc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	portVar := findVar(vars, "SVC_PORT")
+	if portVar == nil {
+		t.Fatal("expected SVC_PORT")
+	}
+	if portVar.Value != "8080" {
+		t.Errorf("expected SVC_PORT=8080 for zero port, got %q", portVar.Value)
+	}
+}
+
+func TestEmptyBindingsReturnsEmpty(t *testing.T) {
+	c := newFakeClient(t)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", nil)
+	if err != nil {
+		t.Fatalf("empty bindings should not return error, got %v", err)
+	}
+	if len(vars) != 0 {
+		t.Errorf("expected empty result for empty bindings, got %v", vars)
+	}
+}
+
+func TestBoundAppNotInEnvListIsEnabled(t *testing.T) {
+	// App has only "staging" in its env list; resolving for "production"
+	// should succeed because the default is enabled when env not listed.
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 80},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "staging"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "svc"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error when env not in list (default enabled), got %v", err)
+	}
+	if findVar(vars, "SVC_HOST") == nil {
+		t.Error("expected SVC_HOST in result")
+	}
+}
+
+func TestBoundAppNilEnabledInEnvIsEnabled(t *testing.T) {
+	// App lists "production" with Enabled=nil — should be treated as enabled.
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 80},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production", Enabled: nil},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "svc"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error for nil Enabled, got %v", err)
+	}
+	if findVar(vars, "SVC_HOST") == nil {
+		t.Error("expected SVC_HOST")
+	}
+}
+
+func TestCredentialKeyMissingInSecretReturnsEmpty(t *testing.T) {
+	db := newDB("db", "pj-web")
+	// Credentials Secret exists but is missing the "password" key.
+	creds := credentialsSecret("db", "pj-web-production", map[string]string{
+		"username": "postgres",
+		// "password" intentionally absent
+	})
+	c := newFakeClient(t, db, creds)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "db"},
+	})
+	if err != nil {
+		t.Fatalf("missing credential key should not error, got %v", err)
+	}
+	pwVar := findVar(vars, "DB_PASSWORD")
+	if pwVar == nil {
+		t.Fatal("expected DB_PASSWORD in result even when key missing")
+	}
+	if pwVar.Value != "" {
+		t.Errorf("expected empty string for missing key, got %q", pwVar.Value)
+	}
+}
+
+func TestResolveInternalAndExternalCombined(t *testing.T) {
+	internal := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "redis:7"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 6379},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	external := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "mailer", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type: mortisev1alpha1.SourceTypeExternal,
+				External: &mortisev1alpha1.ExternalSource{
+					Host: "smtp.example.com",
+					Port: 587,
+				},
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+	c := newFakeClient(t, internal, external)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "cache"},
+		{Ref: "mailer"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findVar(vars, "CACHE_HOST") == nil {
+		t.Error("expected CACHE_HOST (internal binding)")
+	}
+	if findVar(vars, "MAILER_HOST") == nil {
+		t.Error("expected MAILER_HOST (external binding)")
+	}
+	mailerHost := findVar(vars, "MAILER_HOST")
+	if mailerHost.Value != "smtp.example.com" {
+		t.Errorf("MAILER_HOST = %q, want smtp.example.com", mailerHost.Value)
+	}
+	mailerPort := findVar(vars, "MAILER_PORT")
+	if mailerPort == nil || mailerPort.Value != "587" {
+		t.Errorf("MAILER_PORT = %v, want 587", mailerPort)
+	}
+}
+
+func TestPrefixAllDigitsFallsBackToBinding(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 80},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "123"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findVar(vars, "BINDING_HOST") == nil {
+		t.Error("expected BINDING_HOST when all-digit app name strips to empty")
+	}
+	if findVar(vars, "BINDING_PORT") == nil {
+		t.Error("expected BINDING_PORT when all-digit app name strips to empty")
+	}
+}
+
+func TestAutoURLForRedisImage(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "redis:7"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 6379},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "cache"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	urlVar := findVar(vars, "CACHE_URL")
+	if urlVar == nil {
+		t.Fatal("expected CACHE_URL for redis image")
+	}
+	if !strings.HasPrefix(urlVar.Value, "redis://") {
+		t.Errorf("expected redis:// URL, got %q", urlVar.Value)
+	}
+}
+
+func TestAutoURLForMySQLImage(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "mysql:8"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 3306},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "db"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	urlVar := findVar(vars, "DB_URL")
+	if urlVar == nil {
+		t.Fatal("expected DB_URL for mysql image")
+	}
+	if !strings.HasPrefix(urlVar.Value, "mysql://") {
+		t.Errorf("expected mysql:// URL, got %q", urlVar.Value)
+	}
+}
+
+func TestAutoURLForMongoImage(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "docstore", Namespace: "pj-web"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "mongo:6"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 27017},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	c := newFakeClient(t, app)
+	r := &bindings.Resolver{Client: c}
+
+	vars, err := r.Resolve(context.Background(), "web", "production", []mortisev1alpha1.Binding{
+		{Ref: "docstore"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	urlVar := findVar(vars, "DOCSTORE_URL")
+	if urlVar == nil {
+		t.Fatal("expected DOCSTORE_URL for mongo image")
+	}
+	if !strings.HasPrefix(urlVar.Value, "mongodb://") {
+		t.Errorf("expected mongodb:// URL, got %q", urlVar.Value)
+	}
+}

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -3661,6 +3661,248 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("nginx:1.28"))
 		})
 	})
+
+	Context("reconcileEnvSecret — seed-if-missing and binding lifecycle", func() {
+		ctx := context.Background()
+
+		AfterEach(func() {
+			purgeAllAppsIn(ctx, namespace)
+		})
+
+		It("seeds env.Env vars into {app}-env Secret on first deploy and does not overwrite on second reconcile", func() {
+			appName := "seed-test"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:   "production",
+						Domain: "seed.example.com",
+						Env: []mortisev1alpha1.EnvVar{
+							{Name: "PORT", Value: "3000"},
+							{Name: "NODE_ENV", Value: "production"},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// After first reconcile, env.Env vars must be seeded.
+			envData := readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("PORT", "3000"))
+			Expect(envData).To(HaveKeyWithValue("NODE_ENV", "production"))
+
+			// Simulate user changing PORT directly in the Secret (out-of-band).
+			var sec corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.AppEnvSecretName(appName),
+				Namespace: envNsProduction,
+			}, &sec)).To(Succeed())
+			sec.Data["PORT"] = []byte("4000")
+			Expect(k8sClient.Update(ctx, &sec)).To(Succeed())
+
+			// Second reconcile must NOT re-seed (Secret already exists).
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData = readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("PORT", "4000"), "second reconcile should not overwrite user-edited value")
+		})
+
+		It("adds binding vars on first binding, clears them when binding is removed", func() {
+			dbName := "seed-db"
+			apiName := "seed-api"
+
+			dbApp := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: dbName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: "postgres:16",
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Credentials: []mortisev1alpha1.Credential{
+						{Name: "host"},
+						{Name: "port"},
+					},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dbApp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, dbApp)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dbName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// API app with a binding to db.
+			apiApp := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: apiName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+						Domain:   "api-bind.example.com",
+						Bindings: []mortisev1alpha1.Binding{{Ref: dbName}},
+						Env:      []mortisev1alpha1.EnvVar{{Name: "USER_VAR", Value: "stays"}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiApp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, apiApp)).To(Succeed()) }()
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: apiName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData := readAppEnvSecret(ctx, apiName, envNsProduction)
+			Expect(envData).To(HaveKey("SEED_DB_HOST"), "binding vars should appear after first reconcile with binding")
+			Expect(envData).To(HaveKeyWithValue("USER_VAR", "stays"))
+
+			// Remove the binding from the App.
+			var fetchedApp mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: apiName, Namespace: namespace}, &fetchedApp)).To(Succeed())
+			fetchedApp.Spec.Environments[0].Bindings = nil
+			Expect(k8sClient.Update(ctx, &fetchedApp)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: apiName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData = readAppEnvSecret(ctx, apiName, envNsProduction)
+			Expect(envData).NotTo(HaveKey("SEED_DB_HOST"), "binding vars should be cleared after binding removed")
+			// User var must survive the binding removal.
+			Expect(envData).To(HaveKeyWithValue("USER_VAR", "stays"))
+		})
+
+		It("creates empty {app}-env Secret even when there are no vars and no bindings", func() {
+			appName := "no-vars-app"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Secret must exist (for envFrom Optional mount) even though it has no data.
+			var sec corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.AppEnvSecretName(appName),
+				Namespace: envNsProduction,
+			}, &sec)).To(Succeed(), "app-env Secret should exist even with no vars")
+		})
+
+		It("returns an error when a binding references a missing App CRD", func() {
+			appName := "missing-dep-app"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+						Bindings: []mortisev1alpha1.Binding{{Ref: "does-not-exist"}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).To(HaveOccurred(), "reconcile should fail when bound App does not exist")
+		})
+
+		It("materialises shared-env in the env namespace from control-namespace shared vars", func() {
+			appName := "shared-materialize"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			// Write shared vars to the control namespace (the App's namespace = pj-default-project).
+			store := &envstore.Store{Client: k8sClient}
+			Expect(store.SetSharedSource(ctx, namespace, []envstore.Env{
+				{Name: "GLOBAL_LOG_LEVEL", Value: "debug", Source: "shared"},
+			}, nil)).To(Succeed())
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// shared-env in the env namespace should now carry GLOBAL_LOG_LEVEL.
+			var sharedSec corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.SharedEnvName,
+				Namespace: envNsProduction,
+			}, &sharedSec)).To(Succeed())
+			Expect(string(sharedSec.Data["GLOBAL_LOG_LEVEL"])).To(Equal("debug"))
+
+			// Clean up the shared vars source so it doesn't bleed into other tests.
+			_ = store.SetSharedSource(ctx, namespace, nil, nil)
+		})
+	})
 })
 
 // deploymentConflictClient wraps a client.Client and returns a 409 Conflict

--- a/internal/envstore/integration_test.go
+++ b/internal/envstore/integration_test.go
@@ -2,6 +2,7 @@ package envstore
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -245,4 +246,621 @@ func TestGetNonExistentReturnsNil(t *testing.T) {
 	if got != nil {
 		t.Errorf("expected nil for non-existent, got %v", got)
 	}
+}
+
+func TestReplaceSource_ReplacesOnlyNamedSource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	// Seed with binding + user vars.
+	initial := []Env{
+		{Name: "DB_HOST", Value: "old-host", Source: "binding"},
+		{Name: "DB_PORT", Value: "5432", Source: "binding"},
+		{Name: "USER_VAR", Value: "keep-me", Source: "user"},
+	}
+	if err := store.Set(ctx, ns, "app", initial, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace binding source with new vars.
+	newBindings := []Env{
+		{Name: "DB_HOST", Value: "new-host", Source: "binding"},
+	}
+	if err := store.ReplaceSource(ctx, ns, "app", "binding", newBindings, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, ns, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+
+	// Old binding var DB_PORT should be gone.
+	if _, ok := byName["DB_PORT"]; ok {
+		t.Error("DB_PORT should have been removed by ReplaceSource")
+	}
+	// New binding var should be present.
+	if byName["DB_HOST"].Value != "new-host" {
+		t.Errorf("DB_HOST = %q, want new-host", byName["DB_HOST"].Value)
+	}
+	// User var must be preserved.
+	if byName["USER_VAR"].Value != "keep-me" {
+		t.Errorf("USER_VAR = %q, want keep-me", byName["USER_VAR"].Value)
+	}
+}
+
+func TestReplaceSource_EmptyVarsClearsBoundSource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	initial := []Env{
+		{Name: "DB_HOST", Value: "host", Source: "binding"},
+		{Name: "MY_VAR", Value: "preserve", Source: "user"},
+	}
+	if err := store.Set(ctx, ns, "app", initial, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace binding with empty list — removes all binding vars.
+	if err := store.ReplaceSource(ctx, ns, "app", "binding", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, ns, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if _, ok := byName["DB_HOST"]; ok {
+		t.Error("DB_HOST should have been cleared by empty ReplaceSource")
+	}
+	if byName["MY_VAR"].Value != "preserve" {
+		t.Errorf("MY_VAR = %q, want preserve", byName["MY_VAR"].Value)
+	}
+}
+
+func TestReplaceSource_OnNonExistentCreates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	vars := []Env{{Name: "DB_HOST", Value: "host", Source: "binding"}}
+	if err := store.ReplaceSource(ctx, "pj-new-production", "app", "binding", vars, nil); err != nil {
+		t.Fatalf("ReplaceSource on non-existent: %v", err)
+	}
+
+	got, err := store.Get(ctx, "pj-new-production", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "DB_HOST" {
+		t.Errorf("expected [DB_HOST], got %v", got)
+	}
+}
+
+func TestSetReplacesAllData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	// First Set with A and B.
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "A", Value: "1", Source: "user"},
+		{Name: "B", Value: "2", Source: "user"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second Set with only C — should replace A and B entirely.
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "C", Value: "3", Source: "user"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, ns, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 var after Set replace, got %d: %v", len(got), got)
+	}
+	if got[0].Name != "C" {
+		t.Errorf("expected C, got %q", got[0].Name)
+	}
+}
+
+func TestSetPreservesNonMortiseAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	// Pre-create a Secret with a non-Mortise annotation.
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-env",
+			Namespace: "pj-test-production",
+			Labels:    map[string]string{ManagedByLabel: ManagedByValue},
+			Annotations: map[string]string{
+				"linkerd.io/inject": "enabled",
+			},
+		},
+		Data: map[string][]byte{},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	if err := store.Set(ctx, "pj-test-production", "app", []Env{
+		{Name: "PORT", Value: "3000", Source: "user"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "pj-test-production", Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+	if sec.Annotations["linkerd.io/inject"] != "enabled" {
+		t.Errorf("non-Mortise annotation was wiped; want enabled, got %q", sec.Annotations["linkerd.io/inject"])
+	}
+}
+
+func TestDeleteCleansBindingAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "DB_HOST", Value: "host", Source: "binding"},
+		{Name: "DB_PORT", Value: "5432", Source: "binding"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(ctx, ns, "app", "DB_HOST"); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+	csv := sec.Annotations[AnnotationBindingKeys]
+	for _, k := range []string{"DB_HOST"} {
+		for _, part := range splitCSV(csv) {
+			if part == k {
+				t.Errorf("deleted key %q still present in binding annotation: %q", k, csv)
+			}
+		}
+	}
+	// DB_PORT should still be in the annotation.
+	found := false
+	for _, part := range splitCSV(csv) {
+		if part == "DB_PORT" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("DB_PORT should still be in binding annotation, got %q", csv)
+	}
+}
+
+func TestDeleteRemovesAnnotationKeyWhenLastEntry(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "ONLY_BINDING", Value: "v", Source: "binding"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(ctx, ns, "app", "ONLY_BINDING"); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sec.Annotations[AnnotationBindingKeys]; ok {
+		t.Errorf("binding annotation should be removed entirely when last key deleted, got %q", sec.Annotations[AnnotationBindingKeys])
+	}
+}
+
+func TestDeleteGeneratedAnnotationCleanup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "JWT_SECRET", Value: "abc", Source: "generated"},
+		{Name: "PORT", Value: "3000", Source: "user"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(ctx, ns, "app", "JWT_SECRET"); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sec.Annotations[AnnotationGeneratedKeys]; ok {
+		t.Errorf("generated annotation should be removed when last key deleted, got %q", sec.Annotations[AnnotationGeneratedKeys])
+	}
+	// User var data should still be present.
+	if string(sec.Data["PORT"]) != "3000" {
+		t.Errorf("PORT data = %q, want 3000", string(sec.Data["PORT"]))
+	}
+}
+
+func TestSecretExistsReturnsTrue(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.Set(ctx, ns, "app", []Env{{Name: "A", Value: "1", Source: "user"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := store.SecretExists(ctx, ns, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("SecretExists should return true after Set")
+	}
+}
+
+func TestSecretExistsReturnsFalse(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+
+	exists, err := store.SecretExists(context.Background(), "no-ns", "no-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("SecretExists should return false for non-existent Secret")
+	}
+}
+
+func TestEnsureExistsCreatesEmptySecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.EnsureExists(ctx, ns, "app", map[string]string{"mortise.dev/project": "test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatalf("Secret should exist after EnsureExists: %v", err)
+	}
+	if len(sec.Data) != 0 {
+		t.Errorf("expected empty Secret, got %v", sec.Data)
+	}
+}
+
+func TestEnsureExistsIsNoopWhenPresent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	// Set data first.
+	if err := store.Set(ctx, ns, "app", []Env{{Name: "A", Value: "1", Source: "user"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// EnsureExists should not overwrite.
+	if err := store.EnsureExists(ctx, ns, "app", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ctx, ns, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "A" {
+		t.Errorf("EnsureExists wiped existing data, got %v", got)
+	}
+}
+
+func TestMergeOnNonExistentCreates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+
+	if err := store.Merge(ctx, "pj-new-production", "app", []Env{
+		{Name: "DB_URL", Value: "postgres://...", Source: "user"},
+	}, nil); err != nil {
+		t.Fatalf("Merge on non-existent: %v", err)
+	}
+
+	got, err := store.Get(ctx, "pj-new-production", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "DB_URL" {
+		t.Errorf("expected [DB_URL], got %v", got)
+	}
+}
+
+func TestValidateEnvVarNameRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"VALID_NAME", false},
+		{"_valid", false},
+		{"has space", true},
+		{"has,comma", true},
+		{"has-dash", true},
+		{"1starts_with_digit", true},
+		{"", true},
+		{"has.dot", true},
+	}
+	for _, tc := range cases {
+		err := ValidateEnvVarName(tc.name)
+		if tc.wantErr && err == nil {
+			t.Errorf("ValidateEnvVarName(%q) = nil, want error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("ValidateEnvVarName(%q) = %v, want nil", tc.name, err)
+		}
+	}
+}
+
+func TestDeleteOnNonExistentIsNoop(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+
+	if err := store.Delete(context.Background(), "pj-no-ns", "no-app", "KEY"); err != nil {
+		t.Errorf("Delete on non-existent should return nil, got %v", err)
+	}
+}
+
+func TestGetSharedSourceNonExistentReturnsNil(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+
+	got, err := store.GetSharedSource(context.Background(), "pj-no-project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for non-existent shared source, got %v", got)
+	}
+}
+
+func TestEnsureSharedExistsCreatesSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.EnsureSharedExists(ctx, ns, map[string]string{"mortise.dev/project": "test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: SharedEnvName}, &sec); err != nil {
+		t.Fatalf("shared-env Secret should exist after EnsureSharedExists: %v", err)
+	}
+}
+
+func TestEnsureSharedExistsIsNoopWhenPresent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.SetShared(ctx, ns, []Env{{Name: "A", Value: "1", Source: "shared"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.EnsureSharedExists(ctx, ns, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetShared(ctx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "A" {
+		t.Errorf("EnsureSharedExists wiped existing shared data, got %v", got)
+	}
+}
+
+func TestSourceAnnotationsTrackedCorrectly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "DB_HOST", Value: "host", Source: "binding"},
+		{Name: "JWT_SECRET", Value: "abc", Source: "generated"},
+		{Name: "SHARED_VAR", Value: "sv", Source: "shared"},
+		{Name: "USER_VAR", Value: "uv", Source: "user"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+
+	bindingCSV := sec.Annotations[AnnotationBindingKeys]
+	if !containsKey(bindingCSV, "DB_HOST") {
+		t.Errorf("DB_HOST not in binding annotation: %q", bindingCSV)
+	}
+	generatedCSV := sec.Annotations[AnnotationGeneratedKeys]
+	if !containsKey(generatedCSV, "JWT_SECRET") {
+		t.Errorf("JWT_SECRET not in generated annotation: %q", generatedCSV)
+	}
+	sharedCSV := sec.Annotations[AnnotationSharedKeys]
+	if !containsKey(sharedCSV, "SHARED_VAR") {
+		t.Errorf("SHARED_VAR not in shared annotation: %q", sharedCSV)
+	}
+	// USER_VAR should not appear in any source annotation.
+	for _, ann := range []string{bindingCSV, generatedCSV, sharedCSV} {
+		if containsKey(ann, "USER_VAR") {
+			t.Errorf("USER_VAR should not be in any source annotation, found in %q", ann)
+		}
+	}
+}
+
+func TestReplaceSourceUpdatesAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	// Seed with two binding vars.
+	if err := store.Set(ctx, ns, "app", []Env{
+		{Name: "OLD_HOST", Value: "old", Source: "binding"},
+		{Name: "OLD_PORT", Value: "5432", Source: "binding"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace binding source with one new var.
+	if err := store.ReplaceSource(ctx, ns, "app", "binding", []Env{
+		{Name: "NEW_HOST", Value: "new", Source: "binding"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "app-env"}, &sec); err != nil {
+		t.Fatal(err)
+	}
+	csv := sec.Annotations[AnnotationBindingKeys]
+	if containsKey(csv, "OLD_HOST") || containsKey(csv, "OLD_PORT") {
+		t.Errorf("old binding keys should be removed from annotation: %q", csv)
+	}
+	if !containsKey(csv, "NEW_HOST") {
+		t.Errorf("NEW_HOST should be in binding annotation: %q", csv)
+	}
+}
+
+func TestMergeSharedPreservesExisting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	store := &Store{Client: c}
+	ctx := context.Background()
+	ns := "pj-test-production"
+
+	if err := store.SetShared(ctx, ns, []Env{
+		{Name: "LOG_LEVEL", Value: "info", Source: "shared"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.MergeShared(ctx, ns, []Env{
+		{Name: "SENTRY_DSN", Value: "https://sentry/1", Source: "shared"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetShared(ctx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := make(map[string]Env)
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if byName["LOG_LEVEL"].Value != "info" {
+		t.Errorf("LOG_LEVEL wiped by MergeShared, got %q", byName["LOG_LEVEL"].Value)
+	}
+	if byName["SENTRY_DSN"].Value != "https://sentry/1" {
+		t.Errorf("SENTRY_DSN = %q, want https://sentry/1", byName["SENTRY_DSN"].Value)
+	}
+}
+
+// splitCSV splits a comma-separated string, trimming spaces, filtering empty.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// containsKey reports whether a CSV annotation string contains the given key.
+func containsKey(csv, key string) bool {
+	for _, k := range splitCSV(csv) {
+		if k == key {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/templates/embed_test.go
+++ b/internal/templates/embed_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -47,5 +48,17 @@ func TestLoadUnknown(t *testing.T) {
 	_, err := Load("nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown template")
+	}
+}
+
+func TestSupabasePostgRESTSchemaReload(t *testing.T) {
+	tpl, err := Load("supabase")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"PGRST_DB_CHANNEL_ENABLED", "PGRST_DB_CHANNEL"} {
+		if !strings.Contains(tpl.Compose, want) {
+			t.Errorf("supabase template missing %q — PostgREST schema reload will not work", want)
+		}
 	}
 }

--- a/internal/templates/supabase/docker-compose.yml
+++ b/internal/templates/supabase/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_DB_CHANNEL_ENABLED: "true"
+      PGRST_DB_CHANNEL: "pgrst"
 
   storage:
     image: supabase/storage-api:v1.11.13


### PR DESCRIPTION
## Summary

- **envstore (20 new tests):** ReplaceSource, Set-replaces-all, annotation preservation through upsert, Delete annotation cleanup, SecretExists/EnsureExists/EnsureSharedExists, Merge-on-nonexistent, ValidateEnvVarName, source annotation tracking
- **bindings (13 new tests):** Port=0 → 8080, empty bindings, `boundAppEnabledIn` with nil and missing env, missing credential key, internal+external combined, all-digit app name → BINDING prefix, auto-URL for redis/mysql/mongo
- **controller envtest (6 new Ginkgo tests):** seed-if-missing (first deploy seeds, second reconcile does not re-seed), binding add/remove lifecycle with user var preservation, empty Secret created even with no vars, error on missing bound App CRD, shared-vars materialized from control-ns to env-ns

## Why

Before working on #100 (PostgREST schema reload) and #120 (env inheritance), we needed a test harness that would catch regressions in the env var and bindings stack. The previously uncovered paths were the ones that surfaced bugs #122 and #124.

## Test plan

- [ ] `go test ./internal/envstore/ ./internal/bindings/` — 61 tests, all pass locally
- [ ] `go vet ./internal/...` — clean
- [ ] Controller envtest suite runs in CI via `make test` (requires envtest binaries)