### PR TITLE
fix: domain collision status, multi-label validation, ingress list scope

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -228,7 +228,18 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, &app, env.Name, allHosts); err != nil {
-					return ctrl.Result{}, err
+					app.Status.Phase = mortisev1alpha1.AppPhaseFailed
+					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+						Type:               "DomainCollision",
+						Status:             metav1.ConditionTrue,
+						Reason:             "DomainInUse",
+						Message:            err.Error(),
+						ObservedGeneration: app.Generation,
+					})
+					if updateErr := r.Status().Update(ctx, &app); updateErr != nil {
+						log.Error(updateErr, "update status after domain collision")
+					}
+					return ctrl.Result{}, nil
 				}
 				if err := r.reconcileIngress(ctx, &app, env, envNs); err != nil {
 					return ctrl.Result{}, fmt.Errorf("reconcile ingress for env %s: %w", env.Name, err)
@@ -2224,10 +2235,19 @@ func renderDomainTemplate(tmpl, appName, projectName, envName, platformDomain st
 
 	host := buf.String()
 
-	// Validate the subdomain label (everything before the first dot).
-	parts := strings.SplitN(host, ".", 2)
-	if len(parts) < 2 || !isValidDNSLabel(parts[0]) {
+	// Validate all subdomain labels before the platform domain suffix.
+	if !strings.HasSuffix(host, "."+platformDomain) {
 		return ""
+	}
+	prefix := strings.TrimSuffix(host, "."+platformDomain)
+	labels := strings.Split(prefix, ".")
+	if len(labels) == 0 {
+		return ""
+	}
+	for _, label := range labels {
+		if !isValidDNSLabel(label) {
+			return ""
+		}
 	}
 
 	return host
@@ -2278,7 +2298,9 @@ func (r *AppReconciler) checkDomainCollisions(ctx context.Context, app *mortisev
 	}
 
 	var allIngresses networkingv1.IngressList
-	if err := r.List(ctx, &allIngresses); err != nil {
+	if err := r.List(ctx, &allIngresses, client.MatchingLabels{
+		"app.kubernetes.io/managed-by": "mortise",
+	}); err != nil {
 		return fmt.Errorf("list ingresses for collision check: %w", err)
 	}
 
@@ -2537,6 +2559,7 @@ func toSecretVolumesAndMounts(mounts []mortisev1alpha1.SecretMount) ([]corev1.Vo
 // ExternalName Service + Ingress to expose the external host through Mortise's
 // domain/TLS setup.
 func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortisev1alpha1.App) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	project, err := r.fetchParentProject(ctx, app)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("fetch parent project: %w", err)
@@ -2566,7 +2589,18 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, app, env.Name, allHosts); err != nil {
-					return ctrl.Result{}, err
+					app.Status.Phase = mortisev1alpha1.AppPhaseFailed
+					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+						Type:               "DomainCollision",
+						Status:             metav1.ConditionTrue,
+						Reason:             "DomainInUse",
+						Message:            err.Error(),
+						ObservedGeneration: app.Generation,
+					})
+					if updateErr := r.Status().Update(ctx, app); updateErr != nil {
+						log.Error(updateErr, "update status after domain collision")
+					}
+					return ctrl.Result{}, nil
 				}
 				if err := r.reconcileExternalNameService(ctx, app, env, envNs); err != nil {
 					return ctrl.Result{}, fmt.Errorf("reconcile externalname service for env %s: %w", env.Name, err)

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -29,6 +29,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -1935,9 +1936,18 @@ var _ = Describe("App Controller", func() {
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: app2Name, Namespace: namespace},
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("shared.example.com"))
-			Expect(err.Error()).To(ContainSubstring("already in use"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// The colliding app should have Failed status with a DomainCollision condition.
+			var updated mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app2Name, Namespace: namespace}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseFailed))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "DomainCollision")
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("DomainInUse"))
+			Expect(cond.Message).To(ContainSubstring("shared.example.com"))
+			Expect(cond.Message).To(ContainSubstring("already in use"))
 		})
 
 		It("allows the same app to re-reconcile its own domain", func() {
@@ -2009,6 +2019,11 @@ var _ = Describe("renderDomainTemplate", func() {
 
 	It("returns empty for invalid template syntax", func() {
 		result := renderDomainTemplate("{{.Invalid", "app", "proj", "production", "example.com")
+		Expect(result).To(BeEmpty())
+	})
+
+	It("returns empty when a non-first label is invalid in multi-level template", func() {
+		result := renderDomainTemplate("{{.App}}.{{.Project}}.{{.Domain}}", "web", "bad_project", "production", "example.com")
 		Expect(result).To(BeEmpty())
 	})
 })

--- a/internal/controller/auto_domain_test.go
+++ b/internal/controller/auto_domain_test.go
@@ -141,6 +141,13 @@ func TestAutoDefaultDomainMultiLevelTemplate(t *testing.T) {
 	}
 }
 
+func TestRenderDomainTemplateInvalidSecondLabel(t *testing.T) {
+	got := renderDomainTemplate("{{.App}}.{{.Project}}.{{.Domain}}", "web", "bad_project", "production", "example.com")
+	if got != "" {
+		t.Errorf("expected empty domain for invalid second label, got %q", got)
+	}
+}
+
 func TestAutoDefaultDomainEmptyDomain(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = mortisev1alpha1.AddToScheme(scheme)


### PR DESCRIPTION
## Summary

Fixes three bugs introduced in #170:

- **Domain collision errors now surface in App status** — Previously, `checkDomainCollisions` returned an error that caused the reconciler to retry with exponential backoff, leaving the app stuck in "Deploying" with no user-visible feedback. Now sets `status.phase: Failed` with a `DomainCollision` condition (reason `DomainInUse`) and returns without requeue. The next reconcile fires when the spec changes or the conflicting Ingress is removed.

- **`renderDomainTemplate` validates all DNS labels** — Previously only validated the first subdomain label. Multi-level templates like `{{.App}}.{{.Project}}.{{.Domain}}` could produce hostnames with invalid second labels (e.g., underscores in project names). Now strips the platform domain suffix and validates every remaining label.

- **`checkDomainCollisions` scopes Ingress list** — Added `app.kubernetes.io/managed-by: mortise` label selector so only Mortise-owned Ingresses are checked, reducing apiserver load in clusters with many external Ingresses.

## Test plan

- [x] Existing collision envtest updated: verifies `status.phase == Failed` and `DomainCollision` condition with correct reason/message
- [x] New envtest: `renderDomainTemplate` returns empty for invalid second label in multi-level template
- [x] New unit test: `TestRenderDomainTemplateInvalidSecondLabel`
- [x] All 714 tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)