### PR TITLE
fix: close viewer project-bypass and enforce restricted-env authz (#231)

### DIFF
--- a/internal/api/build_args.go
+++ b/internal/api/build_args.go
@@ -66,7 +66,7 @@ func (s *Server) GetBuildArgs(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/build-args [put]
 func (s *Server) PutBuildArgs(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)

--- a/internal/api/deploy.go
+++ b/internal/api/deploy.go
@@ -61,7 +61,7 @@ func (s *Server) Deploy(w http.ResponseWriter, r *http.Request) {
 
 	// Check auth: JWT principal (policy-checked) or deploy token (inline check).
 	if p := PrincipalFromContext(r.Context()); p != nil {
-		if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionUpdate) {
+		if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.Environment}, authz.ActionUpdate) {
 			return
 		}
 	} else {

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -89,7 +89,7 @@ func (s *Server) ListDomains(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/domains [post]
 func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)
@@ -177,7 +177,7 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/domains/{domain} [delete]
 func (s *Server) RemoveDomain(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -96,7 +96,7 @@ func (s *Server) GetEnv(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/env [put]
 func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)
@@ -180,7 +180,7 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/env [patch]
 func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)
@@ -297,7 +297,7 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 // @Router /projects/{project}/apps/{app}/env/import [post]
 func (s *Server) ImportEnv(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: queryEnv(r)}, authz.ActionUpdate) {
 		return
 	}
 	app, envName, ok := s.resolveAppEnv(w, r)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -52,12 +52,11 @@ func (s *Server) ExecInApp(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
+	appName := chi.URLParam(r, "app")
+	env := envFromQuery(r)
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: env}, authz.ActionUpdate) {
 		return
 	}
-	appName := chi.URLParam(r, "app")
-
-	env := envFromQuery(r)
 	envNs := constants.EnvNamespace(projectName, env)
 
 	var req execRequest

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -181,20 +181,25 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeJSON(w, http.StatusUnauthorized, errorResponse{"authentication required"})
+		return
+	}
+
 	var restarted []string
+	var skipped []string
 	for _, es := range app.Status.Environments {
 		if es.PendingEnvHash == "" || es.DeployedEnvHash == "" || es.PendingEnvHash == es.DeployedEnvHash {
 			continue
 		}
-		if p != nil {
-			allowed, err := s.authz.Authorize(r.Context(), *p, authz.Resource{Kind: "app", Project: projectName, Environment: es.Name}, authz.ActionUpdate)
-			if err != nil {
-				writeError(w, err)
-				return
-			}
-			if !allowed {
-				continue
-			}
+		allowed, err := s.authz.Authorize(r.Context(), *p, authz.Resource{Kind: "app", Project: projectName, Environment: es.Name}, authz.ActionUpdate)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		if !allowed {
+			skipped = append(skipped, es.Name)
+			continue
 		}
 		envNs := constants.EnvNamespace(projectName, es.Name)
 		if err := restartDeployment(r.Context(), s.client, envNs, appName, es.PendingEnvHash, s.clock().Now()); err != nil {
@@ -226,7 +231,11 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 		s.recordActivity(r, projectName, "deploy", "app", appName, fmt.Sprintf("Redeployed stale envs for %s: %v", appName, restarted), "")
 	}
 
-	writeJSON(w, http.StatusOK, map[string][]string{"restarted": restarted})
+	resp := map[string][]string{"restarted": restarted}
+	if len(skipped) > 0 {
+		resp["skipped"] = skipped
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func envStatusPendingHash(envStatuses []mortisev1alpha1.EnvironmentStatus, envName string) string {

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -194,7 +194,7 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 		}
 		allowed, err := s.authz.Authorize(r.Context(), *p, authz.Resource{Kind: "app", Project: projectName, Environment: es.Name}, authz.ActionUpdate)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 		if !allowed {
@@ -202,7 +202,7 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		envNs := constants.EnvNamespace(projectName, es.Name)
-		if err := restartDeployment(r.Context(), s.client, envNs, appName, es.PendingEnvHash, s.clock().Now()); err != nil {
+	if err := restartDeployment(r.Context(), s.client, envNs, appName, es.PendingEnvHash, s.clock().Now()); err != nil {
 			writeError(w, r, err)
 			return
 		}

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -107,11 +107,11 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate) {
-		return
-	}
 	appName := chi.URLParam(r, "app")
 	env := envFromQuery(r)
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName, Environment: env}, authz.ActionUpdate) {
+		return
+	}
 
 	envNs := constants.EnvNamespace(projectName, env)
 
@@ -180,10 +180,21 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p := PrincipalFromContext(r.Context())
 	var restarted []string
 	for _, es := range app.Status.Environments {
 		if es.PendingEnvHash == "" || es.DeployedEnvHash == "" || es.PendingEnvHash == es.DeployedEnvHash {
 			continue
+		}
+		if p != nil {
+			allowed, err := s.authz.Authorize(r.Context(), *p, authz.Resource{Kind: "app", Project: projectName, Environment: es.Name}, authz.ActionUpdate)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			if !allowed {
+				continue
+			}
 		}
 		envNs := constants.EnvNamespace(projectName, es.Name)
 		if err := restartDeployment(r.Context(), s.client, envNs, appName, es.PendingEnvHash, s.clock().Now()); err != nil {

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -153,10 +153,6 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"from and to must be different environments"})
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.To}, authz.ActionUpdate) {
-		return
-	}
-
 	// Authorize read on the source environment so developers cannot exfiltrate
 	// production state by promoting FROM a restricted env to a less-restricted one.
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.From}, authz.ActionRead) {

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -157,6 +157,16 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authorize read on the source environment so developers cannot exfiltrate
+	// production state by promoting FROM a restricted env to a less-restricted one.
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.From}, authz.ActionRead) {
+		return
+	}
+	// Authorize update on the target environment (restricted-env guard).
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.To}, authz.ActionUpdate) {
+		return
+	}
+
 	var app mortisev1alpha1.App
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
 		writeError(w, r, err)

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -43,9 +43,6 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionUpdate) {
-		return
-	}
 	appName := chi.URLParam(r, "app")
 
 	var req rollbackRequest
