### PR TITLE
docs: domain template, pullSecretRef wiring, observer image naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,7 @@ kind: PlatformConfig
 metadata: { name: platform }
 spec:
   domain: yourdomain.com
+  domainTemplate: "..."      # optional; Go text/template with {{.App}}, {{.Project}}, {{.Env}}, {{.Domain}}
   storage: { defaultStorageClass: ... }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ After installing, follow the **[Quickstart](docs/quickstart.md)** to create an a
 - **Environment variables** - Secret-backed storage, masked values, source badges, multi-line paste, raw editor
 - **Project variables** - project-level vars shared across all apps in a project
 - **Service bindings** - bind apps to backing services, auto-inject `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_URL`
-- **Auto-domain routing** - public apps get `{app}.{platformDomain}` automatically with TLS
+- **Auto-domain routing** - public apps get `{app}-{project}.{platformDomain}` automatically with TLS (customizable via `domainTemplate`)
 - **Per-environment namespaces** - production, staging, and preview environments each get an isolated k8s namespace
 - **Preview environments** - PR-driven ephemeral deploys for git-source apps
 - **CrashLoop detection** - surfaces pod crash reasons directly in the UI

--- a/SPEC.md
+++ b/SPEC.md
@@ -176,7 +176,7 @@ spec:
   # don't get a public URL.
   preview:
     enabled: true
-    domain: "pr-{number}-{app}.yourdomain.com"  # `{app}` renders per-App
+    domain: "{app}-{project}-pr-{number}.yourdomain.com"  # `{app}`, `{project}`, `{number}` render per-App
     ttl: 72h
     resources: { cpu: 250m, memory: 256Mi }     # preview default; apps can't override
     botPR: false                                 # opt-in: preview bots' PRs (dependabot etc.)
@@ -360,7 +360,8 @@ spec:
     # --- OR ---
     # type: image
     # image: ghcr.io/paperless-ngx/paperless-ngx:latest
-    # pullSecretRef: ghcr-credentials
+    # pullSecretRef: ghcr-credentials  # wired into the app's ServiceAccount imagePullSecrets
+    #                                   # (merged with the platform registry pull secret)
 
   network:
     public: true                      # default true; false for backing services
@@ -683,8 +684,22 @@ service. No contradiction; they serve different needs.
 ### 5.6 Network, Domains, TLS
 
 Operator annotates `Ingress` → ExternalDNS creates DNS record → cert-manager
-issues TLS cert. Zero user action. Each environment gets its own subdomain
-automatically, rooted at the platform domain configured at install.
+issues TLS cert. Zero user action. Each environment gets a collision-safe
+subdomain automatically, rooted at the platform domain configured at install.
+The default pattern includes the project name to prevent hostname collisions
+when two projects have apps with the same name:
+
+- Production: `{app}-{project}.{domain}` (e.g. `api-backend.apps.example.com`)
+- Other envs: `{app}-{project}-{env}.{domain}` (e.g. `api-backend-staging.apps.example.com`)
+
+The domain pattern is configurable via `PlatformConfig.spec.domainTemplate`,
+a Go `text/template` string with variables `{{.App}}`, `{{.Project}}`,
+`{{.Env}}`, and `{{.Domain}}`. The default template is:
+`{{.App}}-{{.Project}}{{if ne .Env "production"}}-{{.Env}}{{end}}.{{.Domain}}`
+
+**Collision detection.** The operator rejects reconciliation with a
+`DomainCollision` status condition if a computed hostname is already owned
+by another app. This prevents silent routing conflicts.
 
 Custom domains: user sets CNAME, adds the domain in UI, Ingress rule + TLS
 added by operator.
@@ -960,9 +975,11 @@ to be specced if and when real demand shows up; they are not a v1 contract.
 ### 5.11 Observability (v1)
 
 **mortise-observer (bundled, enabled by default).** The chart includes a
-`mortise-observer` binary that implements the log/metrics/traffic adapter
-contract (§5.11a). It runs as a separate pod backed by a SQLite database on
-a PVC and serves historical data to the Mortise UI. Default retention:
+`mortise-observer` binary (image: `ghcr.io/mortise-org/mortise-observer:{version}`,
+a separate image repository from the operator) that implements the
+log/metrics/traffic adapter contract (§5.11a). It runs as a separate pod
+backed by a SQLite database on a PVC and serves historical data to the
+Mortise UI. Default retention:
 
 | Data type | Retention |
 |---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,11 @@ All configuration happens in **Settings** in the Mortise UI, or via the
 ## Platform domain
 
 **What it does:** Gives your apps automatic URLs. When set to
