### PR TITLE
fix: remove redundant nil check (staticcheck S1009)

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1112,7 +1112,7 @@ func TestRedeployStaleNoStaleEnvs(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.Restarted != nil && len(resp.Restarted) != 0 {
+	if len(resp.Restarted) != 0 {
 		t.Errorf("expected no envs restarted, got %v", resp.Restarted)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove redundant `resp.Restarted != nil` guard in `server_test.go:1115` — `len()` on a nil slice returns 0
- Fixes staticcheck S1009 that is blocking PR #218 and any other open PRs

## Test plan
- [x] `staticcheck ./...` passes locally
- [x] No behavior change — purely a lint fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)