@@ -55,6 +52,9 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Environment == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"environment is required"})
+		return
+	}
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.Environment}, authz.ActionUpdate) {
 		return
 	}
 
@@ -138,9 +138,6 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionUpdate) {
-		return
-	}
 	appName := chi.URLParam(r, "app")
 
 	var req promoteRequest
@@ -154,6 +151,9 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.From == req.To {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"from and to must be different environments"})
+		return
+	}
+	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: req.To}, authz.ActionUpdate) {
 		return
 	}
 

--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -67,7 +67,7 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName}, authz.ActionCreate) {
+	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName, Environment: envFromQuery(r)}, authz.ActionCreate) {
 		return
 	}
 	appName := chi.URLParam(r, "app")
@@ -166,7 +166,7 @@ func (s *Server) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName}, authz.ActionDelete) {
+	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName, Environment: envFromQuery(r)}, authz.ActionDelete) {
 		return
 	}
 	appName := chi.URLParam(r, "app")

--- a/internal/authz/native.go
+++ b/internal/authz/native.go
@@ -28,6 +28,9 @@ func (e *NativePolicyEngine) Authorize(ctx context.Context, p auth.Principal, re
 		if resource.Project == "" {
 			return action == ActionRead, nil
 		}
+		if action != ActionRead {
+			return false, nil
+		}
 		return e.authorizeProject(ctx, p, resource, action)
 	}
 

--- a/internal/authz/native.go
+++ b/internal/authz/native.go
@@ -25,7 +25,10 @@ func (e *NativePolicyEngine) Authorize(ctx context.Context, p auth.Principal, re
 	}
 
 	if p.Role == auth.RoleViewer {
-		return action == ActionRead, nil
+		if resource.Project == "" {
+			return action == ActionRead, nil
+		}
+		return e.authorizeProject(ctx, p, resource, action)
 	}
 
 	// Platform-scoped resources (no project context)

--- a/internal/authz/native_test.go
+++ b/internal/authz/native_test.go
@@ -227,6 +227,117 @@ func TestNonMemberDeniedProjectAccess(t *testing.T) {
 	}
 }
 
