### PR TITLE
fix: consolidate observer into main package with -observer tag suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
       - id: meta-observer
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-observer
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-observer
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -119,6 +121,10 @@ jobs:
           done
           # Keep the mortise-core subchart pin in the umbrella chart in sync.
           sed -i '/name: mortise-core/{n;s/version:.*/version: "'"${VERSION}"'"/}' charts/mortise/Chart.yaml
+          # Stamp operator image tag in mortise-core values.
+          sed -i "s/^  tag: .*/  tag: ${VERSION}/" charts/mortise-core/values.yaml
+          # Stamp observer image tag in umbrella values.
+          sed -i "s|image: ghcr.io/mortise-org/mortise:.*-observer|image: ghcr.io/mortise-org/mortise:${VERSION}-observer|" charts/mortise/values.yaml
 
       - name: Package charts
         run: |

--- a/charts/mortise-core/values.yaml
+++ b/charts/mortise-core/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/mortise-org/mortise
-  tag: 0.1.0
+  tag: 0.1.1
   pullPolicy: IfNotPresent
 
 replicaCount: 1

--- a/charts/mortise/values.yaml
+++ b/charts/mortise/values.yaml
@@ -124,7 +124,7 @@ metricsServer:
 # out by pointing PlatformConfig.spec.observability at your own adapter.
 observer:
   enabled: true
-  image: ghcr.io/mortise-org/mortise-observer:0.1.0
+  image: ghcr.io/mortise-org/mortise:0.1.1-observer
   storage: emptyDir
   storageSize: 2Gi
   retention:


### PR DESCRIPTION
Moves `ghcr.io/mortise-org/mortise-observer` → `ghcr.io/mortise-org/mortise:*-observer` so both images live in the same GHCR package and `GITHUB_TOKEN` can push both without separate package permissions.

Also fixes a latent bug where the stamp step never updated `image.tag` in `mortise-core/values.yaml` or `observer.image` in `mortise/values.yaml`, so every release shipped charts pointing at the previous version's images.