### PR TITLE
fix: audit batch — rollback names, MustParse panic, volume sync, dead fields, latest tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v5
         with:

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -164,6 +164,7 @@ type ConfigFile struct {
 }
 
 type EnvVar struct {
+	// Name is the environment variable name.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
 	// +kubebuilder:validation:MaxLength=253

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -164,6 +164,9 @@ type ConfigFile struct {
 }
 
 type EnvVar struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
+	// +kubebuilder:validation:MaxLength=253
 	Name      string        `json:"name"`
 	Value     string        `json:"value,omitempty"`
 	ValueFrom *EnvVarSource `json:"valueFrom,omitempty"`
@@ -495,15 +498,6 @@ type AppStatus struct {
 	// Zero means no port was detected.
 	// +optional
 	DetectedPort int32 `json:"detectedPort,omitempty"`
-
-	// PendingEnvHash is the hash of the current env Secret state.
-	// +optional
-	PendingEnvHash string `json:"pendingEnvHash,omitempty"`
-
-	// DeployedEnvHash is the env hash currently on the running pod template.
-	// When it differs from PendingEnvHash, the app has unapplied env changes.
-	// +optional
-	DeployedEnvHash string `json:"deployedEnvHash,omitempty"`
 
 	// +listType=map
 	// +listMapKey=type

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -184,6 +184,8 @@ spec:
                       items:
                         properties:
                           name:
+                            maxLength: 253
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           value:
                             type: string
@@ -400,6 +402,8 @@ spec:
                 items:
                   properties:
                     name:
+                      maxLength: 253
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string
                     value:
                       type: string
@@ -581,11 +585,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              deployedEnvHash:
-                description: |-
-                  DeployedEnvHash is the env hash currently on the running pod template.
-                  When it differs from PendingEnvHash, the app has unapplied env changes.
-                type: string
               detectedPort:
                 description: |-
                   DetectedPort is the container port auto-detected from EXPOSE directives
@@ -686,10 +685,6 @@ spec:
                 description: |-
                   LastBuiltSHA is the git commit SHA of the most recently completed build.
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
-                type: string
-              pendingEnvHash:
-                description: PendingEnvHash is the hash of the current env Secret
-                  state.
                 type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -184,6 +184,7 @@ spec:
                       items:
                         properties:
                           name:
+                            description: Name is the environment variable name.
                             maxLength: 253
                             pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
@@ -402,6 +403,7 @@ spec:
                 items:
                   properties:
                     name:
+                      description: Name is the environment variable name.
                       maxLength: 253
                       pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string

--- a/charts/mortise-core/crds/mortise.mortise.dev_previewenvironments.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_previewenvironments.yaml
@@ -82,6 +82,7 @@ spec:
                 items:
                   properties:
                     name:
+                      description: Name is the environment variable name.
                       maxLength: 253
                       pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string

--- a/charts/mortise-core/crds/mortise.mortise.dev_previewenvironments.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_previewenvironments.yaml
@@ -82,6 +82,8 @@ spec:
                 items:
                   properties:
                     name:
+                      maxLength: 253
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string
                     value:
                       type: string

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -184,6 +184,8 @@ spec:
                       items:
                         properties:
                           name:
+                            maxLength: 253
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           value:
                             type: string
@@ -400,6 +402,8 @@ spec:
                 items:
                   properties:
                     name:
+                      maxLength: 253
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string
                     value:
                       type: string
@@ -581,11 +585,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              deployedEnvHash:
-                description: |-
-                  DeployedEnvHash is the env hash currently on the running pod template.
-                  When it differs from PendingEnvHash, the app has unapplied env changes.
-                type: string
               detectedPort:
                 description: |-
                   DetectedPort is the container port auto-detected from EXPOSE directives
@@ -686,10 +685,6 @@ spec:
                 description: |-
                   LastBuiltSHA is the git commit SHA of the most recently completed build.
                   The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
-                type: string
-              pendingEnvHash:
-                description: PendingEnvHash is the hash of the current env Secret
-                  state.
                 type: string
               phase:
                 description: AppPhase represents the overall lifecycle phase.

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -184,6 +184,7 @@ spec:
                       items:
                         properties:
                           name:
+                            description: Name is the environment variable name.
                             maxLength: 253
                             pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
@@ -402,6 +403,7 @@ spec:
                 items:
                   properties:
                     name:
+                      description: Name is the environment variable name.
                       maxLength: 253
                       pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string

--- a/config/crd/bases/mortise.mortise.dev_previewenvironments.yaml
+++ b/config/crd/bases/mortise.mortise.dev_previewenvironments.yaml
@@ -82,6 +82,7 @@ spec:
                 items:
                   properties:
                     name:
+                      description: Name is the environment variable name.
                       maxLength: 253
                       pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string

--- a/config/crd/bases/mortise.mortise.dev_previewenvironments.yaml
+++ b/config/crd/bases/mortise.mortise.dev_previewenvironments.yaml
@@ -82,6 +82,8 @@ spec:
                 items:
                   properties:
                     name:
+                      maxLength: 253
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       type: string
                     value:
                       type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1281,12 +1281,6 @@ definitions:
         items:
           $ref: '#/definitions/v1.Condition'
         type: array
-      deployedEnvHash:
-        description: |-
-          DeployedEnvHash is the env hash currently on the running pod template.
-          When it differs from PendingEnvHash, the app has unapplied env changes.
-          +optional
-        type: string
       detectedPort:
         description: |-
           DetectedPort is the container port auto-detected from EXPOSE directives
@@ -1308,11 +1302,6 @@ definitions:
         description: |-
           LastBuiltSHA is the git commit SHA of the most recently completed build.
           The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
-          +optional
-        type: string
-      pendingEnvHash:
-        description: |-
-          PendingEnvHash is the hash of the current env Secret state.
           +optional
         type: string
       phase:
@@ -1449,6 +1438,10 @@ definitions:
   v1alpha1.EnvVar:
     properties:
       name:
+        description: |-
+          +kubebuilder:validation:Required
+          +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
+          +kubebuilder:validation:MaxLength=253
         type: string
       value:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1439,6 +1439,7 @@ definitions:
     properties:
       name:
         description: |-
+          Name is the environment variable name.
           +kubebuilder:validation:Required
           +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
           +kubebuilder:validation:MaxLength=253

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1281,12 +1281,6 @@ definitions:
         items:
           $ref: '#/definitions/v1.Condition'
         type: array
-      deployedEnvHash:
-        description: |-
-          DeployedEnvHash is the env hash currently on the running pod template.
-          When it differs from PendingEnvHash, the app has unapplied env changes.
-          +optional
-        type: string
       detectedPort:
         description: |-
           DetectedPort is the container port auto-detected from EXPOSE directives
@@ -1308,11 +1302,6 @@ definitions:
         description: |-
           LastBuiltSHA is the git commit SHA of the most recently completed build.
           The reconciler uses this to short-circuit rebuilds when the revision hasn't changed.
-          +optional
-        type: string
-      pendingEnvHash:
-        description: |-
-          PendingEnvHash is the hash of the current env Secret state.
           +optional
         type: string
       phase:
@@ -1449,6 +1438,10 @@ definitions:
   v1alpha1.EnvVar:
     properties:
       name:
+        description: |-
+          +kubebuilder:validation:Required
+          +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
+          +kubebuilder:validation:MaxLength=253
         type: string
       value:
         type: string

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1439,6 +1439,7 @@ definitions:
     properties:
       name:
         description: |-
+          Name is the environment variable name.
           +kubebuilder:validation:Required
           +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$`
           +kubebuilder:validation:MaxLength=253

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -88,7 +88,7 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 		rollbackImage = target.Digest
 	}
 
-	depName := deploymentName(appName)
+	depName := constants.DeploymentName(appName)
 	var dep appsv1.Deployment
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: envNs}, &dep); err != nil {
 		writeError(w, err)
@@ -199,7 +199,7 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		promoteImage = fromStatus.CurrentDigest
 	}
 
-	depName := deploymentName(appName)
+	depName := constants.DeploymentName(appName)
 	toEnvNs := constants.EnvNamespace(projectName, req.To)
 	var dep appsv1.Deployment
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: toEnvNs}, &dep); err != nil {
@@ -256,5 +256,3 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		"image":  promoteImage,
 	})
 }
-
-func deploymentName(appName string) string { return appName }

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -88,7 +88,7 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 		rollbackImage = target.Digest
 	}
 
-	depName := fmt.Sprintf("%s-%s", appName, req.Environment)
+	depName := deploymentName(appName)
 	var dep appsv1.Deployment
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: envNs}, &dep); err != nil {
 		writeError(w, err)
@@ -199,7 +199,7 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		promoteImage = fromStatus.CurrentDigest
 	}
 
-	depName := fmt.Sprintf("%s-%s", appName, req.To)
+	depName := deploymentName(appName)
 	toEnvNs := constants.EnvNamespace(projectName, req.To)
 	var dep appsv1.Deployment
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: toEnvNs}, &dep); err != nil {
@@ -256,3 +256,5 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		"image":  promoteImage,
 	})
 }
+
+func deploymentName(appName string) string { return appName }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1139,7 +1139,6 @@ func TestPromote(t *testing.T) {
 	}
 
 	// Create Deployments for both envs in their per-env workload namespaces.
-	// The controller names Deployments as just appName (not appName-envName).
 	for _, envName := range []string{"staging", "production"} {
 		depNs := constants.EnvNamespace("default", envName)
 		dep := &appsv1.Deployment{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -605,7 +605,7 @@ func TestRollback(t *testing.T) {
 	// in the per-env namespace.
 	envNs := constants.EnvNamespace("default", "production")
 	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "rollback-app-production", Namespace: envNs},
+		ObjectMeta: metav1.ObjectMeta{Name: "rollback-app", Namespace: envNs},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "rollback-app"}},
 			Template: corev1.PodTemplateSpec{
@@ -649,7 +649,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Verify Deployment was patched.
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "rollback-app-production", Namespace: envNs}, dep); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "rollback-app", Namespace: envNs}, dep); err != nil {
 		t.Fatalf("get deployment: %v", err)
 	}
 	if dep.Spec.Template.Spec.Containers[0].Image != "nginx:1.26" {
@@ -1139,10 +1139,11 @@ func TestPromote(t *testing.T) {
 	}
 
 	// Create Deployments for both envs in their per-env workload namespaces.
+	// The controller names Deployments as just appName (not appName-envName).
 	for _, envName := range []string{"staging", "production"} {
 		depNs := constants.EnvNamespace("default", envName)
 		dep := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "promote-app-" + envName, Namespace: depNs},
+			ObjectMeta: metav1.ObjectMeta{Name: "promote-app", Namespace: depNs},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "promote-app", "env": envName}},
 				Template: corev1.PodTemplateSpec{
@@ -1176,7 +1177,7 @@ func TestPromote(t *testing.T) {
 	// Verify production Deployment has the staging image.
 	prodNs := constants.EnvNamespace("default", "production")
 	var dep appsv1.Deployment
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "promote-app-production", Namespace: prodNs}, &dep); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "promote-app", Namespace: prodNs}, &dep); err != nil {
 		t.Fatalf("get production deployment: %v", err)
 	}
 	if dep.Spec.Template.Spec.Containers[0].Image != "sha256:abc123" {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -66,6 +66,12 @@ func ProjectFromControlNs(ns string) (string, bool) {
 	return ns[len(ControlNamespacePrefix):], true
 }
 
+// DeploymentName returns the Deployment name for an App in any env namespace.
+func DeploymentName(appName string) string { return appName }
+
+// CronJobName returns the CronJob name for an App in any env namespace.
+func CronJobName(appName string) string { return appName }
+
 // Namespace role label values — stamped on every namespace the Project
 // controller owns so callers can distinguish control / env / preview.
 const (

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2356,8 +2356,8 @@ func deploymentRollingOut(dep *appsv1.Deployment) bool {
 	return false
 }
 
-func deploymentName(appName string) string { return appName }
-func cronJobName(appName string) string    { return appName }
+func deploymentName(appName string) string { return constants.DeploymentName(appName) }
+func cronJobName(appName string) string    { return constants.CronJobName(appName) }
 func serviceName(appName string) string    { return appName }
 func ingressName(appName string) string    { return appName }
 

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -855,7 +855,11 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		},
 	}
 
-	containers[0].Resources = toResourceRequirements(r.effectiveResources(ctx, env))
+	resources, err := toResourceRequirements(r.effectiveResources(ctx, env))
+	if err != nil {
+		return fmt.Errorf("resources: %w", err)
+	}
+	containers[0].Resources = resources
 
 	port := appPort(app)
 	containers[0].LivenessProbe = buildProbe(env.LivenessProbe, port)
@@ -929,7 +933,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	// don't cascade cross-ns; the App's finalizer handles cleanup by label.
 
 	var existing appsv1.Deployment
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
+	err = r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
 	if errors.IsNotFound(err) {
 		return r.Create(ctx, desired)
 	}
@@ -986,6 +990,9 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		if !equality.Semantic.DeepEqual(existingContainer.VolumeMounts, desiredContainer.VolumeMounts) {
 			needsUpdate = true
 		}
+		if !equality.Semantic.DeepEqual(existing.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
+			needsUpdate = true
+		}
 		if !equality.Semantic.DeepEqual(existingContainer.Resources, desiredContainer.Resources) {
 			needsUpdate = true
 		}
@@ -1020,6 +1027,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		existing.Spec.Template.Spec.Containers[0].EnvFrom = desiredContainer.EnvFrom
 		existing.Spec.Template.Spec.Containers[0].Ports = desiredContainer.Ports
 		existing.Spec.Template.Spec.Containers[0].VolumeMounts = desiredContainer.VolumeMounts
+		existing.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
 		existing.Spec.Template.Spec.Containers[0].Resources = desiredContainer.Resources
 		existing.Spec.Template.Spec.Containers[0].LivenessProbe = desiredContainer.LivenessProbe
 		existing.Spec.Template.Spec.Containers[0].ReadinessProbe = desiredContainer.ReadinessProbe
@@ -1061,7 +1069,11 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		},
 	}
 
-	containers[0].Resources = toResourceRequirements(r.effectiveResources(ctx, env))
+	resources, err := toResourceRequirements(r.effectiveResources(ctx, env))
+	if err != nil {
+		return fmt.Errorf("resources: %w", err)
+	}
+	containers[0].Resources = resources
 
 	volumes, mounts := toVolumesAndMounts(app)
 
@@ -1131,7 +1143,7 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 	// Cross-namespace: no controller ref; finalizer-based GC on App delete.
 
 	var existing batchv1.CronJob
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
+	err = r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &existing)
 	if errors.IsNotFound(err) {
 		return r.Create(ctx, desired)
 	}
@@ -2589,22 +2601,28 @@ func (r *AppReconciler) effectiveResources(ctx context.Context, env *mortisev1al
 	return res
 }
 
-func toResourceRequirements(r mortisev1alpha1.ResourceRequirements) corev1.ResourceRequirements {
+func toResourceRequirements(r mortisev1alpha1.ResourceRequirements) (corev1.ResourceRequirements, error) {
 	req := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{},
 		Limits:   corev1.ResourceList{},
 	}
 	if r.CPU != "" {
-		q := resource.MustParse(r.CPU)
+		q, err := resource.ParseQuantity(r.CPU)
+		if err != nil {
+			return req, fmt.Errorf("invalid cpu %q: %w", r.CPU, err)
+		}
 		req.Requests[corev1.ResourceCPU] = q
 		req.Limits[corev1.ResourceCPU] = q
 	}
 	if r.Memory != "" {
-		q := resource.MustParse(r.Memory)
+		q, err := resource.ParseQuantity(r.Memory)
+		if err != nil {
+			return req, fmt.Errorf("invalid memory %q: %w", r.Memory, err)
+		}
 		req.Requests[corev1.ResourceMemory] = q
 		req.Limits[corev1.ResourceMemory] = q
 	}
-	return req
+	return req, nil
 }
 
 func toVolumesAndMounts(app *mortisev1alpha1.App) ([]corev1.Volume, []corev1.VolumeMount) {

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2657,6 +2657,7 @@ func toVolumesAndMounts(app *mortisev1alpha1.App) ([]corev1.Volume, []corev1.Vol
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+					DefaultMode:          ptr.To(int32(0644)),
 				},
 			},
 		})
@@ -2701,8 +2702,9 @@ func toSecretVolumesAndMounts(mounts []mortisev1alpha1.SecretMount) ([]corev1.Vo
 			Name: m.Name,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: m.Secret,
-					Items:      items,
+					SecretName:  m.Secret,
+					Items:       items,
+					DefaultMode: ptr.To(int32(0644)),
 				},
 			},
 		})

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -5001,3 +5001,35 @@ func readAppEnvSecret(ctx context.Context, appName, namespace string) map[string
 	}
 	return result
 }
+
+var _ = Describe("toResourceRequirements", func() {
+	It("should parse valid CPU and memory", func() {
+		r := mortisev1alpha1.ResourceRequirements{CPU: "500m", Memory: "256Mi"}
+		req, err := toResourceRequirements(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Requests.Cpu().String()).To(Equal("500m"))
+		Expect(req.Requests.Memory().String()).To(Equal("256Mi"))
+	})
+
+	It("should return error for invalid CPU", func() {
+		r := mortisev1alpha1.ResourceRequirements{CPU: "banana", Memory: "256Mi"}
+		_, err := toResourceRequirements(r)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid cpu"))
+	})
+
+	It("should return error for invalid memory", func() {
+		r := mortisev1alpha1.ResourceRequirements{CPU: "500m", Memory: "notamemory"}
+		_, err := toResourceRequirements(r)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid memory"))
+	})
+
+	It("should handle empty values without error", func() {
+		r := mortisev1alpha1.ResourceRequirements{}
+		req, err := toResourceRequirements(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Requests).To(BeEmpty())
+		Expect(req.Limits).To(BeEmpty())
+	})
+})

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -369,7 +369,11 @@ func (r *PreviewEnvironmentReconciler) reconcilePreviewDeployment(ctx context.Co
 	}
 
 	if pe.Spec.Resources.CPU != "" || pe.Spec.Resources.Memory != "" {
-		containers[0].Resources = toResourceRequirements(pe.Spec.Resources)
+		resources, err := toResourceRequirements(pe.Spec.Resources)
+		if err != nil {
+			return fmt.Errorf("resources: %w", err)
+		}
+		containers[0].Resources = resources
 	}
 
 	labels := previewLabels(pe)

--- a/ui/src/lib/templates.ts
+++ b/ui/src/lib/templates.ts
@@ -128,7 +128,7 @@ export const templates: Template[] = [
 		defaults: {
 			name: 'paperless',
 			spec: {
-				source: { type: 'image', image: 'ghcr.io/paperless-ngx/paperless-ngx:latest' },
+				source: { type: 'image', image: 'ghcr.io/paperless-ngx/paperless-ngx:2.20.15' },
 				network: { public: true },
 				storage: [
 					{ name: 'data', mountPath: '/usr/src/paperless/data', size: '5Gi' },
@@ -163,7 +163,7 @@ export const templates: Template[] = [
 		defaults: {
 			name: 'vaultwarden',
 			spec: {
-				source: { type: 'image', image: 'vaultwarden/server:latest' },
+				source: { type: 'image', image: 'vaultwarden/server:1.36.0' },
 				network: { public: true },
 				storage: [
 					{ name: 'data', mountPath: '/data', size: '2Gi' }
@@ -196,7 +196,7 @@ export const templates: Template[] = [
 		defaults: {
 			name: 'mealie',
 			spec: {
-				source: { type: 'image', image: 'ghcr.io/mealie-recipes/mealie:latest' },
+				source: { type: 'image', image: 'ghcr.io/mealie-recipes/mealie:v3.17.0' },
 				network: { public: true },
 				storage: [
 					{ name: 'data', mountPath: '/app/data', size: '2Gi' }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -143,8 +143,6 @@ export interface Condition {
 export interface AppStatus {
 	phase?: AppPhase;
 	environments?: EnvironmentStatus[];
-	pendingEnvHash?: string;
-	deployedEnvHash?: string;
 	conditions?: Condition[];
 }
 


### PR DESCRIPTION
## Summary

Batch fix for 5 audit findings — all concrete bugs with clear fixes:

- **#220 — Rollback/Promote always 404:** Both handlers constructed Deployment names as `appName-envName`, but the controller names them as just `appName`. Every rollback and promote operation was broken. Fixed both handlers and updated tests.

- **#229 — resource.MustParse panic:** `toResourceRequirements` called `resource.MustParse` which panics on malformed CPU/Memory strings (e.g. `cpu: "banana"`), crashing the operator. Replaced with `resource.ParseQuantity` + error propagation. Also added kubebuilder validation markers (`Required`, `Pattern`, `MaxLength`) to `EnvVar.Name` to match `Credential.Name`.

- **#230 — Deployment update never syncs Volumes:** The `needsUpdate` check compared VolumeMounts but not Volumes. Adding/removing storage or configFiles after initial creation left stale Volume definitions, causing pods to fail. Added Volumes to both the comparison and apply blocks.

- **#212 — Dead AppStatus fields:** Removed `PendingEnvHash` and `DeployedEnvHash` from `AppStatus` (superseded by per-environment fields in `EnvironmentStatus`). Removed from Go types, TypeScript types, regenerated CRDs and OpenAPI spec.

- **#225 — :latest image tags:** Pinned UI template images to current stable versions (paperless-ngx 2.20.15, vaultwarden 1.36.0, mealie v3.17.0). Removed `:latest` tag from observer image metadata in release workflow.

Closes #212, closes #220, closes #225, closes #229, closes #230

## Test plan

- [x] `go build ./...` compiles clean
- [x] `make test` — all 769 tests pass (including updated rollback/promote tests)
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `make manifests` — CRDs and OpenAPI spec regenerated
- [x] Rollback/Promote tests updated to use correct Deployment name (`appName` not `appName-envName`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)