+func TestViewerDeniedProjectWithoutMembership(t *testing.T) {
+	const project = "secret-project"
+
+	c := fake.NewClientBuilder().
+		WithScheme(authzScheme(t)).
+		Build()
+	engine := NewNativePolicyEngine(c)
+	ctx := context.Background()
+	viewer := auth.Principal{ID: "viewer@example.com", Email: "viewer@example.com", Role: auth.RoleViewer}
+
+	for _, a := range []Action{ActionCreate, ActionRead, ActionUpdate, ActionDelete} {
+		ok, err := engine.Authorize(ctx, viewer, Resource{Kind: "app", Project: project}, a)
+		if err != nil {
+			t.Fatalf("Authorize(app, %s): %v", a, err)
+		}
+		if ok {
+			t.Errorf("viewer without project membership should not be allowed %s on project app", a)
+		}
+	}
+}
+
+func TestViewerWithProjectMembership(t *testing.T) {
+	const email = "viewer@example.com"
+	const project = "my-project"
+
+	c := fake.NewClientBuilder().
+		WithScheme(authzScheme(t)).
+		WithObjects(memberForProject(email, project, mortisev1alpha1.ProjectRoleViewer)).
+		Build()
+	engine := NewNativePolicyEngine(c)
+	ctx := context.Background()
+	viewer := auth.Principal{ID: email, Email: email, Role: auth.RoleViewer}
+
+	ok, err := engine.Authorize(ctx, viewer, Resource{Kind: "app", Project: project}, ActionRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("viewer with project membership should be allowed to read project app")
+	}
+
+	for _, a := range []Action{ActionCreate, ActionUpdate, ActionDelete} {
+		ok, err := engine.Authorize(ctx, viewer, Resource{Kind: "app", Project: project}, a)
+		if err != nil {
+			t.Fatalf("Authorize(app, %s): %v", a, err)
+		}
+		if ok {
+			t.Errorf("project-viewer should not be allowed %s on project app", a)
+		}
+	}
+}
+
+func TestDeveloperRestrictedEnv(t *testing.T) {
+	const email = "dev@example.com"
+	const project = "my-project"
+
+	c := fake.NewClientBuilder().
+		WithScheme(authzScheme(t)).
+		WithObjects(
+			memberForProject(email, project, mortisev1alpha1.ProjectRoleDeveloper),
+			&mortisev1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: project},
+				Spec: mortisev1alpha1.ProjectSpec{
+					Environments: []mortisev1alpha1.ProjectEnvironment{
+						{Name: "staging", Restricted: false},
+						{Name: "production", Restricted: true},
+					},
+				},
+			},
+		).
+		Build()
+	engine := NewNativePolicyEngine(c)
+	ctx := context.Background()
+	dev := auth.Principal{ID: email, Email: email, Role: auth.RoleMember}
+
+	// Developer can update staging (not restricted)
+	ok, err := engine.Authorize(ctx, dev, Resource{Kind: "app", Project: project, Environment: "staging"}, ActionUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("developer should be allowed to update app in staging")
+	}
+
+	// Developer can only read in restricted production
+	ok, err = engine.Authorize(ctx, dev, Resource{Kind: "app", Project: project, Environment: "production"}, ActionRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("developer should be allowed to read app in restricted production")
+	}
+
+	ok, err = engine.Authorize(ctx, dev, Resource{Kind: "app", Project: project, Environment: "production"}, ActionUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("developer should NOT be allowed to update app in restricted production")
+	}
+
+	// Developer without env specified can still update (no restriction check)
+	ok, err = engine.Authorize(ctx, dev, Resource{Kind: "app", Project: project}, ActionUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("developer should be allowed to update app without env specified")
+	}
+}
+
 func TestProjectMemberNameConvention(t *testing.T) {
 	// Verify the name used by ensureOwnerMember matches what authorizeProject looks up.
 	// If these diverge the owner can never access their own project.

--- a/internal/authz/native_test.go
+++ b/internal/authz/native_test.go
@@ -279,6 +279,27 @@ func TestViewerWithProjectMembership(t *testing.T) {
 	}
 }
 
+func TestViewerMembershipDoesNotGrantWrite(t *testing.T) {
+	const email = "viewer@example.com"
+	const project = "my-project"
+
+	c := fake.NewClientBuilder().
+		WithScheme(authzScheme(t)).
+		WithObjects(memberForProject(email, project, mortisev1alpha1.ProjectRoleDeveloper)).
+		Build()
+	engine := NewNativePolicyEngine(c)
+	ctx := context.Background()
+	viewer := auth.Principal{ID: email, Email: email, Role: auth.RoleViewer}
+
+	ok, err := engine.Authorize(ctx, viewer, Resource{Kind: "app", Project: project}, ActionUpdate)
+	if err != nil {
+		t.Fatalf("Authorize(app, update): %v", err)
+	}
+	if ok {
+		t.Error("platform viewer should remain read-only even with developer project membership")
+	}
+}
+
 func TestDeveloperRestrictedEnv(t *testing.T) {
 	const email = "dev@example.com"
 	const project = "my-project"


### PR DESCRIPTION
## Summary
- Close authorization bypass where viewers could read all projects regardless of membership
- Enforce restricted environment access controls that were previously unenforced
- Add authz tests for viewer project membership and restricted env checks

Closes #231

## Test plan
- [ ] Verify viewer can only access projects they are members of
- [ ] Confirm restricted environments are inaccessible to unauthorized roles
- [ ] Run `make test` — all authz tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)