### PR TITLE
fix: security audit batch (XSS, env-var protection, webhook, setup race, build resolution, cache isolation)

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/mortise-org/mortise/internal/auth"
 )
 
@@ -70,14 +74,25 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"email and password required"})
 		return
 	}
-
-	users, err := s.auth.ListUsers(r.Context())
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+	if len(req.Password) < 8 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"password must be at least 8 characters"})
 		return
 	}
-	if len(users) > 0 {
-		writeJSON(w, http.StatusConflict, errorResponse{"setup already complete"})
+
+	// Atomic setup claim: create a sentinel ConfigMap. If it already exists,
+	// another request won the race and setup is complete.
+	sentinel := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mortise-setup-complete",
+			Namespace: "mortise-system",
+		},
+	}
+	if err := s.client.Create(r.Context(), sentinel); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			writeJSON(w, http.StatusConflict, errorResponse{"setup already complete"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
 	}
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -79,6 +79,12 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	native, ok := s.auth.(*auth.NativeAuthProvider)
+	if !ok {
+		writeJSON(w, http.StatusNotImplemented, errorResponse{"setup requires native auth provider"})
+		return
+	}
+
 	// Atomic setup claim: create a sentinel ConfigMap. If it already exists,
 	// another request won the race and setup is complete.
 	sentinel := &corev1.ConfigMap{
@@ -96,12 +102,8 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	native, ok := s.auth.(*auth.NativeAuthProvider)
-	if !ok {
-		writeJSON(w, http.StatusNotImplemented, errorResponse{"setup requires native auth provider"})
-		return
-	}
 	if err := native.CreateUser(r.Context(), req.Email, req.Password, auth.RoleAdmin); err != nil {
+		_ = s.client.Delete(r.Context(), sentinel)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
 	}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -162,10 +162,10 @@ func TestProtectedRouteAcceptsValidToken(t *testing.T) {
 
 	authProvider := auth.NewNativeAuthProvider(k8sClient)
 	jwtHelper := auth.NewJWTHelper(k8sClient)
-	if err := authProvider.CreateUser(ctx, "user@example.com", "pass123", auth.RoleAdmin); err != nil {
+	if err := authProvider.CreateUser(ctx, "user@example.com", "pass1234", auth.RoleAdmin); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
-	principal, _ := authProvider.Authenticate(ctx, auth.Credentials{Email: "user@example.com", Password: "pass123"})
+	principal, _ := authProvider.Authenticate(ctx, auth.Credentials{Email: "user@example.com", Password: "pass1234"})
 	token, _ := jwtHelper.GenerateToken(ctx, principal)
 
 	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -132,6 +132,37 @@ func TestLoginInvalidCredentials(t *testing.T) {
 	}
 }
 
+// TestSetupRejectsShortPassword verifies setup returns 400 for passwords under 8 chars.
+func TestSetupRejectsShortPassword(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	body := map[string]any{"email": "admin@example.com", "password": "short"}
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/setup", body, "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for short password, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateUserRejectsShortPassword verifies CreateUser rejects passwords under 8 chars.
+func TestCreateUserRejectsShortPassword(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	err := authProvider.CreateUser(ctx, "user@example.com", "short", auth.RoleMember)
+	if err == nil {
+		t.Fatal("expected error for short password")
+	}
+}
+
 // TestProtectedRouteRequiresToken verifies /api/projects requires auth.
 func TestProtectedRouteRequiresToken(t *testing.T) {
 	k8sClient := setupEnvtest(t)

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -208,10 +208,17 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Apply unsets.
+	// Apply unsets — reject non-user sources.
 	unsetMap := make(map[string]bool, len(req.Unset))
 	for _, k := range req.Unset {
 		unsetMap[k] = true
+	}
+	for _, e := range existing {
+		if unsetMap[e.Name] && e.Source != "" && e.Source != "user" {
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
+				"cannot unset %q: managed by %s (only user-set vars can be removed)", e.Name, e.Source)})
+			return
+		}
 	}
 	var result []envstore.Env
 	for _, e := range existing {
@@ -220,7 +227,18 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Apply sets.
+	// Apply sets — reject overwrites of non-user sources.
+	existingSource := make(map[string]string, len(result))
+	for _, e := range result {
+		existingSource[e.Name] = e.Source
+	}
+	for k := range req.Set {
+		if src, ok := existingSource[k]; ok && src != "" && src != "user" {
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
+				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", k, src)})
+			return
+		}
+	}
 	for k, v := range req.Set {
 		found := false
 		for i := range result {

--- a/internal/api/env_handler_test.go
+++ b/internal/api/env_handler_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/envstore"
 )
 
 // seedAppForEnv creates a project and app for env handler tests.
@@ -271,6 +274,105 @@ func TestPutSharedVarsRoundTrip(t *testing.T) {
 	_ = json.NewDecoder(w.Body).Decode(&got)
 	if len(got) != 1 || got[0]["name"] != "SHARED_KEY" {
 		t.Errorf("expected SHARED_KEY, got %+v", got)
+	}
+}
+
+func TestPatchEnvRejectsManagedVarOverwrite(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "bound-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	envNs := constants.EnvNamespace("default", "production")
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envNs}})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envstore.AppEnvSecretName("bound-app"),
+			Namespace: envNs,
+			Annotations: map[string]string{
+				"mortise.dev/binding-keys": "DB_URL",
+			},
+		},
+		Data: map[string][]byte{
+			"DB_URL":   []byte("postgres://localhost/db"),
+			"APP_PORT": []byte("3000"),
+		},
+	}
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		t.Fatalf("seed env secret: %v", err)
+	}
+
+	w := doRequest(h, http.MethodPatch, "/api/projects/default/apps/bound-app/env?environment=production", map[string]any{
+		"set": map[string]string{"DB_URL": "postgres://evil/db"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when overwriting binding var, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPatchEnvRejectsManagedVarUnset(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "unset-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	envNs := constants.EnvNamespace("default", "production")
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envNs}})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envstore.AppEnvSecretName("unset-app"),
+			Namespace: envNs,
+			Annotations: map[string]string{
+				"mortise.dev/generated-keys": "SECRET_KEY",
+			},
+		},
+		Data: map[string][]byte{
+			"SECRET_KEY": []byte("generated-value"),
+			"USER_VAR":   []byte("can-delete"),
+		},
+	}
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		t.Fatalf("seed env secret: %v", err)
+	}
+
+	w := doRequest(h, http.MethodPatch, "/api/projects/default/apps/unset-app/env?environment=production", map[string]any{
+		"unset": []string{"SECRET_KEY"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when unsetting generated var, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doRequest(h, http.MethodPatch, "/api/projects/default/apps/unset-app/env?environment=production", map[string]any{
+		"unset": []string{"USER_VAR"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when unsetting user var, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"embed"
+	"html"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -306,14 +307,14 @@ func (s *Server) Handler() http.Handler {
 			// previews (Discord, Slack, etc.) resolve the image correctly.
 			if path == "index.html" {
 				scheme := "https"
-				if proto := req.Header.Get("X-Forwarded-Proto"); proto != "" {
+				if proto := req.Header.Get("X-Forwarded-Proto"); proto == "http" || proto == "https" {
 					scheme = proto
 				} else if req.TLS == nil {
 					scheme = "http"
 				}
 				raw, err := fs.ReadFile(s.ui, "index.html")
 				if err == nil {
-					abs := scheme + "://" + req.Host + "/og-image.png"
+					abs := scheme + "://" + html.EscapeString(req.Host) + "/og-image.png"
 					body := strings.ReplaceAll(string(raw), `content="/og-image.png"`, `content="`+abs+`"`)
 					w.Header().Set("Content-Type", "text/html; charset=utf-8")
 					_, _ = w.Write([]byte(body))

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1318,5 +1319,61 @@ func TestMemberCanCRUDSecrets(t *testing.T) {
 	w = doRequest(h, http.MethodDelete, "/api/projects/default/apps/sec-app/secrets/db-pass", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("delete secret: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOGImageEscapesHostHeader(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+
+	mockUI := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<html><head><meta property="og:image" content="/og-image.png"></head><body></body></html>`),
+		},
+	}
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, mockUI, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = `evil.com"><script>alert(1)</script><img src="`
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Fatal("Host header was not escaped — XSS payload present in response body")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") && !strings.Contains(body, "&#") {
+		t.Log("body:", body)
+	}
+}
+
+func TestOGImageRejectsInvalidProto(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+
+	mockUI := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<html><head><meta property="og:image" content="/og-image.png"></head><body></body></html>`),
+		},
+	}
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, mockUI, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	req.Header.Set("X-Forwarded-Proto", "javascript")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "javascript://") {
+		t.Fatal("invalid X-Forwarded-Proto was not rejected — 'javascript' scheme in response")
 	}
 }

--- a/internal/auth/native.go
+++ b/internal/auth/native.go
@@ -169,6 +169,9 @@ func (n *NativeAuthProvider) RevokeUser(ctx context.Context, userID string) erro
 
 // CreateUser stores a new user in a k8s Secret. Used during invite acceptance.
 func (n *NativeAuthProvider) CreateUser(ctx context.Context, email, password string, role Role) error {
+	if len(password) < 8 {
+		return fmt.Errorf("password must be at least 8 characters")
+	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("hashing password: %w", err)

--- a/internal/auth/native_test.go
+++ b/internal/auth/native_test.go
@@ -32,11 +32,11 @@ func setup(t *testing.T) (*NativeAuthProvider, context.Context) {
 func TestCreateAndAuthenticate(t *testing.T) {
 	provider, ctx := setup(t)
 
-	if err := provider.CreateUser(ctx, "alice@example.com", "s3cret", RoleAdmin); err != nil {
+	if err := provider.CreateUser(ctx, "alice@example.com", "s3cret12", RoleAdmin); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
-	p, err := provider.Authenticate(ctx, Credentials{Email: "alice@example.com", Password: "s3cret"})
+	p, err := provider.Authenticate(ctx, Credentials{Email: "alice@example.com", Password: "s3cret12"})
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
@@ -51,11 +51,11 @@ func TestCreateAndAuthenticate(t *testing.T) {
 func TestAuthenticateWrongPassword(t *testing.T) {
 	provider, ctx := setup(t)
 
-	if err := provider.CreateUser(ctx, "bob@example.com", "correct", RoleMember); err != nil {
+	if err := provider.CreateUser(ctx, "bob@example.com", "correct1", RoleMember); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
-	_, err := provider.Authenticate(ctx, Credentials{Email: "bob@example.com", Password: "wrong"})
+	_, err := provider.Authenticate(ctx, Credentials{Email: "bob@example.com", Password: "wrongpwd"})
 	if err == nil {
 		t.Fatal("expected error for wrong password")
 	}
@@ -92,7 +92,7 @@ func TestListUsers(t *testing.T) {
 	provider, ctx := setup(t)
 
 	for _, email := range []string{"a@example.com", "b@example.com"} {
-		if err := provider.CreateUser(ctx, email, "pass", RoleMember); err != nil {
+		if err := provider.CreateUser(ctx, email, "pass1234", RoleMember); err != nil {
 			t.Fatalf("CreateUser(%s): %v", email, err)
 		}
 	}
@@ -124,7 +124,7 @@ func TestInviteUser(t *testing.T) {
 func TestRevokeUser(t *testing.T) {
 	provider, ctx := setup(t)
 
-	if err := provider.CreateUser(ctx, "doomed@example.com", "pass", RoleMember); err != nil {
+	if err := provider.CreateUser(ctx, "doomed@example.com", "pass1234", RoleMember); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestRevokeUser(t *testing.T) {
 		t.Fatalf("RevokeUser: %v", err)
 	}
 
-	_, err := provider.Authenticate(ctx, Credentials{Email: "doomed@example.com", Password: "pass"})
+	_, err := provider.Authenticate(ctx, Credentials{Email: "doomed@example.com", Password: "pass1234"})
 	if err == nil {
 		t.Fatal("expected error after revocation")
 	}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -142,9 +142,24 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
+	// Environments are project-scoped: an App auto-exists in every
+	// `Project.Spec.Environments` entry, and `App.Spec.Environments[]`
+	// carries only per-env overrides. If the parent project isn't resolvable
+	// yet (just-created, being deleted, label missing) there's nothing to
+	// reconcile — skip workloads but keep the status pass so the UI sees the
+	// app's current state.
+	project, err := r.fetchParentProject(ctx, &app)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("fetch parent project: %w", err)
+	}
+	var resolvedEnvs []mortisev1alpha1.Environment
+	if project != nil {
+		resolvedEnvs = resolveEnvs(project, &app)
+	}
+
 	switch app.Spec.Source.Type {
 	case mortisev1alpha1.SourceTypeGit:
-		if r.BuildClient != nil && !r.allEnvBuildsCurrentForRevision(&app) {
+		if r.BuildClient != nil && !r.allEnvBuildsCurrentForRevision(&app, resolvedEnvs) {
 			result, proceed, err := r.prepareGitSource(ctx, &app)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -160,21 +175,6 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	default:
 		log.Info("skipping unsupported source type", "type", app.Spec.Source.Type)
 		return ctrl.Result{}, nil
-	}
-
-	// Environments are project-scoped: an App auto-exists in every
-	// `Project.Spec.Environments` entry, and `App.Spec.Environments[]`
-	// carries only per-env overrides. If the parent project isn't resolvable
-	// yet (just-created, being deleted, label missing) there's nothing to
-	// reconcile — skip workloads but keep the status pass so the UI sees the
-	// app's current state.
-	project, err := r.fetchParentProject(ctx, &app)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("fetch parent project: %w", err)
-	}
-	var resolvedEnvs []mortisev1alpha1.Environment
-	if project != nil {
-		resolvedEnvs = resolveEnvs(project, &app)
 	}
 
 	// Each env gets its own namespace; per-app resources (SA, credentials
@@ -369,7 +369,7 @@ func (r *AppReconciler) prepareGitSource(ctx context.Context, app *mortisev1alph
 	}
 
 	// Stash the token transiently for per-env builds during this reconcile.
-	r.gitTokenCache.Store(app.Name, tokenResult.Token)
+	r.gitTokenCache.Store(app.Namespace+"/"+app.Name, tokenResult.Token)
 
 	return ctrl.Result{}, true, nil
 }
@@ -423,7 +423,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 	}
 
-	tokenVal, _ := r.gitTokenCache.Load(app.Name)
+	tokenVal, _ := r.gitTokenCache.Load(app.Namespace + "/" + app.Name)
 	token, _ := tokenVal.(string)
 
 	imageRef, err := r.RegistryBackend.PushTarget(app.Name, envImageTag(revision, envName))
@@ -739,11 +739,10 @@ func (r *AppReconciler) currentImageForEnv(app *mortisev1alpha1.App, envName str
 	return app.Spec.Source.Image
 }
 
-// allEnvBuildsCurrentForRevision returns true only when every environment
-// listed in the app spec already has a per-env build matching the current
-// revision. Used to skip prepareGitSource (auth + clone) when no new builds
-// are needed.
-func (r *AppReconciler) allEnvBuildsCurrentForRevision(app *mortisev1alpha1.App) bool {
+// allEnvBuildsCurrentForRevision returns true only when every resolved
+// environment already has a per-env build matching the current revision.
+// Used to skip prepareGitSource (auth + clone) when no new builds are needed.
+func (r *AppReconciler) allEnvBuildsCurrentForRevision(app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment) bool {
 	revision := app.Annotations["mortise.dev/revision"]
 	if revision == "" {
 		revision = app.Spec.Source.Branch
@@ -751,10 +750,10 @@ func (r *AppReconciler) allEnvBuildsCurrentForRevision(app *mortisev1alpha1.App)
 	if revision == "" {
 		revision = "main"
 	}
-	if len(app.Spec.Environments) == 0 {
+	if len(envs) == 0 {
 		return false
 	}
-	for _, env := range app.Spec.Environments {
+	for _, env := range envs {
 		es := envStatusFor(app, env.Name)
 		if es == nil || es.LastBuiltSHA != revision || es.LastBuiltImage == "" {
 			return false

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -389,20 +389,25 @@ func branchFromRef(ref string) string {
 }
 
 // repoMatches returns true if the App's configured repo URL and the webhook
-// event's repo identifier refer to the same repository.
+// event's repo identifier refer to the same repository. Both sides must
+// resolve to the same owner/repo pair after normalization.
 func repoMatches(appRepo, eventRepo string) bool {
 	if appRepo == "" || eventRepo == "" {
 		return false
 	}
 	a := normalizeRepo(appRepo)
 	b := normalizeRepo(eventRepo)
-	if a == b {
-		return true
+	return ownerRepo(a) == ownerRepo(b)
+}
+
+// ownerRepo extracts the "owner/repo" suffix from a normalized repo string,
+// requiring both components to be present for a valid match.
+func ownerRepo(normalized string) string {
+	parts := strings.Split(normalized, "/")
+	if len(parts) < 2 {
+		return ""
 	}
-	if strings.HasSuffix(a, "/"+b) || strings.HasSuffix(b, "/"+a) {
-		return true
-	}
-	return false
+	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
 }
 
 // normalizeRepo returns a canonical lowercased string for comparison.

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -1427,6 +1427,10 @@ func TestRepoMatches(t *testing.T) {
 		{"org/repo", "org/repo", true},
 		// Different repo — no match.
 		{"https://github.com/org/repo", "org/other", false},
+		// Different owner, same repo name — no match (prevents cross-owner spoofing).
+		{"https://github.com/org/repo", "attacker/repo", false},
+		// Bare repo name without owner — no match.
+		{"https://github.com/org/repo", "repo", false},
 	}
 	for _, tc := range tests {
 		got := repoMatches(tc.a, tc.b)

--- a/test/integration/env_clone_test.go
+++ b/test/integration/env_clone_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
@@ -66,16 +67,19 @@ func TestPreviewEnvironmentInheritsSourceEnvVars(t *testing.T) {
 	// The app is already deployed (image source), so this doesn't affect
 	// the running workload — it just lets us test env var inheritance
 	// without needing full Gitea + BuildKit infrastructure.
-	var latest mortisev1alpha1.App
-	if err := k8sClient.Get(context.Background(), types.NamespacedName{
-		Namespace: ns, Name: app.Name,
-	}, &latest); err != nil {
-		t.Fatalf("get app for patch: %v", err)
-	}
-	latest.Spec.Source.Type = mortisev1alpha1.SourceTypeGit
-	latest.Spec.Source.Repo = "http://fake/repo.git"
-	latest.Spec.Source.Branch = "main"
-	if err := k8sClient.Update(context.Background(), &latest); err != nil {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest mortisev1alpha1.App
+		if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Namespace: ns, Name: app.Name,
+		}, &latest); err != nil {
+			return err
+		}
+		latest.Spec.Source.Type = mortisev1alpha1.SourceTypeGit
+		latest.Spec.Source.Repo = "http://fake/repo.git"
+		latest.Spec.Source.Branch = "main"
+		return k8sClient.Update(context.Background(), &latest)
+	})
+	if err != nil {
 		t.Fatalf("patch app source type: %v", err)
 	}
 

--- a/test/integration/env_clone_test.go
+++ b/test/integration/env_clone_test.go
@@ -67,7 +67,7 @@ func TestPreviewEnvironmentInheritsSourceEnvVars(t *testing.T) {
 	// The app is already deployed (image source), so this doesn't affect
 	// the running workload — it just lets us test env var inheritance
 	// without needing full Gitea + BuildKit infrastructure.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var latest mortisev1alpha1.App
 		if err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: ns, Name: app.Name,


### PR DESCRIPTION
## Summary

Fixes six v1-tagged security/correctness issues from the audit:

- **#219 — Reflected XSS via Host header**: Whitelist X-Forwarded-Proto to http/https only; escape req.Host with html.EscapeString in OG image URL injection.
- **#222 — PatchEnv overwrites managed vars**: Reject set/unset of non-user env vars (source = binding, generated, shared) with HTTP 409 before applying changes.
- **#234 — Webhook repo suffix spoofing**: Replace suffix-based repoMatches with owner/repo pair extraction. Bare repo names and cross-owner matches are now rejected.
- **#235 — Setup TOCTOU race + weak passwords**: Replace list-then-create with atomic ConfigMap sentinel (mortise-setup-complete). Add 8-character minimum password validation to both CreateUser and the /api/auth/setup endpoint.
- **#237 — allEnvBuildsCurrentForRevision uses wrong env list**: Move project fetch + resolveEnvs before the source-type switch so allEnvBuildsCurrentForRevision receives the full resolved environment list instead of only app-level overrides.
- **#239 — gitTokenCache cross-project leakage**: Key token cache by namespace/name instead of bare app.Name to prevent cross-project token reuse.

Closes #219, closes #222, closes #234, closes #235, closes #237, closes #239

## Test plan

- [x] All tests pass
- [x] Added regression tests for XSS, env-var protection, webhook spoofing, setup password validation, and PatchEnv source guarding
- [x] Updated existing test passwords to meet new 8-char minimum
- [x] go build ./... compiles cleanly

Generated with [Claude Code](https://claude.com/claude-code)