### PR TITLE
Note CLAUDE.md applies to any AI assistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # Mortise
 
+> This file is named CLAUDE.md for Claude Code compatibility but applies to any AI assistant.
+> For a public-facing LLM index see https://mortise.me/llms.txt
+
 ## What this is
 
 Self-hosted Railway-style deploy platform for Kubernetes. One operator, one


### PR DESCRIPTION
Adds two-line note at the top clarifying the filename is a Claude Code convention but the content applies to any AI assistant. Links to the new llms.txt for the public-facing equivalent.

Part of #131.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>