### PR TITLE
fix: UI save clobber, operator CPU default, build args editor

### DIFF
--- a/charts/mortise/templates/platformconfig.yaml
+++ b/charts/mortise/templates/platformconfig.yaml
@@ -27,4 +27,8 @@ spec:
     metricsAdapterEndpoint: http://mortise-observer.{{ include "mortise.depsNamespace" . }}.svc:9091
     trafficAdapterEndpoint: http://mortise-observer.{{ include "mortise.depsNamespace" . }}.svc:9091
   {{- end }}
+  defaults:
+    resources:
+      cpu: {{ (.Values.platformConfig.defaults).resources.cpu | default "100m" | quote }}
+      memory: {{ (.Values.platformConfig.defaults).resources.memory | default "256Mi" | quote }}
 {{- end }}

--- a/charts/mortise/values.yaml
+++ b/charts/mortise/values.yaml
@@ -142,3 +142,7 @@ platformConfig:
   enabled: true
   domain: ""
   buildPlatform: ""
+  defaults:
+    resources:
+      cpu: "100m"
+      memory: "256Mi"

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2296,10 +2296,10 @@ func (r *AppReconciler) effectiveResources(ctx context.Context, env *mortisev1al
 		}
 	}
 	if res.CPU == "" {
-		res.CPU = "500m"
+		res.CPU = "100m"
 	}
 	if res.Memory == "" {
-		res.Memory = "512Mi"
+		res.Memory = "256Mi"
 	}
 	return res
 }

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -15,11 +15,14 @@
 		onAppDeleted: () => void;
 	} = $props();
 
-	// Shadow the app prop with the most-recently server-returned spec so that
-	// concurrent saves (e.g. Scale then Source) don't clobber each other while
-	// waiting for the SSE update to arrive from the parent.
 	let specOverride = $state<AppSpec | null>(null);
-	$effect(() => { void app; specOverride = null; });
+	let lastSeenSpec = $state<AppSpec | null>(null);
+	$effect(() => {
+		if (lastSeenSpec !== null && app.spec !== lastSeenSpec) {
+			specOverride = null;
+		}
+		lastSeenSpec = app.spec;
+	});
 	function cloneSpec(): AppSpec { return JSON.parse(JSON.stringify(specOverride ?? app.spec)); }
 
 	const selectedEnv = $derived(store.currentEnv(project) ?? '');
@@ -63,7 +66,7 @@
 	let buildMode = $state<'auto' | 'dockerfile' | 'railpack'>('auto');
 	let dockerfilePath = $state('');
 	let buildContext = $state<'' | 'root' | 'subdir'>('');
-	let buildArgs = $state<Record<string, string>>({});
+	let buildArgs = $state<[string, string][]>([]);
 	let savingBuild = $state(false);
 
 	// --- Networking ---
@@ -78,7 +81,7 @@
 		buildMode = app.spec.source.build?.mode ?? 'auto';
 		dockerfilePath = app.spec.source.build?.dockerfilePath ?? '';
 		buildContext = app.spec.source.build?.context ?? '';
-		buildArgs = { ...(app.spec.source.build?.args ?? {}) };
+		buildArgs = Object.entries(app.spec.source.build?.args ?? {});
 		netPublic = app.spec.network?.public ?? true;
 		netPort = String(app.spec.network?.port ?? '');
 	});
