### PR TITLE
fix: proxy security, REST API source.type, env var CRD propagation

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -60,9 +60,41 @@ const maxEnvNameLen = 63
 
 // createAppRequest is the JSON body for POST /api/projects/{project}/apps.
 // Namespace is NOT caller-specified — it's always the project's namespace.
+// Accepts both wrapped ({"name":"…","spec":{…}}) and flat ({"name":"…","source":{…}})
+// formats — see UnmarshalJSON.
 type createAppRequest struct {
 	Name string                  `json:"name"`
 	Spec mortisev1alpha1.AppSpec `json:"spec"`
+}
+
+func (r *createAppRequest) UnmarshalJSON(data []byte) error {
+	// Try wrapped format first: {"name":"…","spec":{…}}.
+	type wrapped createAppRequest
+	var w wrapped
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	// If spec.source.type is populated, the caller used the wrapped format.
+	if w.Spec.Source.Type != "" {
+		*r = createAppRequest(w)
+		return nil
+	}
+	// Fall back to flat format: top-level fields map directly to AppSpec.
+	var flat struct {
+		Name string                  `json:"name"`
+		Spec mortisev1alpha1.AppSpec `json:"spec"`
+		mortisev1alpha1.AppSpec
+	}
+	if err := json.Unmarshal(data, &flat); err != nil {
+		return err
+	}
+	r.Name = flat.Name
+	if flat.AppSpec.Source.Type != "" {
+		r.Spec = flat.AppSpec
+	} else {
+		r.Spec = flat.Spec
+	}
+	return nil
 }
 
 // @Summary Create an app

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -159,3 +159,38 @@ func TestCreateAppRequestUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateAppRequestUnmarshalJSON_InvalidJSON(t *testing.T) {
+	var req createAppRequest
+	if err := json.Unmarshal([]byte(`{not json}`), &req); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestCreateAppRequestUnmarshalJSON_NoSource(t *testing.T) {
+	var req createAppRequest
+	if err := json.Unmarshal([]byte(`{"name":"x"}`), &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Name != "x" {
+		t.Errorf("name: got %q, want %q", req.Name, "x")
+	}
+	if req.Spec.Source.Type != "" {
+		t.Errorf("source.type should be empty, got %q", req.Spec.Source.Type)
+	}
+}
+
+func TestCreateAppRequestUnmarshalJSON_WrappedTakesPrecedence(t *testing.T) {
+	// When both spec.source and top-level source are present, wrapped wins.
+	input := `{"name":"x","spec":{"source":{"type":"image","image":"nginx:1.27"}},"source":{"type":"git","repo":"https://github.com/o/r.git"}}`
+	var req createAppRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Spec.Source.Type != mortisev1alpha1.SourceTypeImage {
+		t.Errorf("wrapped format should take precedence, got source.type %q", req.Spec.Source.Type)
+	}
+	if req.Spec.Source.Image != "nginx:1.27" {
+		t.Errorf("source.image: got %q, want %q", req.Spec.Source.Image, "nginx:1.27")
+	}
+}

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,6 +82,79 @@ func TestNormalizeRepoURL(t *testing.T) {
 			got := tc.s.normalizeRepoURL(context.Background(), "pj-test", tc.providerRef, tc.repo)
 			if got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateAppRequestUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantName   string
+		wantType   mortisev1alpha1.SourceType
+		wantImage  string
+		wantRepo   string
+		wantEnvLen int
+	}{
+		{
+			name:      "wrapped format with image source",
+			input:     `{"name":"my-app","spec":{"source":{"type":"image","image":"nginx:1.27"},"environments":[{"name":"production"}]}}`,
+			wantName:  "my-app",
+			wantType:  mortisev1alpha1.SourceTypeImage,
+			wantImage: "nginx:1.27",
+		},
+		{
+			name:     "wrapped format with git source",
+			input:    `{"name":"my-app","spec":{"source":{"type":"git","repo":"https://github.com/org/repo.git"},"environments":[{"name":"production"}]}}`,
+			wantName: "my-app",
+			wantType: mortisev1alpha1.SourceTypeGit,
+			wantRepo: "https://github.com/org/repo.git",
+		},
+		{
+			name:      "flat format with image source",
+			input:     `{"name":"my-app","source":{"type":"image","image":"nginx:1.27"},"environments":[{"name":"production"}]}`,
+			wantName:  "my-app",
+			wantType:  mortisev1alpha1.SourceTypeImage,
+			wantImage: "nginx:1.27",
+		},
+		{
+			name:     "flat format with git source",
+			input:    `{"name":"my-app","source":{"type":"git","repo":"https://github.com/org/repo.git"},"environments":[{"name":"staging"}]}`,
+			wantName: "my-app",
+			wantType: mortisev1alpha1.SourceTypeGit,
+			wantRepo: "https://github.com/org/repo.git",
+		},
+		{
+			name:       "flat format preserves environments",
+			input:      `{"name":"my-app","source":{"type":"image","image":"nginx:1.27"},"environments":[{"name":"production"},{"name":"staging"}]}`,
+			wantName:   "my-app",
+			wantType:   mortisev1alpha1.SourceTypeImage,
+			wantImage:  "nginx:1.27",
+			wantEnvLen: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req createAppRequest
+			if err := json.Unmarshal([]byte(tc.input), &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if req.Name != tc.wantName {
+				t.Errorf("name: got %q, want %q", req.Name, tc.wantName)
+			}
+			if req.Spec.Source.Type != tc.wantType {
+				t.Errorf("source.type: got %q, want %q", req.Spec.Source.Type, tc.wantType)
+			}
+			if tc.wantImage != "" && req.Spec.Source.Image != tc.wantImage {
+				t.Errorf("source.image: got %q, want %q", req.Spec.Source.Image, tc.wantImage)
+			}
+			if tc.wantRepo != "" && req.Spec.Source.Repo != tc.wantRepo {
+				t.Errorf("source.repo: got %q, want %q", req.Spec.Source.Repo, tc.wantRepo)
+			}
+			if tc.wantEnvLen > 0 && len(req.Spec.Environments) != tc.wantEnvLen {
+				t.Errorf("environments length: got %d, want %d", len(req.Spec.Environments), tc.wantEnvLen)
 			}
 		})
 	}

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -77,11 +77,17 @@ type appProxyEntry struct {
 	listener net.Listener
 }
 
+const proxyBindAddress = "127.0.0.1"
+
 // appProxyManager manages per-app reverse proxy listeners. Each app gets its
 // own port — no path prefix, no asset rewriting issues.
 type appProxyManager struct {
 	mu      sync.Mutex
 	proxies map[string]*appProxyEntry // key: "project/app/env"
+}
+
+func proxyKey(project, app, env string) string {
+	return project + "/" + app + "/" + env
 }
 
 func newAppProxyManager() *appProxyManager {
@@ -119,7 +125,7 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	appName := chi.URLParam(r, "app")
 	env := envFromQuery(r)
 	envNs := constants.EnvNamespace(projectName, env)
-	key := projectName + "/" + appName + "/" + env
+	key := proxyKey(projectName, appName, env)
 
 	// If already proxying, return the existing URL.
 	s.proxies.mu.Lock()
@@ -150,7 +156,7 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Allocate a random port and start listening.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", proxyBindAddress+":0")
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to allocate port: " + err.Error()})
 		return
@@ -210,7 +216,7 @@ func (s *Server) handleDisconnect(w http.ResponseWriter, r *http.Request) {
 	}
 	appName := chi.URLParam(r, "app")
 	env := envFromQuery(r)
-	key := projectName + "/" + appName + "/" + env
+	key := proxyKey(projectName, appName, env)
 
 	s.proxies.mu.Lock()
 	entry, exists := s.proxies.proxies[key]

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -81,7 +81,7 @@ type appProxyEntry struct {
 // own port — no path prefix, no asset rewriting issues.
 type appProxyManager struct {
 	mu      sync.Mutex
-	proxies map[string]*appProxyEntry // key: "project/app"
+	proxies map[string]*appProxyEntry // key: "project/app/env"
 }
 
 func newAppProxyManager() *appProxyManager {
@@ -117,10 +117,9 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	appName := chi.URLParam(r, "app")
-	key := projectName + "/" + appName
-
 	env := envFromQuery(r)
 	envNs := constants.EnvNamespace(projectName, env)
+	key := projectName + "/" + appName + "/" + env
 
 	// If already proxying, return the existing URL.
 	s.proxies.mu.Lock()
@@ -151,7 +150,7 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Allocate a random port and start listening.
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to allocate port: " + err.Error()})
 		return
@@ -210,7 +209,8 @@ func (s *Server) handleDisconnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	appName := chi.URLParam(r, "app")
-	key := projectName + "/" + appName
+	env := envFromQuery(r)
+	key := projectName + "/" + appName + "/" + env
 
 	s.proxies.mu.Lock()
 	entry, exists := s.proxies.proxies[key]

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"net"
+	"testing"
+)
+
+func TestProxyManagerKeyIncludesEnv(t *testing.T) {
+	pm := newAppProxyManager()
+
+	pm.mu.Lock()
+	pm.proxies["myproject/myapp/staging"] = &appProxyEntry{Port: 1234, URL: "http://localhost:1234"}
+	pm.mu.Unlock()
+
+	pm.mu.Lock()
+	_, existsStaging := pm.proxies["myproject/myapp/staging"]
+	_, existsProduction := pm.proxies["myproject/myapp/production"]
+	pm.mu.Unlock()
+
+	if !existsStaging {
+		t.Error("expected staging proxy to exist")
+	}
+	if existsProduction {
+		t.Error("production proxy should not exist — key must include environment")
+	}
+}
+
+func TestProxyListenerBindsLocalhost(t *testing.T) {
+	// Verify the bind address pattern used by handleConnect.
+	// This is a structural test: the listener should bind to 127.0.0.1, not 0.0.0.0.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on 127.0.0.1:0: %v", err)
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	if !addr.IP.IsLoopback() {
+		t.Errorf("expected loopback address, got %s", addr.IP)
+	}
+}

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -5,37 +5,31 @@ import (
 	"testing"
 )
 
-func TestProxyManagerKeyIncludesEnv(t *testing.T) {
+func TestProxyKeyIncludesEnv(t *testing.T) {
+	k1 := proxyKey("myproject", "myapp", "staging")
+	k2 := proxyKey("myproject", "myapp", "production")
+
+	if k1 == k2 {
+		t.Errorf("keys for different environments must differ: staging=%q production=%q", k1, k2)
+	}
+
 	pm := newAppProxyManager()
+	pm.proxies[k1] = &appProxyEntry{Port: 1234, URL: "http://localhost:1234"}
 
-	pm.mu.Lock()
-	pm.proxies["myproject/myapp/staging"] = &appProxyEntry{Port: 1234, URL: "http://localhost:1234"}
-	pm.mu.Unlock()
-
-	pm.mu.Lock()
-	_, existsStaging := pm.proxies["myproject/myapp/staging"]
-	_, existsProduction := pm.proxies["myproject/myapp/production"]
-	pm.mu.Unlock()
-
-	if !existsStaging {
+	if _, ok := pm.proxies[k1]; !ok {
 		t.Error("expected staging proxy to exist")
 	}
-	if existsProduction {
-		t.Error("production proxy should not exist — key must include environment")
+	if _, ok := pm.proxies[k2]; ok {
+		t.Error("production proxy should not exist")
 	}
 }
 
-func TestProxyListenerBindsLocalhost(t *testing.T) {
-	// Verify the bind address pattern used by handleConnect.
-	// This is a structural test: the listener should bind to 127.0.0.1, not 0.0.0.0.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen on 127.0.0.1:0: %v", err)
+func TestProxyBindAddressIsLoopback(t *testing.T) {
+	ip := net.ParseIP(proxyBindAddress)
+	if ip == nil {
+		t.Fatalf("proxyBindAddress %q is not a valid IP", proxyBindAddress)
 	}
-	defer listener.Close()
-
-	addr := listener.Addr().(*net.TCPAddr)
-	if !addr.IP.IsLoopback() {
-		t.Errorf("expected loopback address, got %s", addr.IP)
+	if !ip.IsLoopback() {
+		t.Errorf("proxyBindAddress must be loopback, got %s", proxyBindAddress)
 	}
 }

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1589,40 +1590,52 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		return fmt.Errorf("materialize shared-env: %w", err)
 	}
 
-	// Check if the {app}-env Secret has been seeded by testing whether
-	// the Secret object exists — not whether it has data. This lets us
-	// distinguish "first deploy" (no Secret) from "user cleared all vars"
-	// (empty Secret).
-	// Seed spec-defined env vars that aren't already in the Secret.
-	// This replaces the old SecretExists gate which had a race: if
-	// ReplaceSource or EnsureExists created the Secret before Set ran,
-	// the existence check returned true and seeding was skipped forever.
-	// By merging only missing keys, we handle the race without overwriting
-	// values the user may have changed via the UI.
+	// Sync CRD spec env vars into the {app}-env Secret. Uses a last-applied
+	// annotation to distinguish CRD spec changes from out-of-band user edits:
+	// - Missing keys are seeded from the spec.
+	// - Keys whose Secret value matches the last-applied spec value are updated
+	//   when the CRD spec changes (no user override detected).
+	// - Keys whose Secret value differs from last-applied are preserved (the
+	//   user or UI changed them out-of-band).
 	existing, err := store.Get(ctx, envNs, app.Name)
 	if err != nil {
 		return fmt.Errorf("read existing env vars: %w", err)
 	}
-	existingKeys := make(map[string]bool, len(existing))
+	existingByName := make(map[string]string, len(existing))
 	for _, e := range existing {
-		existingKeys[e.Name] = true
+		existingByName[e.Name] = e.Value
 	}
-	var missing []envstore.Env
+
+	lastSpec := r.readLastSpecEnv(ctx, envNs, app.Name)
+
+	var toMerge []envstore.Env
 	for _, ev := range env.Env {
-		if !existingKeys[ev.Name] {
-			missing = append(missing, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
+		existingVal, exists := existingByName[ev.Name]
+		if !exists {
+			toMerge = append(toMerge, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
+			continue
+		}
+		if ev.Value == existingVal {
+			continue
+		}
+		// Key exists with a different value. Update only if the user hasn't
+		// overridden it (Secret value still matches what the spec last set).
+		if lastVal, tracked := lastSpec[ev.Name]; tracked && existingVal == lastVal {
+			toMerge = append(toMerge, envstore.Env{Name: ev.Name, Value: ev.Value, Source: "user"})
 		}
 	}
 	for _, sv := range app.Spec.SharedVars {
-		if !existingKeys[sv.Name] {
-			missing = append(missing, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
+		if _, exists := existingByName[sv.Name]; !exists {
+			toMerge = append(toMerge, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
 		}
 	}
-	if len(missing) > 0 {
-		if err := store.Merge(ctx, envNs, app.Name, missing, labels); err != nil {
+	if len(toMerge) > 0 {
+		if err := store.Merge(ctx, envNs, app.Name, toMerge, labels); err != nil {
 			return fmt.Errorf("seed env secret: %w", err)
 		}
 	}
+
+	r.writeLastSpecEnv(ctx, envNs, app.Name, env.Env)
 
 	var bindingEnvs []envstore.Env
 	if len(env.Bindings) > 0 {
@@ -1640,6 +1653,51 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		}
 	}
 	return store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels)
+}
+
+func (r *AppReconciler) readLastSpecEnv(ctx context.Context, ns, appName string) map[string]string {
+	var sec corev1.Secret
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      envstore.AppEnvSecretName(appName),
+		Namespace: ns,
+	}, &sec); err != nil {
+		return nil
+	}
+	raw := sec.Annotations[envstore.AnnotationLastSpecEnv]
+	if raw == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string, envVars []mortisev1alpha1.EnvVar) {
+	var sec corev1.Secret
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      envstore.AppEnvSecretName(appName),
+		Namespace: ns,
+	}, &sec); err != nil {
+		return
+	}
+	m := make(map[string]string, len(envVars))
+	for _, ev := range envVars {
+		m[ev.Name] = ev.Value
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+	if sec.Annotations == nil {
+		sec.Annotations = make(map[string]string)
+	}
+	if sec.Annotations[envstore.AnnotationLastSpecEnv] == string(data) {
+		return
+	}
+	sec.Annotations[envstore.AnnotationLastSpecEnv] = string(data)
+	_ = r.Client.Update(ctx, &sec)
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1635,7 +1635,9 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		}
 	}
 
-	r.writeLastSpecEnv(ctx, envNs, app.Name, env.Env)
+	if err := r.writeLastSpecEnv(ctx, envNs, app.Name, env.Env); err != nil {
+		return fmt.Errorf("write last-spec-env: %w", err)
+	}
 
 	var bindingEnvs []envstore.Env
 	if len(env.Bindings) > 0 {
@@ -1674,13 +1676,16 @@ func (r *AppReconciler) readLastSpecEnv(ctx context.Context, ns, appName string)
 	return m
 }
 
-func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string, envVars []mortisev1alpha1.EnvVar) {
+func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string, envVars []mortisev1alpha1.EnvVar) error {
 	var sec corev1.Secret
 	if err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      envstore.AppEnvSecretName(appName),
 		Namespace: ns,
 	}, &sec); err != nil {
-		return
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get env secret for last-spec annotation: %w", err)
 	}
 	m := make(map[string]string, len(envVars))
 	for _, ev := range envVars {
@@ -1688,16 +1693,19 @@ func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string
 	}
 	data, err := json.Marshal(m)
 	if err != nil {
-		return
+		return fmt.Errorf("marshal last-spec env: %w", err)
 	}
 	if sec.Annotations == nil {
 		sec.Annotations = make(map[string]string)
 	}
 	if sec.Annotations[envstore.AnnotationLastSpecEnv] == string(data) {
-		return
+		return nil
 	}
 	sec.Annotations[envstore.AnnotationLastSpecEnv] = string(data)
-	_ = r.Client.Update(ctx, &sec)
+	if err := r.Client.Update(ctx, &sec); err != nil {
+		return fmt.Errorf("write last-spec-env annotation: %w", err)
+	}
+	return nil
 }
 
 // credentialsSecretName is the name of the {app}-credentials Secret this

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4523,6 +4523,14 @@ var _ = Describe("App Controller — git source", func() {
 			envData = readAppEnvSecret(ctx, appName, envNsProduction)
 			Expect(envData).To(HaveKeyWithValue("R2_BUCKET_NAME", "new-value"), "CRD spec change should propagate to Secret")
 			Expect(envData).To(HaveKeyWithValue("STATIC_VAR", "unchanged"))
+
+			// Verify the last-applied annotation was written.
+			var sec corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.AppEnvSecretName(appName),
+				Namespace: envNsProduction,
+			}, &sec)).To(Succeed())
+			Expect(sec.Annotations).To(HaveKey(envstore.AnnotationLastSpecEnv))
 		})
 
 		It("preserves user-overridden values even when CRD spec changes", func() {
@@ -4575,6 +4583,59 @@ var _ = Describe("App Controller — git source", func() {
 
 			envData := readAppEnvSecret(ctx, appName, envNsProduction)
 			Expect(envData).To(HaveKeyWithValue("PORT", "5000"), "user-overridden value should be preserved even when CRD changes")
+		})
+
+		It("retains removed CRD spec env var keys in the Secret", func() {
+			appName := "key-removal-test"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:   "production",
+						Domain: "keyremoval.example.com",
+						Env: []mortisev1alpha1.EnvVar{
+							{Name: "KEEP_ME", Value: "yes"},
+							{Name: "DROP_ME", Value: "initially"},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData := readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("KEEP_ME", "yes"))
+			Expect(envData).To(HaveKeyWithValue("DROP_ME", "initially"))
+
+			// Remove DROP_ME from the CRD spec.
+			var fetchedApp mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fetchedApp)).To(Succeed())
+			fetchedApp.Spec.Environments[0].Env = []mortisev1alpha1.EnvVar{
+				{Name: "KEEP_ME", Value: "yes"},
+			}
+			Expect(k8sClient.Update(ctx, &fetchedApp)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Key removal from CRD does NOT delete from Secret — user may
+			// have set it via UI. The key remains with its last value.
+			envData = readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("KEEP_ME", "yes"))
+			Expect(envData).To(HaveKey("DROP_ME"), "removed CRD key should remain in Secret")
 		})
 
 		It("adds binding vars on first binding, clears them when binding is removed", func() {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4476,6 +4476,107 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(envData).To(HaveKeyWithValue("PORT", "4000"), "second reconcile should not overwrite user-edited value")
 		})
 
+		It("propagates CRD spec env var changes to the Secret when user has not overridden", func() {
+			appName := "spec-change-test"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:   "production",
+						Domain: "specchange.example.com",
+						Env: []mortisev1alpha1.EnvVar{
+							{Name: "R2_BUCKET_NAME", Value: "old-value"},
+							{Name: "STATIC_VAR", Value: "unchanged"},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData := readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("R2_BUCKET_NAME", "old-value"))
+			Expect(envData).To(HaveKeyWithValue("STATIC_VAR", "unchanged"))
+
+			// Patch the CRD spec to change R2_BUCKET_NAME.
+			var fetchedApp mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fetchedApp)).To(Succeed())
+			fetchedApp.Spec.Environments[0].Env[0].Value = "new-value"
+			Expect(k8sClient.Update(ctx, &fetchedApp)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData = readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("R2_BUCKET_NAME", "new-value"), "CRD spec change should propagate to Secret")
+			Expect(envData).To(HaveKeyWithValue("STATIC_VAR", "unchanged"))
+		})
+
+		It("preserves user-overridden values even when CRD spec changes", func() {
+			appName := "user-override-test"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:   "production",
+						Domain: "override.example.com",
+						Env: []mortisev1alpha1.EnvVar{
+							{Name: "PORT", Value: "3000"},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// User edits the Secret directly (simulating UI edit).
+			var sec corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.AppEnvSecretName(appName),
+				Namespace: envNsProduction,
+			}, &sec)).To(Succeed())
+			sec.Data["PORT"] = []byte("5000")
+			Expect(k8sClient.Update(ctx, &sec)).To(Succeed())
+
+			// Now change the CRD spec to a DIFFERENT value.
+			var fetchedApp mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fetchedApp)).To(Succeed())
+			fetchedApp.Spec.Environments[0].Env[0].Value = "4000"
+			Expect(k8sClient.Update(ctx, &fetchedApp)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			envData := readAppEnvSecret(ctx, appName, envNsProduction)
+			Expect(envData).To(HaveKeyWithValue("PORT", "5000"), "user-overridden value should be preserved even when CRD changes")
+		})
+
 		It("adds binding vars on first binding, clears them when binding is removed", func() {
 			dbName := "seed-db"
 			apiName := "seed-api"

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -46,6 +46,11 @@ const (
 	AnnotationBindingKeys   = "mortise.dev/binding-keys"
 	AnnotationGeneratedKeys = "mortise.dev/generated-keys"
 	AnnotationSharedKeys    = "mortise.dev/shared-keys"
+
+	// AnnotationLastSpecEnv stores the JSON-encoded CRD spec env vars that
+	// were last applied by the controller. Used to detect CRD spec changes
+	// vs out-of-band user edits to the Secret.
+	AnnotationLastSpecEnv = "mortise.dev/last-spec-env"
 )
 
 // AppEnvSecretName returns the Secret name for an app's env vars.


### PR DESCRIPTION
## Summary

Fixes three audit findings:

- **#233 (P1 security):** Reverse proxy listener was binding to `0.0.0.0`, making it accessible from any network. Now binds to `127.0.0.1` via `proxyBindAddress` constant. Also, the proxy cache key ignored the environment parameter, causing cross-env routing (staging proxy reused for production). Key now uses `proxyKey()` helper that includes environment.

- **#250 (P0 bug):** `POST /api/projects/{project}/apps` failed for REST API users who sent `source` at the top level (`{"name":"…","source":{…}}`) instead of wrapped in `spec` (`{"name":"…","spec":{…}}`). Added `UnmarshalJSON` on `createAppRequest` that accepts both formats. Wrapped format takes precedence when both are present.

- **#249 (P0 bug):** Env var value changes via CRD patch (kubectl, GitOps) were silently ignored because `reconcileEnvSecret` only seeded missing keys. Now tracks last-applied CRD spec env vars via a `mortise.dev/last-spec-env` annotation on the Secret. CRD spec changes propagate when the user hasn't overridden the value out-of-band (via UI/API), preserving the UI edit path. `writeLastSpecEnv` properly propagates errors (tolerating NotFound for Secrets not yet created) so the controller retries on failure.

## Test plan

- [x] `TestProxyKeyIncludesEnv` — verifies `proxyKey()` produces distinct keys per environment
- [x] `TestProxyBindAddressIsLoopback` — verifies `proxyBindAddress` constant is loopback
- [x] `TestCreateAppRequestUnmarshalJSON` — 5 cases covering wrapped/flat formats for image and git sources
- [x] `TestCreateAppRequestUnmarshalJSON_InvalidJSON` — rejects malformed JSON
- [x] `TestCreateAppRequestUnmarshalJSON_NoSource` — accepts body with no source (downstream validation catches)
- [x] `TestCreateAppRequestUnmarshalJSON_WrappedTakesPrecedence` — wrapped format wins when both present
- [x] `propagates CRD spec env var changes to the Secret when user has not overridden` — envtest, also verifies annotation is written
- [x] `preserves user-overridden values even when CRD spec changes` — envtest
- [x] `retains removed CRD spec env var keys in the Secret` — envtest, documents key-removal behavior
- [x] Existing `seeds env.Env vars` test still passes (no regression)
- [x] Full suite: 780 tests pass (687 internal + 93 cmd)

Closes #233, closes #249, closes #250