### PR TITLE
docs: BYO Traefik access logs, llms.txt, local-only recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full system diagrams.
 | [External Secrets](docs/recipes/external-secrets.md) | Vault, AWS SM, GCP SM via ESO |
 | [Backup](docs/recipes/backup.md) | Velero backup and restore |
 | [Cloudflare Tunnel](docs/recipes/cloudflare-tunnel.md) | Access without a public IP |
+| [Local-Only Deployment](docs/recipes/local-only.md) | Run without DNS, TLS, or ingress |
 
 **For contributors:**
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -116,6 +116,26 @@ If you disable components, you'll configure Mortise to point at your
 external ones via `PlatformConfig`. See
 [Configuring your platform](./configuration.md).
 
+> **BYO Traefik + observer traffic metrics:** If you bring your own Traefik
+> and enable the observer (`observer.enableTraffic: true`), Traefik must have
+> **JSON-formatted access logs** enabled. The observer parses JSON fields
+> (`ServiceName`, `OriginStatus`, `Duration`) — Traefik's default Common Log
+> Format is silently dropped. Add this to your Traefik Helm values:
+>
+> ```yaml
+> logs:
+>   access:
+>     enabled: true
+>     format: json
+>     fields:
+>       headers:
+>         defaultMode: drop
+> ```
+>
+> Without this, `/v1/traffic` returns empty data. See
+> [Troubleshooting > Observer traffic empty with BYO Traefik](./troubleshooting.md#observer-traffic-empty-with-byo-traefik)
+> for details.
+
 ### Two charts
 
 | Chart | Contains | When to pick |

--- a/docs/recipes/local-only.md
+++ b/docs/recipes/local-only.md
@@ -1,0 +1,119 @@
+# Local-Only Deployment (No DNS / No TLS / No Ingress)
+
+Mortise works fully without Traefik, DNS, or TLS by using `kubectl
+port-forward` to access apps directly. This is useful for:
+
+- Local development on k3d / kind / minikube
+- Testing without DNS configuration
+- Air-gapped or LAN-only environments
+- Evaluating Mortise before committing to domain setup
+
+---
+
+## Install with ingress disabled
+
+### Quick install
+
+The standard quick install works out of the box for local use — it
+installs Traefik but you can access everything via `localhost:8090`
+without DNS:
+
+```bash
+curl -fsSL https://mortise.me/install | bash
+```
+
+### Helm (minimal, no ingress/TLS)
+
+If you want the lightest possible install:
+
+```bash
+helm install mortise mortise/mortise \
+  --namespace mortise-system --create-namespace \
+  --set traefik.enabled=false \
+  --set cert-manager.enabled=false
+```
+
+Apps won't get automatic public URLs, but they'll build and deploy
+normally. You access them via port-forward.
+
+---
+
+## Accessing the Mortise UI
+
+```bash
+kubectl port-forward -n mortise-system svc/mortise 8090:80
+# open http://localhost:8090
+```
+
+---
+
+## Accessing deployed apps
+
+Every app gets a Service in its environment namespace. The namespace
+follows the pattern `pj-{project}-{env}` and the service is named
+after the app.
+
+```bash
+# Format: kubectl port-forward -n pj-{project}-{env} svc/{app} {local-port}:80
+kubectl port-forward -n pj-my-project-production svc/my-app 3000:80
+# open http://localhost:3000
+```
+
+To find the exact service name and port:
+
+```bash
+kubectl get svc -n pj-my-project-production
+```
+
+---
+
+## Skipping the domain step in the wizard
+
+When you first open the Mortise UI, the setup wizard asks for a platform
+domain. This step is optional — you can leave it blank or skip it
+entirely. Apps will still build and deploy; they just won't get
+automatic `{app}.{domain}` URLs.
+
+You can set the domain later in **Settings > Platform** when you're
+ready to configure DNS.
+
+---
+
+## Using the CLI with port-forward
+
+The Mortise CLI connects to the API at whatever address you specify
+during `mortise login`:
+
+```bash
+mortise login --server http://localhost:8090
+```
+
+All CLI commands (`mortise app list`, `mortise deploy`, etc.) work
+normally over the port-forwarded connection.
+
+---
+
+## Limitations
+
+- **No automatic URLs:** Without an ingress controller and DNS, apps
+  have no public hostname. Each app requires a manual port-forward.
+- **No webhooks:** Git push-to-deploy requires the git provider to
+  reach your cluster via HTTPS. Without a public URL, webhooks won't
+  arrive. You can still trigger deploys manually via the UI or CLI.
+- **No TLS:** Port-forwarded connections are plain HTTP over localhost.
+  This is fine for local development but not for production.
+- **One port-forward per app:** Each app you want to access
+  simultaneously needs its own local port.
+
+---
+
+## When to upgrade to full DNS
+
+Move to the full setup when you want:
+- Automatic `{app}.{domain}` URLs
+- Push-to-deploy via git webhooks
+- TLS certificates
+- Preview environments (require webhook delivery)
+
+See [Configuration > Platform domain](../configuration.md) to add a
+domain later without reinstalling.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,6 +116,50 @@ kubelet can already reach those registries over HTTPS with standard DNS.
 
 ---
 
+## Observer traffic empty with BYO Traefik
+
+**Symptom:** The observer is enabled (`observer.enableTraffic: true`) and
+tailing Traefik pods, but `/v1/traffic` returns all null series. No errors
+in the observer logs.
+
+**Cause:** The observer's traffic collector expects Traefik access logs in
+**JSON format** with fields like `ServiceName`, `OriginStatus`, and
+`Duration`. Traefik's default access log format is Common Log Format (CLF),
+which fails `json.Unmarshal` silently — every line is discarded.
+
+**Fix:** Configure your Traefik installation to emit JSON access logs:
+
+```yaml
+# Traefik Helm values
+logs:
+  access:
+    enabled: true
+    format: json
+    fields:
+      headers:
+        defaultMode: drop
+```
+
+If you installed Traefik via Helm:
+
+```bash
+helm upgrade traefik traefik/traefik \
+  --namespace traefik-system --reuse-values \
+  --set 'logs.access.enabled=true' \
+  --set 'logs.access.format=json' \
+  --set 'logs.access.fields.headers.defaultMode=drop'
+```
+
+After the Traefik pods restart, the observer will begin parsing traffic data
+within seconds. Verify with `curl http://localhost:8090/v1/traffic`.
+
+**Why the bundled Traefik doesn't hit this:** The Mortise chart's Traefik
+subchart pre-configures JSON access logs in `charts/mortise/values.yaml`.
+This only affects BYO Traefik installations where you set
+`traefik.enabled=false`.
+
+---
+
 ## Known Limitations
 
 ### supabase/postgres and POSTGRES_USER

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,7 @@ Mortise is a self-hosted, Railway-style deploy platform for Kubernetes. Connect 
 
 - Docs: https://mortise.me
 - Install script: https://mortise.me/install (macOS/Linux) or https://mortise.me/install.ps1 (Windows)
+- OpenAPI spec (stable): https://raw.githubusercontent.com/mortise-org/mortise/main/docs/swagger.yaml
 - OpenAPI spec (live cluster): {base}/api/openapi.yaml
 - Helm chart: https://mortise-org.github.io/mortise
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -322,6 +322,8 @@ wait_and_print_success() {
     printf '  Port-forward is running in the background.\n'
     printf '  To restart it later: kubectl port-forward -n %s svc/mortise %s:80\n' "$MORTISE_NAMESPACE" "$pf_port"
     printf '\n'
+    printf '  LLM context & API reference: https://mortise.me/llms.txt\n'
+    printf '\n'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#169** — Document that BYO Traefik requires JSON-formatted access logs for observer traffic metrics. Added a callout in `docs/install.md` (BYO ingress section) and a full troubleshooting entry in `docs/troubleshooting.md`.
- **#131** — Add stable OpenAPI URL (`raw.githubusercontent.com/.../swagger.yaml`) to `llms.txt` and print `mortise.me/llms.txt` in the install script success banner so LLMs can discover Mortise context automatically.
- **#35** — New `docs/recipes/local-only.md` recipe covering installation without ingress/DNS/TLS, port-forward access to apps, wizard domain-skip, and CLI usage over localhost. Referenced from README recipes table.

Closes #169, closes #131, closes #35

## Test plan

- [ ] Verify markdown renders correctly on GitHub (tables, code blocks, callouts)
- [ ] Confirm `docs/troubleshooting.md` anchor link works from `docs/install.md`
- [ ] Confirm `docs/recipes/local-only.md` link works from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)