### PR TITLE
fix: observer poll interval, drawer delete handling, PSA labels

### DIFF
--- a/charts/mortise/templates/namespace.yaml
+++ b/charts/mortise/templates/namespace.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ include "mortise.depsNamespace" . }}
   labels:
     {{- include "mortise.labels" . | nindent 4 }}
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 {{- end }}

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	var (
 		listen        = flag.String("listen", ":9091", "HTTP listen address")
-		pollInterval  = flag.Duration("metrics-poll-interval", 60*time.Second, "Metrics collection interval")
+		pollInterval  = flag.Duration("metrics-poll-interval", 5*time.Second, "Metrics collection interval")
 		metricsRet    = flag.Duration("metrics-retention", 72*time.Hour, "Metrics retention duration")
 		logRet        = flag.Duration("log-retention", 48*time.Hour, "Log retention duration")
 		trafficRet    = flag.Duration("traffic-retention", 48*time.Hour, "Traffic retention duration")

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -467,11 +467,12 @@
 	async function handleDelete() {
 		if (deleteConfirmText !== app.metadata.name) return;
 		deleting = true;
-		onAppDeleted();
 		try {
 			await api.deleteApp(project, app.metadata.name);
-		} catch {
-			// drawer is already closed; error is unrecoverable from the user's perspective
+			onAppDeleted();
+		} catch (e) {
+			errorMsg = e instanceof Error ? e.message : 'Failed to delete app';
+			deleting = false;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **#154** — Change default `--metrics-poll-interval` from 60s to 5s so metrics charts have actionable resolution
- **#144** — Call delete API before closing drawer; surface errors in existing error banner with retry instead of silently swallowing
- **#113** — Add Pod Security Admission labels (`enforce/audit/warn: privileged`) to `mortise-deps` namespace so BuildKit and registry pods start on PSA-enforcing clusters

Closes #154, #144, #113

## Test plan

- [x] `go test ./cmd/observer/...` — 40 passed
- [x] `make test-charts` — helm lint + template tests pass
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)