### PR TITLE
fix: stamp mortise-core subchart dependency version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
             sed -i "s/^version: .*/version: ${VERSION}/" "${chart}/Chart.yaml"
             sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "${chart}/Chart.yaml"
           done
+          # Keep the mortise-core subchart pin in the umbrella chart in sync.
+          sed -i '/name: mortise-core/{n;s/version:.*/version: "'"${VERSION}"'"/}' charts/mortise/Chart.yaml
 
       - name: Package charts
         run: |


### PR DESCRIPTION
The release workflow stamped `mortise-core/Chart.yaml` to the new version but left the dependency pin in `mortise/Chart.yaml` pointing at the old version, causing `helm dependency update` to fail. One-liner sed fix.