### PR TITLE
fix: observer traffic, SQLite contention, chart decoupling, CPU labels

### DIFF
--- a/charts/mortise/templates/observer.yaml
+++ b/charts/mortise/templates/observer.yaml
@@ -31,9 +31,13 @@ spec:
             - --traffic-retention={{ .Values.observer.retention.traffic | default "48h" }}
             - --max-log-pods={{ .Values.observer.maxLogPods | default "100" }}
             - --storage-path=/data
-            - --ingress-namespace={{ include "mortise.depsNamespace" . }}
+            - --ingress-namespace={{ .Values.observer.ingressNamespace | default (include "mortise.depsNamespace" .) }}
             - --traffic-bucket-size={{ .Values.observer.trafficBucketSize | default "5s" }}
-            {{- if not .Values.traefik.enabled }}
+            {{- $enableTraffic := .Values.traefik.enabled }}
+            {{- if hasKey .Values.observer "enableTraffic" }}
+            {{- $enableTraffic = .Values.observer.enableTraffic }}
+            {{- end }}
+            {{- if not $enableTraffic }}
             - --enable-traffic=false
             {{- end }}
           ports:

--- a/cmd/observer/collectors_test.go
+++ b/cmd/observer/collectors_test.go
@@ -589,3 +589,28 @@ func TestLogCollectorRunStopsOnCancel(t *testing.T) {
 		t.Fatal("Run did not return after context cancellation")
 	}
 }
+
+func TestStripTraefikPort(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"pj-foo-prod-app-80@kubernetes", "pj-foo-prod-app@kubernetes"},
+		{"pj-foo-prod-app-8080@kubernetes", "pj-foo-prod-app@kubernetes"},
+		{"pj-foo-prod-redis-6379-6379@kubernetes", "pj-foo-prod-redis-6379@kubernetes"},
+		{"pj-foo-prod-app2-80@kubernetes", "pj-foo-prod-app2@kubernetes"},
+		{"pj-foo-prod-app@kubernetes", "pj-foo-prod-app@kubernetes"},
+		{"no-at-sign", "no-at-sign"},
+		{"", ""},
+		{"@kubernetes", "@kubernetes"},
+		{"single-80@kubernetes", "single@kubernetes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripTraefikPort(tt.input)
+			if got != tt.want {
+				t.Errorf("stripTraefikPort(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/observer/log_collector.go
+++ b/cmd/observer/log_collector.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,7 @@ type LogCollector struct {
 	tailers     map[string]context.CancelFunc
 	tailerCount int
 	logCh       chan LogEntry
+	dropped     atomic.Int64
 }
 
 func NewLogCollector(cs kubernetes.Interface, store *Store, interval time.Duration, maxPods int, log *slog.Logger) *LogCollector {
@@ -75,6 +77,9 @@ func (c *LogCollector) flushLoop(ctx context.Context) {
 			if len(buf) > 0 {
 				c.flushBatch(buf)
 				buf = buf[:0]
+			}
+			if n := c.dropped.Swap(0); n > 0 {
+				c.log.Warn("log channel full, lines dropped", "count", n)
 			}
 		}
 	}
@@ -206,6 +211,7 @@ func (c *LogCollector) tailPod(ctx context.Context, namespace, podName, app, env
 			Line:      content,
 		}:
 		default:
+			c.dropped.Add(1)
 		}
 	}
 }

--- a/cmd/observer/log_collector.go
+++ b/cmd/observer/log_collector.go
@@ -22,6 +22,7 @@ type LogCollector struct {
 	mu          sync.Mutex
 	tailers     map[string]context.CancelFunc
 	tailerCount int
+	logCh       chan LogEntry
 }
 
 func NewLogCollector(cs kubernetes.Interface, store *Store, interval time.Duration, maxPods int, log *slog.Logger) *LogCollector {
@@ -32,10 +33,13 @@ func NewLogCollector(cs kubernetes.Interface, store *Store, interval time.Durati
 		maxPods:   maxPods,
 		log:       log,
 		tailers:   make(map[string]context.CancelFunc),
+		logCh:     make(chan LogEntry, 4096),
 	}
 }
 
 func (c *LogCollector) Run(ctx context.Context) {
+	go c.flushLoop(ctx)
+
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()
 
@@ -47,6 +51,51 @@ func (c *LogCollector) Run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			c.sync(ctx)
+		}
+	}
+}
+
+func (c *LogCollector) flushLoop(ctx context.Context) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	buf := make([]LogEntry, 0, 256)
+	for {
+		select {
+		case <-ctx.Done():
+			c.drainAndFlush(buf)
+			return
+		case entry := <-c.logCh:
+			buf = append(buf, entry)
+			if len(buf) >= 256 {
+				c.flushBatch(buf)
+				buf = buf[:0]
+			}
+		case <-ticker.C:
+			if len(buf) > 0 {
+				c.flushBatch(buf)
+				buf = buf[:0]
+			}
+		}
+	}
+}
+
+func (c *LogCollector) flushBatch(entries []LogEntry) {
+	if err := c.store.InsertLogs(entries); err != nil {
+		c.log.Warn("failed to insert log batch", "count", len(entries), "error", err)
+	}
+}
+
+func (c *LogCollector) drainAndFlush(buf []LogEntry) {
+	for {
+		select {
+		case entry := <-c.logCh:
+			buf = append(buf, entry)
+		default:
+			if len(buf) > 0 {
+				c.flushBatch(buf)
+			}
+			return
 		}
 	}
 }
