### PR TITLE
fix: v0.1.2 — git URL normalization, GitProvider clientID backfill, llms.txt, README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Helm Chart](https://img.shields.io/badge/helm-mortise--org.github.io%2Fmortise-blue)](https://github.com/mortise-org/mortise#install)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-Connect a git repo or pick a pre-built image - Mortise handles builds, deploys, domains, TLS, environment variables, volumes, preview environments, and service bindings. Kubernetes is abstracted away from users but remains fully extensible.
+Connect a git repo or pick a pre-built image - Mortise handles builds, deploys, domains, TLS, environment variables, volumes, preview environments, and service bindings. Kubernetes stays out of your way, but remains fully extensible.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 [![CI](https://github.com/mortise-org/mortise/actions/workflows/ci.yml/badge.svg)](https://github.com/mortise-org/mortise/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/mortise-org/mortise)](https://github.com/mortise-org/mortise/releases/latest)
-[![Helm Chart](https://img.shields.io/badge/helm-mortise--org.github.io%2Fmortise-blue)](https://mortise-org.github.io/mortise)
+[![Helm Chart](https://img.shields.io/badge/helm-mortise--org.github.io%2Fmortise-blue)](https://github.com/mortise-org/mortise#install)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-Connect a git repo or pick a pre-built image - Mortise handles builds, deploys, domains, TLS, environment variables, volumes, preview environments, and service bindings. Kubernetes is fully abstracted away from users.
+Connect a git repo or pick a pre-built image - Mortise handles builds, deploys, domains, TLS, environment variables, volumes, preview environments, and service bindings. Kubernetes is abstracted away from users but remains fully extensible.
 
 ---
 

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +16,38 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 )
+
+// normalizeRepoURL expands short-form "owner/repo" strings to a full git URL.
+// If the URL already starts with http:// or https:// it is returned unchanged.
+// Otherwise it is treated as owner/repo shorthand: the host is resolved from
+// the GitProvider named by providerRef (or the first GitProvider in the cluster
+// when providerRef is empty). A ".git" suffix is appended if absent.
+// Falls back to https://github.com when no GitProvider can be found.
+func (s *Server) normalizeRepoURL(ctx context.Context, ns, providerRef, repo string) string {
+	if strings.HasPrefix(repo, "http://") || strings.HasPrefix(repo, "https://") {
+		return repo
+	}
+
+	host := "https://github.com"
+
+	if providerRef != "" {
+		var gp mortisev1alpha1.GitProvider
+		if err := s.client.Get(ctx, types.NamespacedName{Name: providerRef}, &gp); err == nil {
+			host = strings.TrimRight(gp.Spec.Host, "/")
+		}
+	} else {
+		var list mortisev1alpha1.GitProviderList
+		if err := s.client.List(ctx, &list); err == nil && len(list.Items) > 0 {
+			host = strings.TrimRight(list.Items[0].Spec.Host, "/")
+		}
+	}
+
+	url := host + "/" + repo
+	if !strings.HasSuffix(url, ".git") {
+		url += ".git"
+	}
+	return url
+}
 
 // maxAppNameLen caps app names. App names are suffixed with "-{env}" in
 // Deployment names; the longest env suffix is ~10 chars, and k8s names max
@@ -68,6 +102,12 @@ func (s *Server) CreateApp(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, errorResponse{msg})
 			return
 		}
+	}
+
+	// Normalize short-form repo URLs (owner/repo → full https URL) before
+	// storing on the CR. go-git requires a full URL.
+	if req.Spec.Source.Type == mortisev1alpha1.SourceTypeGit {
+		req.Spec.Source.Repo = s.normalizeRepoURL(r.Context(), ns, req.Spec.Source.ProviderRef, req.Spec.Source.Repo)
 	}
 
 	// Stamp which user created this app so the controller can resolve
@@ -191,6 +231,11 @@ func (s *Server) UpdateApp(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&spec); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"invalid JSON: " + err.Error()})
 		return
+	}
+
+	// Normalize short-form repo URLs on update too.
+	if spec.Source.Type == mortisev1alpha1.SourceTypeGit {
+		spec.Source.Repo = s.normalizeRepoURL(r.Context(), ns, spec.Source.ProviderRef, spec.Source.Repo)
 	}
 
 	app.Spec = spec

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestNormalizeRepoURL(t *testing.T) {
+	if err := mortisev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	gitea := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "gitea-main"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitea,
+			Host: "https://gitea.internal/",
+		},
+	}
+
+	withProvider := &Server{client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(gitea).Build()}
+	noProvider := &Server{client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()}
+
+	cases := []struct {
+		name        string
+		s           *Server
+		providerRef string
+		repo        string
+		want        string
+	}{
+		{
+			name: "full https URL unchanged",
+			s:    noProvider, repo: "https://github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "full http URL unchanged",
+			s:    noProvider, repo: "http://gitea.local/owner/repo",
+			want: "http://gitea.local/owner/repo",
+		},
+		{
+			name: "short form defaults to github",
+			s:    noProvider, repo: "owner/repo",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "short form already has .git",
+			s:    noProvider, repo: "owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "short form with named providerRef uses provider host",
+			s:    withProvider, providerRef: "gitea-main", repo: "owner/repo",
+			want: "https://gitea.internal/owner/repo.git",
+		},
+		{
+			name: "short form with no providerRef uses first provider in cluster",
+			s:    withProvider, repo: "owner/repo",
+			want: "https://gitea.internal/owner/repo.git",
+		},
+		{
+			name: "provider host trailing slash is stripped",
+			s:    withProvider, providerRef: "gitea-main", repo: "owner/repo.git",
+			want: "https://gitea.internal/owner/repo.git",
+		},
+		{
+			name: "missing named provider falls back to github",
+			s:    noProvider, providerRef: "does-not-exist", repo: "owner/repo",
+			want: "https://github.com/owner/repo.git",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.s.normalizeRepoURL(context.Background(), "pj-test", tc.providerRef, tc.repo)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/gitprovider_controller.go
+++ b/internal/controller/gitprovider_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -31,6 +32,15 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 )
+
+// providerClientIDEnvVars maps each GitProvider type to the environment
+// variable that can supply a default clientID (matches the mapping in
+// internal/api/device_flow.go).
+var providerClientIDEnvVars = map[mortisev1alpha1.GitProviderType]string{
+	mortisev1alpha1.GitProviderTypeGitHub: "MORTISE_GITHUB_CLIENT_ID",
+	mortisev1alpha1.GitProviderTypeGitLab: "MORTISE_GITLAB_CLIENT_ID",
+	mortisev1alpha1.GitProviderTypeGitea:  "MORTISE_GITEA_CLIENT_ID",
+}
 
 // GitProviderReconciler reconciles a GitProvider object
 type GitProviderReconciler struct {
@@ -52,6 +62,23 @@ func (r *GitProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Backfill clientID from the environment when it is absent from the spec.
+	// This handles GitProvider CRs created before clientID was introduced or
+	// adopted via manual Helm labeling (issue #139).
+	if gp.Spec.ClientID == "" {
+		if envVar, ok := providerClientIDEnvVars[gp.Spec.Type]; ok {
+			if clientID := os.Getenv(envVar); clientID != "" {
+				log.Info("backfilling clientID from env", "envVar", envVar)
+				patch := client.MergeFrom(gp.DeepCopy())
+				gp.Spec.ClientID = clientID
+				if err := r.Patch(ctx, &gp, patch); err != nil {
+					return ctrl.Result{}, fmt.Errorf("patch clientID: %w", err)
+				}
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
 	}
 
 	// Validate the type field.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,29 @@
+# Mortise
+
+Mortise is a self-hosted, Railway-style deploy platform for Kubernetes. Connect a git repo or supply a pre-built image and Mortise handles builds, deploys, domains, TLS, environment variables, volumes, preview environments, and service-to-service bindings. Kubernetes is fully abstracted from end users; operators think in Apps and Projects, not Deployments or Ingresses.
+
+## Key URLs
+
+- Docs: https://mortise.me
+- Install script: https://mortise.me/install (macOS/Linux) or https://mortise.me/install.ps1 (Windows)
+- OpenAPI spec (live cluster): {base}/api/openapi.yaml
+- Helm chart: https://mortise-org.github.io/mortise
+
+## API Surface
+
+- REST API: mounted at /api on the Mortise operator pod. Full OpenAPI 3.0 spec at docs/swagger.yaml and served live at /api/openapi.yaml.
+- CLI: see cmd/cli — covers apps, projects, git providers, env vars, secrets, domains, logs, exec, and device-flow OAuth.
+
+## Deep Context
+
+- SPEC.md — product and engineering specification (workload model, bindings, build pipeline, CRD schema, scope boundaries)
+- ARCHITECTURE.md — system component diagrams and data-flow walkthrough
+
+## CRD Types (api/v1alpha1)
+
+- App — workload (git/image/external source, environments, storage, bindings)
+- Project — namespace + environment definitions
+- GitProvider — OAuth/device-flow credentials for a git forge (GitHub, GitLab, Gitea)
+- PlatformConfig — cluster-wide defaults (domain, TLS issuer, registry)
+- PreviewEnvironment — ephemeral envs created per pull request
+- ProjectMember — RBAC membership within a project


### PR DESCRIPTION
## Summary

- **#141 — git URL normalization**: `normalizeRepoURL` in `internal/api/apps.go` ensures all git source URLs are stored as canonical `https://host/owner/repo.git` form. go-git requires full URLs; short `owner/repo` form caused clone failures.
- **#139 — GitProvider clientID backfill**: Reconciler reads `MORTISE_GITHUB_CLIENT_ID` (and GitLab/Gitea equivalents) from env and patches `spec.clientID` when the field is missing. Helm 3-way merge doesn't backfill adopted resources.
- **llms.txt**: Machine-readable project description at repo root for LLM discoverability.
- **README**: Updated tagline ("fully abstracted away" → "abstracted away but remains fully extensible"); fixed Helm badge link (was pointing to bare gh-pages root which 404s).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` — 40 tests pass (envtest)
- [x] `go test $(go list ./internal/... | grep -v controller)` — 313 tests pass