### PR TITLE
fix: Helm chart security -- securityContext, RBAC docs, least privilege (#226)

### DIFF
--- a/charts/mortise-core/templates/deployment.yaml
+++ b/charts/mortise-core/templates/deployment.yaml
@@ -17,10 +17,14 @@ spec:
         app.kubernetes.io/name: mortise
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: mortise
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           ports:
             - name: api
               containerPort: {{ .Values.api.port }}
@@ -34,8 +38,14 @@ spec:
             - name: MORTISE_INGRESS_CLASS
               value: {{ .Values.operator.ingressClassName | quote }}
             {{- end }}
+            # Redirect temp writes to the writable emptyDir volume
+            - name: TMPDIR
+              value: /tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -48,6 +58,10 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
 ---
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1

--- a/charts/mortise-core/templates/rbac.yaml
+++ b/charts/mortise-core/templates/rbac.yaml
@@ -1,52 +1,134 @@
+# -----------------------------------------------------------------------------
+# ClusterRole: mortise-controller
+#
+# This role grants the minimum permissions the Mortise operator needs.
+# Where possible, permissions are scoped by apiGroup, resource, and verb.
+#
+# RBAC SCOPING NOTES (see #226):
+#
+#   Secrets  — The operator creates per-App Secrets (image pull, env) in
+#              dynamically-created pj-* namespaces AND reads its own GitHub
+#              OAuth secret in mortise-system.  K8s RBAC cannot filter by
+#              namespace name pattern, so cluster-wide access is still
+#              required.  RISK: a bug in the operator could read/write
+#              Secrets in any namespace.  Mitigate with OPA/Kyverno
+#              policies that restrict Secret access to pj-* + mortise-system.
+#
+#   Namespaces — The Project controller creates/deletes one namespace per
+#              Project CRD.  Namespace names are dynamic (pj-{project}), so
+#              resourceNames cannot be used.  Cluster-wide is required.
+#
+#   Pods/exec — Used by the /api/projects/{project}/apps/{app}/exec
+#              endpoint to exec into user pods.  These pods only exist in
+#              pj-* namespaces.  Cluster-wide is granted because K8s RBAC
+#              cannot scope to a namespace name pattern.  Mitigate with
+#              OPA/Kyverno policies restricting exec to pj-* namespaces.
+# -----------------------------------------------------------------------------
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: mortise-controller
 rules:
-  # Project CRD (cluster-scoped; operator creates/deletes the backing namespace)
+  # ---------------------------------------------------------------------------
+  # Mortise CRDs — full lifecycle management
+  # The operator is the sole controller for all Mortise custom resources.
+  # ---------------------------------------------------------------------------
+
+  # Project CRD: cluster-scoped; operator creates/deletes the backing namespace.
   - apiGroups: ["mortise.mortise.dev"]
     resources: ["projects", "projects/status", "projects/finalizers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # App CRDs
+
+  # App CRD: namespaced inside pj-* namespaces.
   - apiGroups: ["mortise.mortise.dev"]
     resources: ["apps", "apps/status", "apps/finalizers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Supporting CRDs: PlatformConfig, GitProvider, PreviewEnvironment, ProjectMember.
   - apiGroups: ["mortise.mortise.dev"]
     resources: ["platformconfigs", "gitproviders", "previewenvironments", "projectmembers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["mortise.mortise.dev"]
     resources: ["platformconfigs/status", "gitproviders/status", "previewenvironments/status", "previewenvironments/finalizers", "projectmembers/status"]
     verbs: ["get", "update", "patch"]
-  # Namespaces: Project controller creates + deletes one per Project.
+
+  # ---------------------------------------------------------------------------
+  # Namespaces (cluster-wide — see scoping note above)
+  # Project controller creates one namespace per Project CRD (pj-{name}).
+  # Cannot use resourceNames because namespace names are dynamic.
+  # ---------------------------------------------------------------------------
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Core resources the App controller creates
+
+  # ---------------------------------------------------------------------------
+  # Core workload resources — created by App controller in pj-* namespaces
+  # ---------------------------------------------------------------------------
+
+  # Deployments: one per App for long-running services.
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Services: one per App for internal routing.
   - apiGroups: [""]
-    resources: ["services", "secrets", "persistentvolumeclaims", "serviceaccounts"]
+    resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # ConfigMaps: per-project Activity event store (§5.11) and App configFiles
-  # (one CM per configFiles entry, named {app}-config-{i}). Delete verb is
-  # required so reconcileConfigMaps can prune orphans when a configFiles
-  # entry is removed.
+
+  # PVCs: one per App with persistent storage configured.
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # ServiceAccounts: one per App if the App needs its own identity.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # ---------------------------------------------------------------------------
+  # Secrets (cluster-wide — see scoping note above)
+  # Used for: per-App image pull secrets, per-App env secrets, and the
+  # operator's own GitHub OAuth client secret in mortise-system.
+  # Cannot scope to pj-* + mortise-system because K8s RBAC lacks namespace
+  # name pattern matching.  Mitigate with admission policies.
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # ---------------------------------------------------------------------------
+  # ConfigMaps: per-project Activity event store (section 5.11) and App
+  # configFiles (one CM per configFiles entry, named {app}-config-{i}).
+  # Delete is required so reconcileConfigMaps can prune orphans.
+  # ---------------------------------------------------------------------------
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Ingresses: one per App with an external route configured.
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # CronJobs for cron-type Apps
+
+  # CronJobs: one per cron-type App.
   - apiGroups: ["batch"]
     resources: ["cronjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Pod logs for SSE streaming
+
+  # ---------------------------------------------------------------------------
+  # Pod observability — read-only
+  # Used for SSE streaming of pod logs to the Mortise UI.
+  # ---------------------------------------------------------------------------
   - apiGroups: [""]
     resources: ["pods", "pods/log"]
     verbs: ["get", "list", "watch"]
-  # Pod exec for /api/projects/{project}/apps/{app}/exec
+
+  # ---------------------------------------------------------------------------
+  # Pod exec (cluster-wide — see scoping note above)
+  # Used by /api/projects/{project}/apps/{app}/exec to exec into user pods.
+  # Pods only exist in pj-* namespaces, but RBAC cannot scope by namespace
+  # name pattern.  Mitigate with admission policies restricting exec to pj-*.
+  # ---------------------------------------------------------------------------
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]

--- a/charts/mortise-core/values.yaml
+++ b/charts/mortise-core/values.yaml
@@ -33,13 +33,12 @@ resources:
 # Security context defaults — hardened out of the box.
 # Override per-environment in your values override file.
 podSecurityContext:
-  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
 containerSecurityContext:
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   capabilities:
     drop:
       - ALL

--- a/charts/mortise-core/values.yaml
+++ b/charts/mortise-core/values.yaml
@@ -33,12 +33,13 @@ resources:
 # Security context defaults — hardened out of the box.
 # Override per-environment in your values override file.
 podSecurityContext:
+  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
 containerSecurityContext:
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL

--- a/charts/mortise-core/values.yaml
+++ b/charts/mortise-core/values.yaml
@@ -30,6 +30,20 @@ resources:
     cpu: 200m
     memory: 128Mi
 
+# Security context defaults — hardened out of the box.
+# Override per-environment in your values override file.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
 serviceAccount:
   create: true
   name: mortise-controller


### PR DESCRIPTION
## Summary

- **P0-15 (securityContext):** Add pod-level (`seccompProfile: RuntimeDefault`) and container-level (`allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: false`, `capabilities.drop: [ALL]`) security contexts to the operator Deployment. Add writable `/tmp` via emptyDir volume (64Mi limit) for future `readOnlyRootFilesystem` enablement.
- **P0-16/17/18 (RBAC scoping):** Break the monolithic `services, secrets, persistentvolumeclaims, serviceaccounts` rule into separate per-resource rules, each with a clear comment explaining WHY that permission is needed. Add a file-level RBAC SCOPING NOTES block documenting why cluster-wide access is still required for Secrets, Namespaces, and pods/exec (K8s RBAC cannot filter by namespace name pattern), and recommending OPA/Kyverno admission policies as mitigation.
- **Helm values:** Add `podSecurityContext` and `containerSecurityContext` values with hardened defaults, overridable per-environment.

> **Note:** `readOnlyRootFilesystem` is set to `false` and `runAsNonRoot` is omitted pending operator image hardening. The operator currently requires writable disk access beyond `/tmp`. These will be re-enabled once the operator's write paths are audited and confirmed compatible.

## Test plan

- [ ] `helm lint charts/mortise-core` passes (verified locally)
- [ ] `helm template` renders all resources correctly with security contexts applied (verified locally)
- [ ] Deploy to dev cluster and verify operator pod starts
- [ ] Verify operator can still reconcile Projects (namespace CRUD), Apps (deployments, services, secrets), and exec into pods
- [ ] Test overriding `podSecurityContext` / `containerSecurityContext` via values file

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)