@@ -245,7 +248,8 @@
 	async function saveBuild() {
 		savingBuild = true;
 		const optimisticSpec = cloneSpec();
-		const args = Object.keys(buildArgs).length > 0 ? buildArgs : undefined;
+		const filtered = buildArgs.filter(([k]) => k.trim() !== '');
+		const args = filtered.length > 0 ? Object.fromEntries(filtered) : undefined;
 		optimisticSpec.source = {
 			...optimisticSpec.source,
 			build: {
@@ -585,29 +589,33 @@
 				<div>
 					<p class={labelCls}>Build args</p>
 					<p class="mb-2 text-xs text-gray-500">Passed as Docker <code class="font-mono">--build-arg</code>. Required for build-time env vars (e.g. <code class="font-mono">VITE_*</code>).</p>
-					{#each Object.entries(buildArgs) as [k, v], i}
+					{#each buildArgs as [k, v], i}
 						<div class="mb-1.5 flex gap-1.5">
 							<input type="text" value={k}
 								oninput={(e) => {
-									const entries = Object.entries(buildArgs);
-									entries[i] = [(e.target as HTMLInputElement).value, entries[i][1]];
-									buildArgs = Object.fromEntries(entries);
+									buildArgs = buildArgs.map((entry, j) =>
+										j === i ? [(e.target as HTMLInputElement).value, entry[1]] as [string, string] : entry
+									);
 								}}
 								placeholder="ARG_NAME"
 								class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2 py-1.5 font-mono text-xs text-white placeholder-gray-600 outline-none focus:border-accent" />
 							<input type="text" value={v}
-								oninput={(e) => { buildArgs = { ...buildArgs, [k]: (e.target as HTMLInputElement).value }; }}
+								oninput={(e) => {
+									buildArgs = buildArgs.map((entry, j) =>
+										j === i ? [entry[0], (e.target as HTMLInputElement).value] as [string, string] : entry
+									);
+								}}
 								placeholder="value"
 								class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2 py-1.5 font-mono text-xs text-white placeholder-gray-600 outline-none focus:border-accent" />
 							<button type="button"
-								onclick={() => { const { [k]: _, ...rest } = buildArgs; buildArgs = rest; }}
+								onclick={() => { buildArgs = buildArgs.filter((_, j) => j !== i); }}
 								class="rounded p-1 text-gray-500 hover:text-danger">
 								<Trash2 class="h-3.5 w-3.5" />
 							</button>
 						</div>
 					{/each}
 					<button type="button"
-						onclick={() => { buildArgs = { ...buildArgs, '': '' }; }}
+						onclick={() => { buildArgs = [...buildArgs, ['', '']]; }}
 						class="mt-1 flex items-center gap-1 text-xs text-accent hover:text-accent-hover">
 						<Plus class="h-3 w-3" /> Add build arg
 					</button>

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -15,6 +15,13 @@
 		onAppDeleted: () => void;
 	} = $props();
 
+	// Shadow the app prop with the most-recently server-returned spec so that
+	// concurrent saves (e.g. Scale then Source) don't clobber each other while
+	// waiting for the SSE update to arrive from the parent.
+	let specOverride = $state<AppSpec | null>(null);
+	$effect(() => { void app; specOverride = null; });
+	function cloneSpec(): AppSpec { return JSON.parse(JSON.stringify(specOverride ?? app.spec)); }
+
 	const selectedEnv = $derived(store.currentEnv(project) ?? '');
 	const envEntry = $derived(app.spec.environments?.find(e => e.name === selectedEnv));
 	const envEnabled = $derived(envEntry?.enabled !== false);
@@ -24,7 +31,7 @@
 		if (!selectedEnv) return;
 		togglingEnabled = true;
 		const next = !envEnabled;
-		const spec = JSON.parse(JSON.stringify(app.spec));
+		const spec = cloneSpec();
 		spec.environments = spec.environments ?? [];
 		const idx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 		if (idx >= 0) {
@@ -33,7 +40,8 @@
 			spec.environments.push({ name: selectedEnv, enabled: next });
 		}
 		try {
-			await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, spec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to toggle environment';
 		} finally {
@@ -55,6 +63,7 @@
 	let buildMode = $state<'auto' | 'dockerfile' | 'railpack'>('auto');
 	let dockerfilePath = $state('');
 	let buildContext = $state<'' | 'root' | 'subdir'>('');
+	let buildArgs = $state<Record<string, string>>({});
 	let savingBuild = $state(false);
 
 	// --- Networking ---
@@ -69,6 +78,7 @@
 		buildMode = app.spec.source.build?.mode ?? 'auto';
 		dockerfilePath = app.spec.source.build?.dockerfilePath ?? '';
 		buildContext = app.spec.source.build?.context ?? '';
+		buildArgs = { ...(app.spec.source.build?.args ?? {}) };
 		netPublic = app.spec.network?.public ?? true;
 		netPort = String(app.spec.network?.port ?? '');
 	});
@@ -138,7 +148,7 @@
 		if (!newVol.name || !newVol.mountPath) return;
 		savingVolume = true;
 		const prevVol = { ...newVol };
-		const optimisticSpec = JSON.parse(JSON.stringify(app.spec));
+		const optimisticSpec = cloneSpec();
 		optimisticSpec.storage = [...(optimisticSpec.storage ?? []), {
 			name: newVol.name,
 			mountPath: newVol.mountPath,
@@ -148,7 +158,8 @@
 		showAddVolume = false;
 		newVol = { name: '', mountPath: '', size: '', storageClass: '' };
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to add volume';
 			showAddVolume = true;
@@ -159,10 +170,11 @@
 	}
 
 	async function removeVolume(idx: number) {
-		const optimisticSpec = JSON.parse(JSON.stringify(app.spec));
+		const optimisticSpec = cloneSpec();
 		optimisticSpec.storage = (optimisticSpec.storage ?? []).filter((_: unknown, i: number) => i !== idx);
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to remove volume';
 		}
@@ -197,7 +209,7 @@
 	}
 
 	function buildUpdatedSpec(): AppSpec {
-		const spec = JSON.parse(JSON.stringify(app.spec));
+		const spec = cloneSpec();
 
 		// Source
 		if (spec.source.type === 'git') {
@@ -221,7 +233,8 @@
 		errorMsg = '';
 		const optimisticSpec = buildUpdatedSpec();
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save';
 		} finally {
@@ -231,17 +244,20 @@
 
 	async function saveBuild() {
 		savingBuild = true;
-		const optimisticSpec = JSON.parse(JSON.stringify(app.spec));
+		const optimisticSpec = cloneSpec();
+		const args = Object.keys(buildArgs).length > 0 ? buildArgs : undefined;
 		optimisticSpec.source = {
 			...optimisticSpec.source,
 			build: {
 				mode: buildMode,
 				dockerfilePath: buildMode === 'dockerfile' ? dockerfilePath : undefined,
-				context: buildContext === '' ? undefined : buildContext
+				context: buildContext === '' ? undefined : buildContext,
+				args
 			}
 		};
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save build config';
 		} finally {
@@ -254,7 +270,8 @@
 		errorMsg = '';
 		const optimisticSpec = buildUpdatedSpec();
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save';
 		} finally {
@@ -266,19 +283,21 @@
 		if (!selectedEnv) return;
 		saving = true;
 		errorMsg = '';
-		const optimisticSpec = JSON.parse(JSON.stringify(app.spec));
+		const optimisticSpec = cloneSpec();
 		optimisticSpec.environments = optimisticSpec.environments ?? [];
 		let envIdx = optimisticSpec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 		if (envIdx < 0) {
 			optimisticSpec.environments.push({ name: selectedEnv });
 			envIdx = optimisticSpec.environments.length - 1;
 		}
-		optimisticSpec.environments[envIdx].replicas = parseInt(scaleReplicas, 10) || 1;
-		optimisticSpec.environments[envIdx].resources = optimisticSpec.environments[envIdx].resources ?? {};
-		if (scaleCpu) optimisticSpec.environments[envIdx].resources.cpu = scaleCpu;
-		if (scaleMemory) optimisticSpec.environments[envIdx].resources.memory = scaleMemory;
+		const envSpec = optimisticSpec.environments[envIdx];
+		envSpec.replicas = parseInt(scaleReplicas, 10) || 1;
+		envSpec.resources = envSpec.resources ?? {};
+		if (scaleCpu) envSpec.resources.cpu = scaleCpu;
+		if (scaleMemory) envSpec.resources.memory = scaleMemory;
 		try {
-			await api.updateApp(project, app.metadata.name, optimisticSpec);
+			const result = await api.updateApp(project, app.metadata.name, optimisticSpec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save';
 		} finally {
@@ -320,7 +339,7 @@
 		if (!selectedEnv) return;
 		savingTls = true;
 		try {
-			const spec = JSON.parse(JSON.stringify(app.spec));
+			const spec = cloneSpec();
 			spec.environments = spec.environments ?? [];
 			let envIdx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 			if (envIdx < 0) {
@@ -331,7 +350,8 @@
 				clusterIssuer: tlsClusterIssuer || undefined,
 				secretName: tlsSecretName || undefined
 			};
-			await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, spec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save TLS config';
 		} finally {
@@ -389,7 +409,7 @@
 		if (!selectedEnv) return;
 		savingAnnotations = true;
 		try {
-			const spec = JSON.parse(JSON.stringify(app.spec));
+			const spec = cloneSpec();
 			spec.environments = spec.environments ?? [];
 			let envIdx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 			if (envIdx < 0) {
@@ -397,7 +417,8 @@
 				envIdx = spec.environments.length - 1;
 			}
 			spec.environments[envIdx] = { ...spec.environments[envIdx], annotations };
-			await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, spec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save annotations';
 		} finally {
@@ -422,7 +443,7 @@
 		if (!selectedEnv) return;
 		savingMounts = true;
 		try {
-			const spec = JSON.parse(JSON.stringify(app.spec));
+			const spec = cloneSpec();
 			spec.environments = spec.environments ?? [];
 			let envIdx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 			if (envIdx < 0) {
@@ -430,7 +451,8 @@
 				envIdx = spec.environments.length - 1;
 			}
 			spec.environments[envIdx] = { ...spec.environments[envIdx], secretMounts };
-			await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, spec);
+			specOverride = result.spec;
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to save mounts';
 		} finally {
@@ -557,6 +579,40 @@
 						<p class="mt-1 text-xs text-gray-500">Override the build context root when the Dockerfile references sibling directories.</p>
 					</div>
 				{/if}
+
+			<!-- Build args (show for git+dockerfile/auto source; hidden for image/railpack) -->
+			{#if app.spec.source.type === 'git' && buildMode !== 'railpack'}
+				<div>
+					<p class={labelCls}>Build args</p>
+					<p class="mb-2 text-xs text-gray-500">Passed as Docker <code class="font-mono">--build-arg</code>. Required for build-time env vars (e.g. <code class="font-mono">VITE_*</code>).</p>
+					{#each Object.entries(buildArgs) as [k, v], i}
+						<div class="mb-1.5 flex gap-1.5">
+							<input type="text" value={k}
+								oninput={(e) => {
+									const entries = Object.entries(buildArgs);
+									entries[i] = [(e.target as HTMLInputElement).value, entries[i][1]];
+									buildArgs = Object.fromEntries(entries);
+								}}
+								placeholder="ARG_NAME"
+								class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2 py-1.5 font-mono text-xs text-white placeholder-gray-600 outline-none focus:border-accent" />
+							<input type="text" value={v}
+								oninput={(e) => { buildArgs = { ...buildArgs, [k]: (e.target as HTMLInputElement).value }; }}
+								placeholder="value"
+								class="flex-1 rounded-md border border-surface-600 bg-surface-800 px-2 py-1.5 font-mono text-xs text-white placeholder-gray-600 outline-none focus:border-accent" />
+							<button type="button"
+								onclick={() => { const { [k]: _, ...rest } = buildArgs; buildArgs = rest; }}
+								class="rounded p-1 text-gray-500 hover:text-danger">
+								<Trash2 class="h-3.5 w-3.5" />
+							</button>
+						</div>
+					{/each}
+					<button type="button"
+						onclick={() => { buildArgs = { ...buildArgs, '': '' }; }}
+						class="mt-1 flex items-center gap-1 text-xs text-accent hover:text-accent-hover">
+						<Plus class="h-3 w-3" /> Add build arg
+					</button>
+				</div>
+			{/if}
 			</div>
 			<button type="button" onclick={saveBuild} disabled={savingBuild}
 				class={btnPrimary}>


### PR DESCRIPTION
## Summary

This PR bundles several stability fixes surfaced while attempting to deploy the mortise-test-app (regular and supabase variants) end-to-end on a real cluster. The intent is to make template/test-app deployments actually one-click reliable, addressing failure modes documented in #149.

> **Note:** The Apache 2.0 `LICENSE` file and README badge were pushed directly to main (45231d2) rather than through this PR. The LICENSE commit on this branch (MIT) is superseded and should be dropped before merging — the rest of the changes stand on their own.

---

## Changes

### 1. UI: Settings tab saves no longer clobber each other (`SettingsTab.svelte`)

**Problem:** Every save function in the app settings drawer cloned `app.spec` (the prop passed from the parent). The parent only updates this prop when the SSE stream delivers a reconcile event from the server — which takes 1-3 seconds. If a user saved Scale (setting `resources.cpu = 100m`) and then immediately saved Source or Networking before the SSE update arrived, `buildUpdatedSpec()` cloned the *stale* prop and overwrote the resources with empty. The operator then fell back to the hardcoded default.

This was the primary cause of repeated CPU overcommit: resources set via Scale were silently wiped by any subsequent save in the same drawer session.

**Fix:** Added a `specOverride` local state variable. After every successful `api.updateApp()` call, the returned `App.spec` is stored in `specOverride`. All spec cloning now uses `cloneSpec()` which reads `specOverride ?? app.spec`. When the SSE update arrives and `app` changes, `specOverride` is cleared (the parent now has the fresh data). This closes the race window regardless of how fast the user clicks.

### 2. Operator: Lower hardcoded CPU/memory fallback (`app_controller.go`)

**Problem:** `effectiveResources()` fell back to `500m` CPU and `512Mi` memory when an app's environment had no resources set and PlatformConfig had no defaults. With 7 apps in a project (the supabase stack), that's 3500m CPU requested before any user code ran. Two worker nodes at 91%/87% utilization meant all pods went Pending.

**Fix:** Lowered the hardcoded fallback from `500m`/`512Mi` to `100m`/`256Mi`. Users can increase via the Scale section.

### 3. Chart: Ship resource defaults via PlatformConfig (`values.yaml`, `platformconfig.yaml`)

**Problem:** The Helm chart never set `spec.defaults.resources` on the PlatformConfig it creates. Every install relied on the Go hardcoded fallback rather than the operator's intended "check PlatformConfig first" behavior.

**Fix:** Added `platformConfig.defaults.resources.cpu/memory` to chart values (defaulting to `100m`/`256Mi`) and rendered them into the PlatformConfig template. Overrideable via `--set platformConfig.defaults.resources.cpu=500m`.

### 4. UI: Build args editor in the Build settings section (`SettingsTab.svelte`)

**Problem:** `spec.source.build.args` (Docker `--build-arg` values) existed in the Go types and was wired through the build runner, but had no UI. Deploying any frontend that uses build-time env vars (React, Next.js, Vite/SvelteKit with `VITE_*` vars, etc.) required `kubectl patch`.

This caused the supabase frontend to deploy a blank/broken UI because `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` were never injected at build time even when set as runtime env vars.

**Fix:** Added a key/value editor in the Build section for git-source apps using dockerfile or auto mode. Saves through the existing `saveBuild()` path.

---

## What this does NOT fix

- The supabase/postgres image conflict with Kubernetes service-discovery env vars — requires either a custom init wrapper or a namespace-scoped env injection blocklist.
- Full E2E test coverage for all templates and test apps (tracked in #149) — the right fix is automated CI that deploys each template to a real cluster and verifies it comes up healthy.

## Test plan

- [x] `go test ./...` — 701 tests, all pass
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `make test-charts` — helm lint + template tests pass
- [ ] Manual: open app drawer, set Scale (cpu/memory), then immediately save Source — verify resources are preserved in the resulting App CR
- [ ] Manual: deploy a Vite frontend app, add `VITE_API_URL` as a build arg, trigger rebuild, verify the value is baked into the bundle