-`apps.example.com`, an app called `api` gets `api.apps.example.com`
-in production and `api-staging.apps.example.com` in staging.
+`apps.example.com`, an app called `api` in project `backend` gets
+`api-backend.apps.example.com` in production and
+`api-backend-staging.apps.example.com` in staging. The project name is
+included in the domain to prevent collisions when different projects have
+apps with the same name.
 
 **What it also does:** Serves as the callback address for git webhooks.
 When you push to a connected repo, your git host sends a notification to
@@ -74,6 +77,56 @@ When you push to a connected repo, your git host sends a notification to
    power-user option; most setups work fine with a wildcard record.
 
 3. **Enter the domain** in Settings > Platform Domain and save.
+
+### Domain template
+
+The default domain pattern is:
+
+```
+{{.App}}-{{.Project}}{{if ne .Env "production"}}-{{.Env}}{{end}}.{{.Domain}}
+```
+
+This produces domains like `api-backend.apps.example.com` for production
+and `api-backend-staging.apps.example.com` for staging.
+
+You can customize the pattern by setting `domainTemplate` on your
+PlatformConfig:
+
+```yaml
+apiVersion: mortise.mortise.dev/v1alpha1
+kind: PlatformConfig
+metadata:
+  name: platform
+spec:
+  domain: apps.example.com
+  domainTemplate: "{{.App}}.{{.Domain}}"  # restore old {app}.{domain} pattern
+```
+
+Available template variables:
+
+| Variable | Description | Example value |
+|----------|-------------|---------------|
+| `{{.App}}` | App name | `api` |
+| `{{.Project}}` | Project name | `backend` |
+| `{{.Env}}` | Environment name | `production`, `staging` |
+| `{{.Domain}}` | Platform domain | `apps.example.com` |
+
+A few useful patterns:
+
+| Pattern | Production result | Staging result |
+|---------|-------------------|----------------|
+| Default (see above) | `api-backend.apps.example.com` | `api-backend-staging.apps.example.com` |
+| `{{.App}}.{{.Domain}}` | `api.apps.example.com` | `api.apps.example.com` |
+| `{{.App}}.{{.Project}}.{{.Domain}}` | `api.backend.apps.example.com` | `api.backend.apps.example.com` |
+
+Templates that omit `{{.Env}}` produce the same domain for every
+environment. Use the `{{if ne .Env "production"}}` conditional from the
+default template to differentiate environments while keeping production
+domains clean.
+
+If two apps in different projects produce the same hostname, the operator
+rejects the second with a `DomainCollision` status condition. The default
+template avoids this by including the project name.
 
 ### Webhook reachability
 

--- a/docs/systems-overview.md
+++ b/docs/systems-overview.md
@@ -68,6 +68,7 @@ Preview namespaces follow a PR pattern (controller-managed) and are isolated fro
 - For `cron`: CronJob path
 - For `external`: external service facade path
 - Resolves bindings and environment materialization
+- Detects domain collisions across apps and rejects with a `DomainCollision` status condition
 - Tracks build/deploy status in `status.environments`
 
 ### PreviewEnvironment controller


### PR DESCRIPTION
## Summary

Documents the three features introduced in #170:

- **Collision-safe auto-generated domains** — Updated domain format examples throughout docs to reflect the new `{app}-{project}.{domain}` pattern. Added a "Domain template" subsection to `docs/configuration.md` covering customization, available variables, pattern examples, and collision detection behavior.
- **pullSecretRef wiring** — Added inline note in SPEC.md §5.2 that `pullSecretRef` is wired into the ServiceAccount's `imagePullSecrets` alongside the platform registry secret.
- **Observer image naming** — Updated SPEC.md §5.11 to reference the separate image repository (`ghcr.io/mortise-org/mortise-observer:{version}`).

## Files changed

- `SPEC.md` — §5.0 preview domain template, §5.2 pullSecretRef note, §5.6 domain format + domainTemplate + collision detection, §5.11 observer image reference
- `docs/configuration.md` — Platform domain examples, new "Domain template" subsection
- `docs/systems-overview.md` — App controller collision detection bullet
- `CLAUDE.md` — `domainTemplate` in PlatformConfig CRD reference
- `README.md` — Auto-domain feature description

## Test plan

- [x] Documentation-only change, no code modified
- [x] Domain template examples are accurate (verified against `renderDomainTemplate` implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)