### PR TITLE
fix: status race in updateStatus, JWT hardening, constant-time token compare

### DIFF
--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -306,6 +306,9 @@ func (s *Server) validateProjectDeployToken(r *http.Request, ns, projectName str
 	for i := range list.Items {
 		sec := &list.Items[i]
 		stored := string(sec.Data["token-hash"])
+		if stored == "" {
+			stored = string(sec.Data["token_hash"])
+		}
 		if subtle.ConstantTimeCompare([]byte(stored), []byte(hashHex)) == 1 {
 			return true, sec.Name
 		}

--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -253,7 +254,7 @@ func (s *Server) validateDeployToken(r *http.Request, ns, appName, env string) (
 	for i := range list.Items {
 		sec := &list.Items[i]
 		stored := string(sec.Data["token-hash"])
-		if stored == hashHex {
+		if subtle.ConstantTimeCompare([]byte(stored), []byte(hashHex)) == 1 {
 			name := sec.Labels["mortise.dev/token-name"]
 			if name == "" {
 				name = sec.Name
@@ -304,8 +305,8 @@ func (s *Server) validateProjectDeployToken(r *http.Request, ns, projectName str
 
 	for i := range list.Items {
 		sec := &list.Items[i]
-		stored := string(sec.Data["token_hash"])
-		if stored == hashHex {
+		stored := string(sec.Data["token-hash"])
+		if subtle.ConstantTimeCompare([]byte(stored), []byte(hashHex)) == 1 {
 			return true, sec.Name
 		}
 	}
@@ -371,7 +372,7 @@ func (s *Server) CreateProjectToken(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		StringData: map[string]string{
-			"token_hash":  hashHex,
+			"token-hash":  hashHex,
 			"description": req.Description,
 			"project":     projectName,
 		},

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -19,6 +19,8 @@ const (
 	jwtSecretKey  = "signing-key"
 	namespace     = "mortise-system"
 	tokenExpiry   = 24 * time.Hour
+	jwtIssuer     = "mortise"
+	jwtAudience   = "mortise-api"
 )
 
 type JWTHelper struct {
@@ -78,6 +80,8 @@ func (h *JWTHelper) GenerateToken(ctx context.Context, p Principal) (string, err
 		"email":   p.Email,
 		"role":    string(p.Role),
 		"pwd_gen": p.PasswordGen,
+		"iss":     jwtIssuer,
+		"aud":     jwtAudience,
 		"iat":     now.Unix(),
 		"exp":     now.Add(tokenExpiry).Unix(),
 	}
@@ -97,7 +101,7 @@ func (h *JWTHelper) ValidateToken(ctx context.Context, tokenString string) (Prin
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return key, nil
-	})
+	}, jwt.WithIssuer(jwtIssuer), jwt.WithAudience(jwtAudience))
 	if err != nil {
 		return Principal{}, 0, fmt.Errorf("invalid token: %w", err)
 	}

--- a/internal/auth/native.go
+++ b/internal/auth/native.go
@@ -186,6 +186,7 @@ func (n *NativeAuthProvider) CreateUser(ctx context.Context, email, password str
 			"email":         []byte(email),
 			"password_hash": hash,
 			"role":          []byte(role),
+			"password_gen":  []byte("0"),
 		},
 	}
 

--- a/internal/auth/native_test.go
+++ b/internal/auth/native_test.go
@@ -338,3 +338,33 @@ func TestJWTRejectsTokenWithWrongIssuer(t *testing.T) {
 		t.Fatal("token with wrong issuer should be rejected")
 	}
 }
+
+func TestJWTRejectsTokenWithWrongAudience(t *testing.T) {
+	provider, ctx := setup(t)
+
+	key, err := provider.jwt.signingKey(ctx)
+	if err != nil {
+		t.Fatalf("signingKey: %v", err)
+	}
+
+	claims := jwt.MapClaims{
+		"sub":     "alice@example.com",
+		"email":   "alice@example.com",
+		"role":    "admin",
+		"pwd_gen": float64(0),
+		"iss":     "mortise",
+		"aud":     "other-api",
+		"iat":     time.Now().Unix(),
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, _, err = provider.jwt.ValidateToken(ctx, tokenString)
+	if err == nil {
+		t.Fatal("token with wrong audience should be rejected")
+	}
+}

--- a/internal/auth/native_test.go
+++ b/internal/auth/native_test.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +47,9 @@ func TestCreateAndAuthenticate(t *testing.T) {
 	}
 	if p.Role != RoleAdmin {
 		t.Errorf("expected role admin, got %s", p.Role)
+	}
+	if p.PasswordGen != 0 {
+		t.Errorf("expected password_gen 0 for new user, got %d", p.PasswordGen)
 	}
 }
 
@@ -272,5 +277,64 @@ func TestPasswordChangeInvalidatesToken(t *testing.T) {
 	}
 	if _, err := provider.Principal(ctx, newToken); err != nil {
 		t.Fatalf("new token should be valid: %v", err)
+	}
+}
+
+func TestJWTRejectsTokenWithoutIssuerAudience(t *testing.T) {
+	provider, ctx := setup(t)
+
+	// Manually craft a token without iss/aud claims.
+	key, err := provider.jwt.signingKey(ctx)
+	if err != nil {
+		t.Fatalf("signingKey: %v", err)
+	}
+
+	claims := jwt.MapClaims{
+		"sub":     "alice@example.com",
+		"email":   "alice@example.com",
+		"role":    "admin",
+		"pwd_gen": float64(0),
+		"iat":     time.Now().Unix(),
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, _, err = provider.jwt.ValidateToken(ctx, tokenString)
+	if err == nil {
+		t.Fatal("token without iss/aud should be rejected")
+	}
+}
+
+func TestJWTRejectsTokenWithWrongIssuer(t *testing.T) {
+	provider, ctx := setup(t)
+
+	key, err := provider.jwt.signingKey(ctx)
+	if err != nil {
+		t.Fatalf("signingKey: %v", err)
+	}
+
+	claims := jwt.MapClaims{
+		"sub":     "alice@example.com",
+		"email":   "alice@example.com",
+		"role":    "admin",
+		"pwd_gen": float64(0),
+		"iss":     "other-service",
+		"aud":     "mortise-api",
+		"iat":     time.Now().Unix(),
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, _, err = provider.jwt.ValidateToken(ctx, tokenString)
+	if err == nil {
+		t.Fatal("token with wrong issuer should be rejected")
 	}
 }

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2193,7 +2193,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 	}
 	if anyCrash {
 		phase = mortisev1alpha1.AppPhaseCrashLooping
-		meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+		meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
 			Type:               "PodHealthy",
 			Status:             metav1.ConditionFalse,
 			Reason:             "CrashLoopBackOff",
@@ -2201,14 +2201,11 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			ObservedGeneration: app.Generation,
 		})
 	} else {
-		meta.RemoveStatusCondition(&app.Status.Conditions, "PodHealthy")
+		meta.RemoveStatusCondition(&fresh.Status.Conditions, "PodHealthy")
 	}
 
 	fresh.Status.Phase = phase
 	fresh.Status.Environments = envStatuses
-	fresh.Status.LastBuiltSHA = app.Status.LastBuiltSHA
-	fresh.Status.LastBuiltImage = app.Status.LastBuiltImage
-	fresh.Status.Conditions = app.Status.Conditions
 	return r.Status().Update(ctx, &fresh)
 }
 


### PR DESCRIPTION
## Summary

Fixes two audit findings:

- **#240 — Controller status race in updateStatus**: `updateStatus` re-read the App into `fresh` but then overwrote `Conditions`, `LastBuiltSHA`, and `LastBuiltImage` from the stale local `app`. Now conditions are set/removed directly on `fresh`, and `LastBuiltSHA`/`LastBuiltImage` are no longer overwritten (they're already carried forward via `existingByName` from the fresh copy).

- **#242 — JWT hardening + token comparison**:
  - Added `iss: "mortise"` and `aud: "mortise-api"` claims to JWT generation; validation now requires both
  - Deploy token hash comparison changed from `==` to `subtle.ConstantTimeCompare`
  - User secrets now explicitly store `password_gen: "0"` on creation (previously implicit zero value)
  - Standardized project token secret key from `token_hash` (underscore) to `token-hash` (hyphen) matching per-app tokens

## Test plan

- [x] All 771 existing tests pass
- [x] New test: `TestJWTRejectsTokenWithoutIssuerAudience` — tokens missing iss/aud are rejected
- [x] New test: `TestJWTRejectsTokenWithWrongIssuer` — tokens from other services are rejected
- [x] New assertion: `TestCreateAndAuthenticate` verifies `PasswordGen == 0` for new users
- [x] Existing `TestJWTRoundTrip` and `TestPasswordChangeInvalidatesToken` still pass (iss/aud round-trips correctly)

Closes #240
Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)