@@ -146,7 +195,8 @@ func (c *LogCollector) tailPod(ctx context.Context, namespace, podName, app, env
 		line := scanner.Text()
 		ts, content := parseLogTimestamp(line)
 
-		if err := c.store.InsertLog(LogEntry{
+		select {
+		case c.logCh <- LogEntry{
 			Ts:        ts,
 			Pod:       podName,
 			Namespace: namespace,
@@ -154,8 +204,8 @@ func (c *LogCollector) tailPod(ctx context.Context, namespace, podName, app, env
 			Env:       env,
 			Stream:    "stdout",
 			Line:      content,
-		}); err != nil {
-			c.log.Warn("failed to insert log", "error", err)
+		}:
+		default:
 		}
 	}
 }

--- a/cmd/observer/store.go
+++ b/cmd/observer/store.go
@@ -128,6 +128,9 @@ func NewStore(path string) (*Store, error) {
 			return nil, fmt.Errorf("exec DDL: %w", err)
 		}
 	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
+
 	return &Store{db: db}, nil
 }
 
@@ -204,6 +207,29 @@ func (s *Store) InsertLog(e LogEntry) error {
 		e.Ts, e.Pod, e.Namespace, e.App, e.Env, e.Stream, e.Line,
 	)
 	return err
+}
+
+func (s *Store) InsertLogs(entries []LogEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare("INSERT INTO logs (ts, pod, namespace, app, env, stream, line) VALUES (?, ?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, e := range entries {
+		if _, err := stmt.Exec(e.Ts, e.Pod, e.Namespace, e.App, e.Env, e.Stream, e.Line); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func (s *Store) QueryLogs(namespace, app, env string, start, end int64, limit int, filter, before string) ([]LogLine, bool, error) {
@@ -320,25 +346,45 @@ func (s *Store) QueryTraffic(namespace, app, env string, start, end, step int64)
 	return series, rows.Err()
 }
 
+const trimChunkSize = 1000
+
 func (s *Store) Trim(metricsRetention, logRetention, trafficRetention time.Duration) (int64, int64, error) {
 	metricsCutoff := time.Now().Add(-metricsRetention).Unix()
-	res, err := s.db.Exec("DELETE FROM metrics WHERE ts < ?", metricsCutoff)
+	metricsDeleted, err := s.chunkedDelete("metrics", "ts < ?", metricsCutoff)
 	if err != nil {
 		return 0, 0, err
 	}
-	metricsDeleted, _ := res.RowsAffected()
 
 	logsCutoff := time.Now().Add(-logRetention).UTC().Format(time.RFC3339Nano)
-	res, err = s.db.Exec("DELETE FROM logs WHERE ts < ?", logsCutoff)
+	logsDeleted, err := s.chunkedDelete("logs", "ts < ?", logsCutoff)
 	if err != nil {
 		return metricsDeleted, 0, err
 	}
-	logsDeleted, _ := res.RowsAffected()
 
 	trafficCutoff := time.Now().Add(-trafficRetention).Unix()
-	if _, err := s.db.Exec("DELETE FROM traffic WHERE ts < ?", trafficCutoff); err != nil {
+	if _, err := s.chunkedDelete("traffic", "ts < ?", trafficCutoff); err != nil {
 		return metricsDeleted, logsDeleted, err
 	}
 
 	return metricsDeleted, logsDeleted, nil
+}
+
+func (s *Store) chunkedDelete(table, where string, cutoff any) (int64, error) {
+	query := fmt.Sprintf(
+		"DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE %s LIMIT %d)",
+		table, table, where, trimChunkSize,
+	)
+	var total int64
+	for {
+		res, err := s.db.Exec(query, cutoff)
+		if err != nil {
+			return total, err
+		}
+		n, _ := res.RowsAffected()
+		total += n
+		if n < trimChunkSize {
+			return total, nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/cmd/observer/traffic_collector.go
+++ b/cmd/observer/traffic_collector.go
@@ -217,8 +217,10 @@ func (c *TrafficCollector) processLine(line []byte) {
 		return
 	}
 
+	lookupKey := stripTraefikPort(entry.ServiceName)
+
 	c.svcMu.RLock()
-	aek, ok := c.svcCache[entry.ServiceName]
+	aek, ok := c.svcCache[lookupKey]
 	c.svcMu.RUnlock()
 	if !ok {
 		return
@@ -310,6 +312,28 @@ func (c *TrafficCollector) stopAll() {
 		cancel()
 	}
 	clear(c.tailers)
+}
+
+// stripTraefikPort removes the port segment from Traefik's ServiceName format.
+// Traefik emits "{ns}-{svc}-{port}@{provider}", but the cache key is "{ns}-{svc}@{provider}".
+func stripTraefikPort(svcName string) string {
+	atIdx := strings.Index(svcName, "@")
+	if atIdx <= 0 {
+		return svcName
+	}
+	prefix := svcName[:atIdx]
+	suffix := svcName[atIdx:]
+	lastDash := strings.LastIndex(prefix, "-")
+	if lastDash <= 0 {
+		return svcName
+	}
+	candidate := prefix[lastDash+1:]
+	for _, c := range candidate {
+		if c < '0' || c > '9' {
+			return svcName
+		}
+	}
+	return prefix[:lastDash] + suffix
 }
 
 func percentile(values []float64, p float64) float64 {

--- a/ui/src/lib/components/drawer/MetricsLineChart.svelte
+++ b/ui/src/lib/components/drawer/MetricsLineChart.svelte
@@ -19,7 +19,7 @@
 	} = $props();
 
 	const width = 640;
-	const padding = { top: 16, right: 16, bottom: 32, left: 56 };
+	const basePadding = { top: 16, right: 16, bottom: 32 };
 
 	const allPoints = $derived.by(() => {
 		const out: Array<{ ts: number; value: number }> = [];
@@ -51,6 +51,20 @@
 			maxY = minY + 1;
 		}
 		return { minX, maxX, minY, maxY };
+	});
+
+	const padding = $derived.by(() => {
+		const ticks: number[] = [];
+		for (let i = 0; i < 5; i++) {
+			ticks.push(domain.minY + ((domain.maxY - domain.minY) * i) / 4);
+		}
+		let maxLen = 0;
+		for (const t of ticks) {
+			const len = formatValue(t).length;
+			if (len > maxLen) maxLen = len;
+		}
+		const left = Math.max(56, maxLen * 8 + 12);
+		return { ...basePadding, left };
 	});
 
 	function xScale(ts: number): number {

--- a/ui/src/lib/components/drawer/MetricsTab.svelte
+++ b/ui/src/lib/components/drawer/MetricsTab.svelte
@@ -46,7 +46,7 @@
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
 
 	function formatCPU(cores: number): string {
-		if (cores < 0.01) return `${(cores * 1000).toFixed(0)}m`;
+		if (cores < 1) return `${(cores * 1000).toFixed(0)}m`;
 		return `${cores.toFixed(2)} cores`;
 	}
 

--- a/ui/src/lib/components/drawer/TrafficChart.svelte
+++ b/ui/src/lib/components/drawer/TrafficChart.svelte
@@ -16,7 +16,7 @@
 	} = $props();
 
 	const width = 640;
-	const padding = { top: 16, right: 16, bottom: 32, left: 56 };
+	const basePadding = { top: 16, right: 16, bottom: 32 };
 
 	const allPoints = $derived.by(() => {
 		const out: Array<{ ts: number; value: number }> = [];
@@ -59,6 +59,20 @@
 		if (maxY <= 0) maxY = 1;
 		maxY *= 1.1;
 		return { minX, maxX, minY: 0, maxY };
+	});
+
+	const padding = $derived.by(() => {
+		const ticks: number[] = [];
+		for (let i = 0; i < 5; i++) {
+			ticks.push(domain.minY + ((domain.maxY - domain.minY) * i) / 4);
+		}
+		let maxLen = 0;
+		for (const t of ticks) {
+			const len = formatValue(t).length;
+			if (len > maxLen) maxLen = len;
+		}
+		const left = Math.max(56, maxLen * 8 + 12);
+		return { ...basePadding, left };
 	});
 
 	function xScale(ts: number): number {


### PR DESCRIPTION
## Summary
- **#146 — Traffic metrics never populate**: Strip port suffix from Traefik's `ServiceName` (`pj-foo-prod-app-80@kubernetes` → `pj-foo-prod-app@kubernetes`) before service cache lookup so traffic data is actually recorded.
- **#117 — SQLite write contention**: Buffer log writes via a 4096-entry channel with 250ms flush interval (batched transactions), chunk DELETE operations into 1000-row batches with 10ms yields, set `MaxOpenConns=4` and `MaxIdleConns=4`.
- **#118 — Traffic collection coupled to bundled Traefik**: Add `observer.enableTraffic` (overrides `traefik.enabled`) and `observer.ingressNamespace` (defaults to deps namespace) chart values. BYO Traefik users can now enable traffic scraping independently.
- **#145 — CPU label clipping**: Change `formatCPU` threshold from `< 0.01` to `< 1` so sub-core values show as millicores ("100m" not "0.10 cores"). Compute chart left padding dynamically from formatted label width in both MetricsLineChart and TrafficChart.

Closes #117, #118, #145, #146

## Test plan
- [ ] `go test ./cmd/observer/...` passes (30/30)
- [ ] `helm template` renders correctly for all 3 traffic scenarios (bundled Traefik, disabled Traefik, BYO with override)
- [ ] Deploy to dev cluster and verify traffic metrics populate for an app with active traffic
- [ ] Verify CPU chart labels display as "100m" not "0.10 cores" for sub-core resource limits
- [ ] Load test log ingestion and verify no "failed to insert log" warnings under pod scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)