### PR TITLE
fix: retry on conflict in env clone, eliminate observer SQLITE_BUSY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,8 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	k3d image import $(INT_IMG) $(INT_OBSERVER_IMG) nginx:1.27 postgres:16 redis:7 busybox:1.37 alpine:3.20 -c $(INT_CLUSTER)
 	@echo "==> Installing CRDs..."
 	kubectl apply -f charts/mortise-core/crds/
+	@echo "==> Waiting for CRDs to be established..."
+	kubectl wait --for=condition=Established crd/platformconfigs.mortise.mortise.dev --timeout=30s
 	@echo "==> Installing test-only dependencies (registry, Gitea, BuildKit)..."
 	kubectl create namespace mortise-system --dry-run=client -o yaml | kubectl apply -f -
 	kubectl apply -f test/integration/manifests/

--- a/cmd/observer/store.go
+++ b/cmd/observer/store.go
@@ -128,8 +128,8 @@ func NewStore(path string) (*Store, error) {
 			return nil, fmt.Errorf("exec DDL: %w", err)
 		}
 	}
-	db.SetMaxOpenConns(4)
-	db.SetMaxIdleConns(4)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	return &Store{db: db}, nil
 }

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -421,9 +421,28 @@ func (s *Server) cloneAppOverrides(ctx context.Context, projectName, ns, sourceN
 	store := &envstore.Store{Client: s.client}
 
 	for i := range apps.Items {
-		app := &apps.Items[i]
+		appName := apps.Items[i].Name
+		if err := s.cloneEnvToApp(ctx, ns, appName, sourceName, targetName, sourceEnvNs, store); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		// Retry-safe: skip apps that already have the target env.
+const maxConflictRetries = 5
+
+func (s *Server) cloneEnvToApp(ctx context.Context, ns, appName, sourceName, targetName, sourceEnvNs string, store *envstore.Store) error {
+	secretVars, err := store.Get(ctx, sourceEnvNs, appName)
+	if err != nil {
+		return fmt.Errorf("read source env vars for app %q: %w", appName, err)
+	}
+
+	for attempt := range maxConflictRetries {
+		var app mortisev1alpha1.App
+		if err := s.client.Get(ctx, types.NamespacedName{Namespace: ns, Name: appName}, &app); err != nil {
+			return fmt.Errorf("get app %q: %w", appName, err)
+		}
+
 		hasTarget := false
 		for j := range app.Spec.Environments {
 			if app.Spec.Environments[j].Name == targetName {
@@ -432,7 +451,7 @@ func (s *Server) cloneAppOverrides(ctx context.Context, projectName, ns, sourceN
 			}
 		}
 		if hasTarget {
-			continue
+			return nil
 		}
 
 		var sourceEnv *mortisev1alpha1.Environment
@@ -443,14 +462,6 @@ func (s *Server) cloneAppOverrides(ctx context.Context, projectName, ns, sourceN
 			}
 		}
 
-		// Read Secret-level env vars from the source env namespace.
-		secretVars, err := store.Get(ctx, sourceEnvNs, app.Name)
-		if err != nil {
-			return fmt.Errorf("read source env vars for app %q: %w", app.Name, err)
-		}
-
-		// Merge: Secret vars first, then CRD vars win on conflict.
-		// Exclude binding-sourced vars — they'll be re-resolved by the controller.
 		envMap := make(map[string]mortisev1alpha1.EnvVar)
 		for _, ev := range secretVars {
 			if ev.Source == "binding" {
@@ -493,8 +504,12 @@ func (s *Server) cloneAppOverrides(ctx context.Context, projectName, ns, sourceN
 		}
 
 		app.Spec.Environments = append(app.Spec.Environments, cloned)
-		if err := s.client.Update(ctx, app); err != nil {
-			return fmt.Errorf("clone env overrides for app %q: %w", app.Name, err)
+		updateErr := s.client.Update(ctx, &app)
+		if updateErr == nil {
+			return nil
+		}
+		if !errors.IsConflict(updateErr) || attempt == maxConflictRetries-1 {
+			return fmt.Errorf("clone env overrides for app %q: %w", appName, updateErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- **Env clone optimistic locking race (fixes #192):** `cloneAppOverrides` did a stale read-modify-write on App CRDs — the controller's reconcile loop could bump `resourceVersion` between the List and Update, causing a 500. Extracted per-app update into `cloneEnvToApp` with a retry-on-conflict loop (up to 5 attempts, re-fetching the latest App on each conflict).
- **Observer SQLITE_BUSY:** Reduced `MaxOpenConns` from 4 to 1. With WAL mode, SQLite supports concurrent readers but only one writer — multiple pool connections caused write contention under CI load. A single connection eliminates BUSY errors entirely.

## Test plan

- [ ] CI integration tests pass (specifically `TestEnvironmentCloneCreatesEnvWithConfig`)
- [ ] Observer tests no longer log `SQLITE_BUSY` transient errors
- [ ] Unit + envtest suite passes locally (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)