### PR TITLE
fix: separate auto-generated domain from primary in status

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -433,6 +433,11 @@ type EnvironmentStatus struct {
 	// +optional
 	Domain string `json:"domain,omitempty"`
 
+	// AutoDomain is the platform-generated domain for this environment,
+	// always computed regardless of whether a custom primary domain is set.
+	// +optional
+	AutoDomain string `json:"autoDomain,omitempty"`
+
 	// LastProcessedRestartedAt stores the mortise.dev/restartedAt annotation
 	// value from the Deployment once the rollout completes. Prevents the
 	// controller from snapping the phase back to Ready before a user-triggered

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -598,6 +598,11 @@ spec:
                   description: EnvironmentStatus tracks the observed state of a single
                     environment.
                   properties:
+                    autoDomain:
+                      description: |-
+                        AutoDomain is the platform-generated domain for this environment,
+                        always computed regardless of whether a custom primary domain is set.
+                      type: string
                     currentDigest:
                       type: string
                     currentImage:

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -598,6 +598,11 @@ spec:
                   description: EnvironmentStatus tracks the observed state of a single
                     environment.
                   properties:
+                    autoDomain:
+                      description: |-
+                        AutoDomain is the platform-generated domain for this environment,
+                        always computed regardless of whether a custom primary domain is set.
+                      type: string
                     currentDigest:
                       type: string
                     currentImage:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1554,6 +1554,12 @@ definitions:
     type: object
   v1alpha1.EnvironmentStatus:
     properties:
+      autoDomain:
+        description: |-
+          AutoDomain is the platform-generated domain for this environment,
+          always computed regardless of whether a custom primary domain is set.
+          +optional
+        type: string
       currentDigest:
         type: string
       currentImage:

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -135,7 +135,7 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		for _, se := range other.Status.Environments {
-			if se.Domain == req.Domain {
+			if se.Domain == req.Domain || se.AutoDomain == req.Domain {
 				writeJSON(w, http.StatusConflict, errorResponse{
 					fmt.Sprintf("domain %s is already used by %s in %s (%s)", req.Domain, other.Name, otherProject, se.Name),
 				})
@@ -329,7 +329,7 @@ func (s *Server) ValidateDomain(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		for _, se := range app.Status.Environments {
-			if se.Domain == req.Domain {
+			if se.Domain == req.Domain || se.AutoDomain == req.Domain {
 				writeJSON(w, http.StatusOK, domainValidateResponse{
 					Valid: false,
 					Conflict: &domainConflict{

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -57,14 +57,14 @@ func (s *Server) ListDomains(w http.ResponseWriter, r *http.Request) {
 
 	env := findEnvironment(app, envName)
 	if env == nil {
-		writeJSON(w, http.StatusOK, domainsResponse{Auto: statusDomain(app, envName)})
+		writeJSON(w, http.StatusOK, domainsResponse{Auto: statusAutoDomain(app, envName)})
 		return
 	}
 
 	writeJSON(w, http.StatusOK, domainsResponse{
 		Primary: env.Domain,
 		Custom:  env.CustomDomains,
-		Auto:    statusDomain(app, envName),
+		Auto:    statusAutoDomain(app, envName),
 	})
 }
 
@@ -155,7 +155,7 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, domainsResponse{
 		Primary: env.Domain,
 		Custom:  env.CustomDomains,
-		Auto:    statusDomain(app, envName),
+		Auto:    statusAutoDomain(app, envName),
 	})
 }
 
@@ -209,7 +209,7 @@ func (s *Server) RemoveDomain(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, domainsResponse{
 		Primary: env.Domain,
 		Custom:  env.CustomDomains,
-		Auto:    statusDomain(app, envName),
+		Auto:    statusAutoDomain(app, envName),
 	})
 }
 
@@ -225,12 +225,12 @@ func findEnvironment(app *mortisev1alpha1.App, name string) *mortisev1alpha1.Env
 	return nil
 }
 
-// statusDomain returns the auto-generated domain from the app's status for
+// statusAutoDomain returns the auto-generated domain from the app's status for
 // the given environment, or empty if none exists.
-func statusDomain(app *mortisev1alpha1.App, envName string) string {
+func statusAutoDomain(app *mortisev1alpha1.App, envName string) string {
 	for _, se := range app.Status.Environments {
 		if se.Name == envName {
-			return se.Domain
+			return se.AutoDomain
 		}
 	}
 	return ""

--- a/internal/api/domains_test.go
+++ b/internal/api/domains_test.go
@@ -547,3 +547,129 @@ func TestAddDomain_RejectsStatusDomainCollision(t *testing.T) {
 		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestListDomains_AutoDomainFromStatus(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "webapp", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production", Domain: "custom.example.com"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+	app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{
+		{Name: "production", Domain: "custom.example.com", AutoDomain: "webapp-default.apps.example.com"},
+	}
+	if err := k8sClient.Status().Update(ctx, app); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/webapp/domains?environment=production", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["auto"] != "webapp-default.apps.example.com" {
+		t.Errorf("auto: expected webapp-default.apps.example.com, got %v", resp["auto"])
+	}
+	if resp["primary"] != "custom.example.com" {
+		t.Errorf("primary: expected custom.example.com, got %v", resp["primary"])
+	}
+}
+
+func TestAddDomain_RejectsAutoDomainCollision(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	other := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(ctx, other); err != nil {
+		t.Fatalf("create other app: %v", err)
+	}
+	other.Status.Environments = []mortisev1alpha1.EnvironmentStatus{
+		{Name: "production", Domain: "primary.example.com", AutoDomain: "other-auto.apps.example.com"},
+	}
+	if err := k8sClient.Status().Update(ctx, other); err != nil {
+		t.Fatalf("update other status: %v", err)
+	}
+
+	target := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, target); err != nil {
+		t.Fatalf("create target app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/target-app/domains?environment=production", map[string]string{
+		"domain": "other-auto.apps.example.com",
+	})
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 for AutoDomain collision, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestValidateDomain_ConflictAutoDomain(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "autogen", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+	app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{
+		{Name: "production", Domain: "primary.example.com", AutoDomain: "autogen-auto.apps.example.com"},
+	}
+	if err := k8sClient.Status().Update(ctx, app); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	w := doRequest(h, http.MethodPost, "/api/domains/validate", map[string]string{
+		"domain": "autogen-auto.apps.example.com",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["valid"] != false {
+		t.Errorf("expected valid=false for AutoDomain collision, got %v", resp["valid"])
+	}
+	conflict := resp["conflict"].(map[string]any)
+	if conflict["app"] != "autogen" {
+		t.Errorf("expected app=autogen, got %v", conflict["app"])
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1554,6 +1554,12 @@ definitions:
     type: object
   v1alpha1.EnvironmentStatus:
     properties:
+      autoDomain:
+        description: |-
+          AutoDomain is the platform-generated domain for this environment,
+          always computed regardless of whether a custom primary domain is set.
+          +optional
+        type: string
       currentDigest:
         type: string
       currentImage:

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2073,14 +2073,19 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 	firstCrashMsg := ""
 
 	for _, env := range resolvedEnvs {
+		autoDomain := ""
+		if app.Spec.Network.Public {
+			autoDomain = r.autoDefaultDomain(ctx, app, env.Name)
+		}
 		domain := env.Domain
-		if domain == "" && app.Spec.Network.Public {
-			domain = r.autoDefaultDomain(ctx, app, env.Name)
+		if domain == "" {
+			domain = autoDomain
 		}
 		es := mortisev1alpha1.EnvironmentStatus{
 			Name:         env.Name,
 			CurrentImage: r.currentImageForEnv(app, env.Name),
 			Domain:       domain,
+			AutoDomain:   autoDomain,
 		}
 		envNs, nsErr := appEnvNs(app, env.Name)
 		if nsErr != nil {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -125,6 +125,7 @@ export interface EnvironmentStatus {
 	currentImage?: string;
 	currentDigest?: string;
 	domain?: string;
+	autoDomain?: string;
 	deployHistory?: DeployRecord[];
 	pendingEnvHash?: string;
 	deployedEnvHash?: string;


### PR DESCRIPTION
## Summary
- Add `AutoDomain` field to `EnvironmentStatus` so the auto-generated domain is always tracked independently of the custom primary domain
- Controller always computes and writes `AutoDomain` regardless of whether a primary domain is set
- API `ListDomains` reads `AutoDomain` instead of `Domain` for the `auto` response field, fixing the bug where setting a primary domain caused the auto domain to show the same value

Closes #217

## Test plan
- [x] All 392 existing tests pass
- [ ] Set a primary domain on an app → verify API returns correct separate `auto` and `primary` values
- [ ] Remove the primary domain → verify `auto` still shows the auto-generated domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)