### PR TITLE
Fix git state sync for rebuilds and previews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,12 +128,13 @@ DEV_CLUSTER ?= mortise-dev
 DEV_IMG ?= mortise:dev
 DEV_OBSERVER_IMG ?= mortise-observer:dev
 GITHUB_CLIENT_ID ?= Ov23lizLTd25E32VrWwl
+K3D_RUNTIME_ULIMIT ?= nofile=1048576:1048576
 
 .PHONY: dev-up
 dev-up: build-ui ## Create k3d dev cluster with build infra, install Mortise, port-forward
 	@echo "==> Creating k3d cluster $(DEV_CLUSTER) (with registry mirror)..."
 	@k3d cluster list | grep -q $(DEV_CLUSTER) || k3d cluster create \
-		--config test/dev/k3d-config.yaml --wait
+		--config test/dev/k3d-config.yaml --runtime-ulimit $(K3D_RUNTIME_ULIMIT) --wait
 	@echo "==> Building Docker images..."
 	$(CONTAINER_TOOL) build --target operator -t $(DEV_IMG) .
 	$(CONTAINER_TOOL) build --target observer -t $(DEV_OBSERVER_IMG) .
@@ -210,7 +211,7 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	@echo "==> Creating k3d cluster $(INT_CLUSTER)..."
 	# --config wires the containerd mirror rule that makes
 	# registry.mortise-test-deps.svc:5000 pulls reachable from the node.
-	k3d cluster create --config test/integration/k3d-config.yaml --wait
+	k3d cluster create --config test/integration/k3d-config.yaml --runtime-ulimit $(K3D_RUNTIME_ULIMIT) --wait
 	@echo "==> Building Docker images..."
 	$(CONTAINER_TOOL) build --target operator -t $(INT_IMG) .
 	$(CONTAINER_TOOL) build --target observer -t $(INT_OBSERVER_IMG) .

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1503,6 +1503,12 @@ definitions:
         items:
           $ref: '#/definitions/v1alpha1.EnvVar'
         type: array
+      image:
+        description: |-
+          Image overrides the spec-level source image for this environment.
+          Set by the deploy handler when a deploy targets a specific environment.
+          +optional
+        type: string
       livenessProbe:
         $ref: '#/definitions/v1alpha1.ProbeConfig'
       name:
@@ -2636,6 +2642,38 @@ paths:
       security:
       - BearerAuth: []
       summary: Create a project
+      tags:
+      - projects
+  /projects/{name}/available:
+    get:
+      description: Returns whether a project name is available. Any authenticated
+        user can call this.
+      parameters:
+      - description: Project name to check
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: boolean
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Check project name availability
       tags:
       - projects
   /projects/{project}:
@@ -3909,8 +3947,9 @@ paths:
       - rollback
   /projects/{project}/apps/{app}/rebuild:
     post:
-      description: Clear the last-built SHA and reset the phase so the reconciler
-        triggers a fresh build. Only supported for git-source apps.
+      description: Resolve the current branch head, sync mortise.dev/revision to that
+        SHA, and clear build freshness state so the reconciler triggers a fresh no-cache
+        build. Only supported for git-source apps.
       parameters:
       - description: Project name
         in: path

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1503,6 +1503,12 @@ definitions:
         items:
           $ref: '#/definitions/v1alpha1.EnvVar'
         type: array
+      image:
+        description: |-
+          Image overrides the spec-level source image for this environment.
+          Set by the deploy handler when a deploy targets a specific environment.
+          +optional
+        type: string
       livenessProbe:
         $ref: '#/definitions/v1alpha1.ProbeConfig'
       name:
@@ -2636,6 +2642,38 @@ paths:
       security:
       - BearerAuth: []
       summary: Create a project
+      tags:
+      - projects
+  /projects/{name}/available:
+    get:
+      description: Returns whether a project name is available. Any authenticated
+        user can call this.
+      parameters:
+      - description: Project name to check
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: boolean
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Check project name availability
       tags:
       - projects
   /projects/{project}:
@@ -3909,8 +3947,9 @@ paths:
       - rollback
   /projects/{project}/apps/{app}/rebuild:
     post:
-      description: Clear the last-built SHA and reset the phase so the reconciler
-        triggers a fresh build. Only supported for git-source apps.
+      description: Resolve the current branch head, sync mortise.dev/revision to that
+        SHA, and clear build freshness state so the reconciler triggers a fresh no-cache
+        build. Only supported for git-source apps.
       parameters:
       - description: Project name
         in: path

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -14,16 +14,17 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 // Rebuild triggers a fresh build from the latest git commit.
-// It clears lastBuiltSHA so the reconciler treats the current revision as new,
-// and resets the phase from Failed/CrashLooping so the build guard doesn't skip it.
+// It resolves the current branch head, syncs mortise.dev/revision to that SHA,
+// and clears build freshness state so the reconciler must run a fresh no-cache build.
 //
 // POST /api/projects/{project}/apps/{app}/rebuild
 //
 // @Summary Rebuild an app from source
-// @Description Clear the last-built SHA and reset the phase so the reconciler triggers a fresh build. Only supported for git-source apps.
+// @Description Resolve the current branch head, sync mortise.dev/revision to that SHA, and clear build freshness state so the reconciler triggers a fresh no-cache build. Only supported for git-source apps.
 // @Tags deploy
 // @Produce json
 // @Security BearerAuth
@@ -53,10 +54,18 @@ func (s *Server) Rebuild(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Signal a no-cache build so BuildKit rebuilds all layers from scratch.
+	revision, err := s.resolveGitBranchHead(r.Context(), &app)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+
+	// Sync git state first, then force a no-cache build so BuildKit rebuilds
+	// all layers from the resolved commit SHA.
 	if app.Annotations == nil {
 		app.Annotations = make(map[string]string)
 	}
+	app.Annotations["mortise.dev/revision"] = revision
 	app.Annotations["mortise.dev/no-cache-build"] = "true"
 	if err := s.client.Update(r.Context(), &app); err != nil {
 		writeError(w, r, err)
@@ -71,8 +80,13 @@ func (s *Server) Rebuild(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Clear lastBuiltSHA so the reconciler sees the revision as new.
+	// Clear app-level and per-environment build freshness so rebuild cannot
+	// no-op even when an older build stored a branch-name fallback.
 	app.Status.LastBuiltSHA = ""
+	app.Status.LastBuiltImage = ""
+	for i := range app.Status.Environments {
+		app.Status.Environments[i].LastBuiltSHA = ""
+	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 	app.Status.Conditions = nil
 	if err := s.client.Status().Update(r.Context(), &app); err != nil {
@@ -83,6 +97,43 @@ func (s *Server) Rebuild(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, projectName, "build", "app", appName, "Triggered rebuild for "+appName, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "rebuilding"})
+}
+
+func (s *Server) resolveGitBranchHead(ctx context.Context, app *mortisev1alpha1.App) (string, error) {
+	if app.Spec.Source.ProviderRef == "" {
+		return "", fmt.Errorf("providerRef is required for git-source rebuilds")
+	}
+
+	var gp mortisev1alpha1.GitProvider
+	if err := s.client.Get(ctx, types.NamespacedName{Name: app.Spec.Source.ProviderRef}, &gp); err != nil {
+		return "", fmt.Errorf("get GitProvider %q: %w", app.Spec.Source.ProviderRef, err)
+	}
+
+	createdBy := app.Annotations["mortise.dev/created-by"]
+	cachedOwner := app.Annotations["mortise.dev/git-token-owner"]
+	tokenResult, err := git.ResolveGitTokenForApp(ctx, s.client, gp.Name, app.Namespace, createdBy, cachedOwner)
+	if err != nil {
+		return "", fmt.Errorf("resolve git token: %w", err)
+	}
+
+	apiFactory := s.GitAPIFactory
+	if apiFactory == nil {
+		apiFactory = git.NewGitAPIFromProvider
+	}
+	api, err := apiFactory(&gp, tokenResult.Token, "")
+	if err != nil {
+		return "", fmt.Errorf("create git API: %w", err)
+	}
+
+	branch := app.Spec.Source.Branch
+	if branch == "" {
+		branch = "main"
+	}
+	sha, err := api.ResolveBranchHead(ctx, app.Spec.Source.Repo, branch)
+	if err != nil {
+		return "", fmt.Errorf("resolve branch head: %w", err)
+	}
+	return sha, nil
 }
 
 // Redeploy triggers a rolling restart of an app's Deployment(s) by annotating

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,13 +12,15 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	kclock "k8s.io/utils/clock"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
+	kclock "k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/activity"
 	"github.com/mortise-org/mortise/internal/auth"
 	"github.com/mortise-org/mortise/internal/authz"
+	"github.com/mortise-org/mortise/internal/git"
 	"github.com/mortise-org/mortise/internal/webhook"
 )
 
@@ -46,6 +48,7 @@ type Server struct {
 	proxies       *appProxyManager
 	activityStore activity.Store
 	Clock         kclock.Clock
+	GitAPIFactory func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
 }
 
 // RESTConfig returns the rest.Config the server was built with. Exposed for
@@ -92,6 +95,7 @@ func NewServer(c client.Client, cs kubernetes.Interface, dc dynamic.Interface, r
 		deviceFlow:    df,
 		proxies:       newAppProxyManager(),
 		activityStore: activity.NewConfigMapStore(c),
+		GitAPIFactory: git.NewGitAPIFromProvider,
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -30,12 +30,41 @@ import (
 	"github.com/mortise-org/mortise/internal/auth"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 // sharedCfg is the envtest rest.Config. Started once by TestMain and reused
 // by every test via setupEnvtest. Starting envtest takes ~4s, so doing it
 // once per package (instead of per test) is the main cost win.
 var sharedCfg *rest.Config
+
+type gitfake struct {
+	branchHead string
+}
+
+func (g *gitfake) RegisterWebhook(context.Context, string, git.WebhookConfig) error { return nil }
+func (g *gitfake) ListWebhooks(context.Context, string) ([]git.WebhookInfo, error)  { return nil, nil }
+func (g *gitfake) DeleteWebhook(context.Context, string, int64) error               { return nil }
+func (g *gitfake) PostCommitStatus(context.Context, string, string, git.CommitStatus) error {
+	return nil
+}
+func (g *gitfake) VerifyWebhookSignature([]byte, http.Header) error { return nil }
+func (g *gitfake) ResolveCloneCredentials(context.Context, string) (git.GitCredentials, error) {
+	return git.GitCredentials{}, nil
+}
+func (g *gitfake) ListRepos(context.Context) ([]git.Repository, error) { return nil, nil }
+func (g *gitfake) ListBranches(context.Context, string) ([]git.Branch, error) {
+	return nil, nil
+}
+func (g *gitfake) ResolveBranchHead(context.Context, string, string) (string, error) {
+	return g.branchHead, nil
+}
+func (g *gitfake) ListOpenPullRequests(context.Context, string) ([]git.PullRequestSnapshot, error) {
+	return nil, nil
+}
+func (g *gitfake) ListTree(context.Context, string, string, string, string) ([]git.TreeEntry, error) {
+	return nil, nil
+}
 
 func TestMain(m *testing.M) {
 	if err := mortisev1alpha1.AddToScheme(scheme.Scheme); err != nil {
@@ -785,14 +814,44 @@ func TestRollbackRequiresAuth(t *testing.T) {
 func TestRebuild(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
+	srv.GitAPIFactory = func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error) {
+		return &gitfake{branchHead: "resolved-sha-123"}, nil
+	}
 	h := srv.Handler()
 	ns := seedProject(t, k8sClient, "default")
 
 	ctx := context.Background()
+	if err := k8sClient.Create(ctx, &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-main"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}); err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	if err := k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-github-main-token-" + hex.EncodeToString([]byte("test@example.com")),
+			Namespace: "mortise-system",
+		},
+		Data: map[string][]byte{"token": []byte("gho_test")},
+	}); err != nil {
+		t.Fatalf("create token secret: %v", err)
+	}
 	app := &mortisev1alpha1.App{
-		ObjectMeta: metav1.ObjectMeta{Name: "rebuild-app", Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "rebuild-app",
+			Namespace:   ns,
+			Annotations: map[string]string{"mortise.dev/created-by": "test@example.com"},
+		},
 		Spec: mortisev1alpha1.AppSpec{
-			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeGit, Repo: "https://github.com/example/repo"},
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/example/repo",
+				Branch:      "main",
+				ProviderRef: "github-main",
+			},
 			Environments: []mortisev1alpha1.Environment{
 				{Name: "production"},
 			},
@@ -803,6 +862,9 @@ func TestRebuild(t *testing.T) {
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseReady
 	app.Status.LastBuiltSHA = "abc123"
+	app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{
+		{Name: "production", LastBuiltSHA: "main", LastBuiltImage: "registry.example/app:main"},
+	}
 	if err := k8sClient.Status().Update(ctx, app); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
@@ -818,8 +880,14 @@ func TestRebuild(t *testing.T) {
 	if app.Annotations["mortise.dev/no-cache-build"] != "true" {
 		t.Errorf("expected no-cache-build annotation, got %q", app.Annotations["mortise.dev/no-cache-build"])
 	}
+	if app.Annotations["mortise.dev/revision"] != "resolved-sha-123" {
+		t.Errorf("expected revision synced to resolved sha, got %q", app.Annotations["mortise.dev/revision"])
+	}
 	if app.Status.LastBuiltSHA != "" {
 		t.Errorf("expected LastBuiltSHA cleared, got %q", app.Status.LastBuiltSHA)
+	}
+	if len(app.Status.Environments) != 1 || app.Status.Environments[0].LastBuiltSHA != "" {
+		t.Errorf("expected env LastBuiltSHA cleared, got %+v", app.Status.Environments)
 	}
 	if app.Status.Phase != mortisev1alpha1.AppPhaseBuilding {
 		t.Errorf("expected phase Building, got %s", app.Status.Phase)

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -61,6 +61,7 @@ import (
 	"github.com/mortise-org/mortise/internal/envstore"
 	"github.com/mortise-org/mortise/internal/git"
 	"github.com/mortise-org/mortise/internal/ingress"
+	"github.com/mortise-org/mortise/internal/previewsync"
 	"github.com/mortise-org/mortise/internal/registry"
 )
 
@@ -99,7 +100,11 @@ type AppReconciler struct {
 	// gitTokenCache holds the resolved git token for the current reconcile
 	// iteration so per-env builds don't re-resolve credentials. Keyed by app name.
 	gitTokenCache sync.Map
+
+	GitAPIFactory func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
 }
+
+const previewSyncStateAnnotation = "mortise.dev/preview-sync-state"
 
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=apps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=apps/status,verbs=get;update;patch
@@ -181,6 +186,11 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit {
+		if err := r.syncOpenPreviews(ctx, &app, project); err != nil {
+			log.Error(err, "preview sync failed", "app", app.Name)
+		}
+	}
 	// Each env gets its own namespace; per-app resources (SA, credentials
 	// Secret, ConfigMaps, PVCs) fan out once per env namespace so pods that
 	// reference them can resolve cross-ns (they can't). The controller owns
@@ -378,6 +388,103 @@ func (r *AppReconciler) prepareGitSource(ctx context.Context, app *mortisev1alph
 	r.gitTokenCache.Store(app.Namespace+"/"+app.Name, tokenResult.Token)
 
 	return ctrl.Result{}, true, nil
+}
+
+func (r *AppReconciler) syncOpenPreviews(ctx context.Context, app *mortisev1alpha1.App, project *mortisev1alpha1.Project) error {
+	if project == nil || project.Spec.Preview == nil || !project.Spec.Preview.Enabled {
+		return nil
+	}
+	if app.Spec.Source.Type != mortisev1alpha1.SourceTypeGit || app.Spec.Source.ProviderRef == "" {
+		return nil
+	}
+
+	desiredState := previewSyncState(app, project)
+	if app.Annotations[previewSyncStateAnnotation] == desiredState {
+		return nil
+	}
+
+	tokenVal, _ := r.gitTokenCache.Load(app.Name)
+	token, _ := tokenVal.(string)
+
+	var gp mortisev1alpha1.GitProvider
+	if err := r.Get(ctx, types.NamespacedName{Name: app.Spec.Source.ProviderRef}, &gp); err != nil {
+		return fmt.Errorf("get GitProvider %q: %w", app.Spec.Source.ProviderRef, err)
+	}
+	if token == "" {
+		createdBy := app.Annotations["mortise.dev/created-by"]
+		cachedOwner := app.Annotations["mortise.dev/git-token-owner"]
+		tokenResult, err := git.ResolveGitTokenForApp(ctx, r.Client, gp.Name, app.Namespace, createdBy, cachedOwner)
+		if err != nil {
+			return fmt.Errorf("resolve git token for preview sync: %w", err)
+		}
+		token = tokenResult.Token
+		r.gitTokenCache.Store(app.Name, token)
+	}
+
+	api, err := r.newGitAPI(&gp, token, "")
+	if err != nil {
+		return fmt.Errorf("create git API: %w", err)
+	}
+	openPRs, err := api.ListOpenPullRequests(ctx, app.Spec.Source.Repo)
+	if err != nil {
+		return fmt.Errorf("list open pull requests: %w", err)
+	}
+	if err := previewsync.ReconcileAppPreviews(ctx, r, app, project, project.Spec.Preview, openPRs); err != nil {
+		return fmt.Errorf("reconcile preview environments: %w", err)
+	}
+
+	patch := client.MergeFrom(app.DeepCopy())
+	if app.Annotations == nil {
+		app.Annotations = map[string]string{}
+	}
+	app.Annotations[previewSyncStateAnnotation] = desiredState
+	if err := r.Patch(ctx, app, patch); err != nil {
+		return fmt.Errorf("patch preview sync state: %w", err)
+	}
+
+	return nil
+}
+
+func previewSyncState(app *mortisev1alpha1.App, project *mortisev1alpha1.Project) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "repo=%s\nprovider=%s\npreview=%t\n", app.Spec.Source.Repo, app.Spec.Source.ProviderRef, project.Spec.Preview != nil && project.Spec.Preview.Enabled)
+	if project.Spec.Preview != nil {
+		fmt.Fprintf(h, "domain=%s\nttl=%s\nbot=%t\ncpu=%s\nmemory=%s\n",
+			project.Spec.Preview.Domain,
+			project.Spec.Preview.TTL,
+			project.Spec.Preview.BotPR,
+			project.Spec.Preview.Resources.CPU,
+			project.Spec.Preview.Resources.Memory,
+		)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (r *AppReconciler) newGitAPI(gp *mortisev1alpha1.GitProvider, token, webhookSecret string) (git.GitAPI, error) {
+	if r.GitAPIFactory != nil {
+		return r.GitAPIFactory(gp, token, webhookSecret)
+	}
+	return git.NewGitAPIFromProvider(gp, token, webhookSecret)
+}
+
+func (r *AppReconciler) ListPreviewEnvironments(ctx context.Context, namespace string) ([]mortisev1alpha1.PreviewEnvironment, error) {
+	var list mortisev1alpha1.PreviewEnvironmentList
+	if err := r.List(ctx, &list, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (r *AppReconciler) CreatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return r.Create(ctx, pe)
+}
+
+func (r *AppReconciler) UpdatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return r.Update(ctx, pe)
+}
+
+func (r *AppReconciler) DeletePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return r.Delete(ctx, pe)
 }
 
 // reconcileEnvBuild handles per-environment builds for git-source apps. Returns
@@ -2132,7 +2239,7 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 	}
 
 	// Build GitAPI and register.
-	api, err := git.NewGitAPIFromProvider(gp, token, webhookSecret)
+	api, err := r.newGitAPI(gp, token, webhookSecret)
 	if err != nil {
 		return fmt.Errorf("create git API: %w", err)
 	}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -460,7 +460,14 @@ func (r *AppReconciler) syncOpenPreviews(ctx context.Context, app *mortisev1alph
 
 func previewSyncState(app *mortisev1alpha1.App, project *mortisev1alpha1.Project) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "repo=%s\nprovider=%s\npreview=%t\n", app.Spec.Source.Repo, app.Spec.Source.ProviderRef, project.Spec.Preview != nil && project.Spec.Preview.Enabled)
+	fmt.Fprintf(h, "repo=%s\nprovider=%s\npreview=%t\nprojectPreviewRev=%s\n",
+		app.Spec.Source.Repo,
+		app.Spec.Source.ProviderRef,
+		project.Spec.Preview != nil && project.Spec.Preview.Enabled,
+		app.Annotations[ProjectPreviewRevAnnotation],
+	)
+	writePreviewSyncHashJSON(h, "appEnvironments", app.Spec.Environments)
+	writePreviewSyncHashJSON(h, "projectEnvironments", project.Spec.Environments)
 	if project.Spec.Preview != nil {
 		fmt.Fprintf(h, "domain=%s\nttl=%s\nbot=%t\ncpu=%s\nmemory=%s\n",
 			project.Spec.Preview.Domain,
@@ -471,6 +478,17 @@ func previewSyncState(app *mortisev1alpha1.App, project *mortisev1alpha1.Project
 		)
 	}
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writePreviewSyncHashJSON(h hashWriter, key string, value any) {
+	fmt.Fprintf(h, "%s=", key)
+	if err := json.NewEncoder(h).Encode(value); err != nil {
+		fmt.Fprintf(h, "json-error=%v\n", err)
+	}
+}
+
+type hashWriter interface {
+	Write([]byte) (int, error)
 }
 
 func (r *AppReconciler) newGitAPI(gp *mortisev1alpha1.GitProvider, token, webhookSecret string) (git.GitAPI, error) {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,6 +53,49 @@ import (
 // testImageNginx is the pinned image used across App controller tests.
 // Hoisted to package scope so it is visible from multiple Describe blocks.
 const testImageNginx = "nginx:1.27"
+
+func TestPreviewSyncStateIncludesBackfillInputs(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "owner/repo",
+				ProviderRef: "github",
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+		},
+	}
+	project := &mortisev1alpha1.Project{
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, Domain: "pr-{number}.example.com"},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	base := previewSyncState(app, project)
+
+	withAppEnvChange := app.DeepCopy()
+	replicas := int32(3)
+	withAppEnvChange.Spec.Environments[0].Replicas = &replicas
+	if got := previewSyncState(withAppEnvChange, project); got == base {
+		t.Fatal("preview sync state did not change after app environment preview input changed")
+	}
+
+	withProjectEnvChange := project.DeepCopy()
+	withProjectEnvChange.Spec.Environments = append(withProjectEnvChange.Spec.Environments, mortisev1alpha1.ProjectEnvironment{Name: "production"})
+	if got := previewSyncState(app, withProjectEnvChange); got == base {
+		t.Fatal("preview sync state did not change after project environment topology changed")
+	}
+
+	withCascadeRev := app.DeepCopy()
+	withCascadeRev.Annotations[ProjectPreviewRevAnnotation] = "2"
+	if got := previewSyncState(withCascadeRev, project); got == base {
+		t.Fatal("preview sync state did not change after project preview cascade revision changed")
+	}
+}
 
 var _ = Describe("App Controller", func() {
 	const namespace = "pj-default-project"

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -69,6 +69,11 @@ const (
 // signal — the App reconciler doesn't read the value.
 const ProjectEnvsRevAnnotation = "mortise.dev/project-envs-rev"
 
+// ProjectPreviewRevAnnotation is the App annotation the Project controller
+// bumps when the Project spec changes so preview backfill can rerun on the
+// next App reconcile.
+const ProjectPreviewRevAnnotation = "mortise.dev/project-preview-rev"
+
 // ProjectNamespace returns the control namespace for a Project. Kept for
 // callers outside this package that used to rely on `project-{name}`.
 func ProjectNamespace(projectName string) string {
@@ -222,6 +227,9 @@ func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, fmt.Errorf("cascade env change: %w", err)
 		}
 	}
+	if err := r.cascadePreviewChange(ctx, &project, controlNs); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cascade preview change: %w", err)
+	}
 
 	if err := r.markReady(ctx, &project, controlNs, appCount, envNsMap); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
@@ -262,6 +270,29 @@ func (r *ProjectReconciler) cascadeEnvChange(ctx context.Context, project *morti
 			continue
 		}
 		app.Annotations[ProjectEnvsRevAnnotation] = rev
+		if err := r.Patch(ctx, app, patch); err != nil {
+			return fmt.Errorf("patch app %q: %w", app.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *ProjectReconciler) cascadePreviewChange(ctx context.Context, project *mortisev1alpha1.Project, controlNs string) error {
+	var apps mortisev1alpha1.AppList
+	if err := r.List(ctx, &apps, client.InNamespace(controlNs)); err != nil {
+		return fmt.Errorf("list apps: %w", err)
+	}
+	rev := fmt.Sprintf("%d", project.Generation)
+	for i := range apps.Items {
+		app := &apps.Items[i]
+		patch := client.MergeFrom(app.DeepCopy())
+		if app.Annotations == nil {
+			app.Annotations = map[string]string{}
+		}
+		if app.Annotations[ProjectPreviewRevAnnotation] == rev {
+			continue
+		}
+		app.Annotations[ProjectPreviewRevAnnotation] = rev
 		if err := r.Patch(ctx, app, patch); err != nil {
 			return fmt.Errorf("patch app %q: %w", app.Name, err)
 		}

--- a/internal/git/api.go
+++ b/internal/git/api.go
@@ -66,6 +66,24 @@ type TreeEntry struct {
 	Path string `json:"path"`
 }
 
+// PullRequestAuthor carries normalized author metadata for forge PR/MR APIs.
+// IsBot is best-effort and may be false when the forge doesn't expose bot
+// identity cleanly in the listing response.
+type PullRequestAuthor struct {
+	Login string `json:"login"`
+	Type  string `json:"type,omitempty"`
+	IsBot bool   `json:"isBot,omitempty"`
+}
+
+// PullRequestSnapshot is the normalized open PR / MR shape used by preview
+// synchronization across all supported forges.
+type PullRequestSnapshot struct {
+	Number int               `json:"number"`
+	Branch string            `json:"branch"`
+	SHA    string            `json:"sha"`
+	Author PullRequestAuthor `json:"author,omitempty"`
+}
+
 // GitAPI handles forge-specific REST API calls. One implementation per forge.
 type GitAPI interface {
 	RegisterWebhook(ctx context.Context, repo string, cfg WebhookConfig) error
@@ -76,5 +94,7 @@ type GitAPI interface {
 	ResolveCloneCredentials(ctx context.Context, repo string) (GitCredentials, error)
 	ListRepos(ctx context.Context) ([]Repository, error)
 	ListBranches(ctx context.Context, repo string) ([]Branch, error)
+	ResolveBranchHead(ctx context.Context, repo, branch string) (string, error)
+	ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequestSnapshot, error)
 	ListTree(ctx context.Context, owner, repo, branch, path string) ([]TreeEntry, error)
 }

--- a/internal/git/api_test.go
+++ b/internal/git/api_test.go
@@ -23,6 +23,10 @@ type fakeGitAPI struct {
 	reposErr       error
 	branches       []Branch
 	branchesErr    error
+	branchHead     string
+	branchHeadErr  error
+	openPRs        []PullRequestSnapshot
+	openPRsErr     error
 	webhooks       []WebhookInfo
 	webhooksErr    error
 	deleteHookErr  error
@@ -60,6 +64,14 @@ func (f *fakeGitAPI) ListRepos(_ context.Context) ([]Repository, error) {
 
 func (f *fakeGitAPI) ListBranches(_ context.Context, _ string) ([]Branch, error) {
 	return f.branches, f.branchesErr
+}
+
+func (f *fakeGitAPI) ResolveBranchHead(_ context.Context, _, _ string) (string, error) {
+	return f.branchHead, f.branchHeadErr
+}
+
+func (f *fakeGitAPI) ListOpenPullRequests(_ context.Context, _ string) ([]PullRequestSnapshot, error) {
+	return f.openPRs, f.openPRsErr
 }
 
 func (f *fakeGitAPI) ListTree(_ context.Context, _, _, _, _ string) ([]TreeEntry, error) {

--- a/internal/git/gitea.go
+++ b/internal/git/gitea.go
@@ -172,6 +172,64 @@ func (g *GiteaAPI) ListBranches(ctx context.Context, repo string) ([]Branch, err
 	return result, nil
 }
 
+func (g *GiteaAPI) ResolveBranchHead(ctx context.Context, repo, branch string) (string, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return "", err
+	}
+	branches, _, err := g.client.ListRepoBranches(owner, name, gogitea.ListRepoBranchesOptions{
+		ListOptions: gogitea.ListOptions{PageSize: 100},
+	})
+	if err != nil {
+		return "", fmt.Errorf("list gitea branches: %w", err)
+	}
+	for _, b := range branches {
+		if b.Name == branch {
+			if b.Commit == nil {
+				return "", fmt.Errorf("gitea branch %q has no commit", branch)
+			}
+			return b.Commit.ID, nil
+		}
+	}
+	return "", fmt.Errorf("gitea branch %q not found", branch)
+}
+
+func (g *GiteaAPI) ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequestSnapshot, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	prs, _, err := g.client.ListRepoPullRequests(owner, name, gogitea.ListPullRequestsOptions{
+		State: gogitea.StateOpen,
+		ListOptions: gogitea.ListOptions{
+			PageSize: 100,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list gitea pull requests: %w", err)
+	}
+	out := make([]PullRequestSnapshot, 0, len(prs))
+	for _, pr := range prs {
+		author := PullRequestAuthor{}
+		if pr.Poster != nil {
+			author.Login = pr.Poster.UserName
+		}
+		branch := ""
+		sha := ""
+		if pr.Head != nil {
+			branch = pr.Head.Ref
+			sha = pr.Head.Sha
+		}
+		out = append(out, PullRequestSnapshot{
+			Number: int(pr.Index),
+			Branch: branch,
+			SHA:    sha,
+			Author: author,
+		})
+	}
+	return out, nil
+}
+
 func (g *GiteaAPI) ListTree(ctx context.Context, owner, repo, branch, path string) ([]TreeEntry, error) {
 	_ = ctx
 	items, _, err := g.client.ListContents(owner, repo, branch, path)

--- a/internal/git/gitea_test.go
+++ b/internal/git/gitea_test.go
@@ -221,3 +221,64 @@ func TestGitea_ResolveCloneCredentials(t *testing.T) {
 		t.Errorf("expected token gitea-tok-123, got %q", creds.Token)
 	}
 }
+
+func TestGitea_ResolveBranchHead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/octo/app/branches" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"name": "main", "commit": map[string]any{"id": "abc999"}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api, err := NewGiteaAPI(srv.URL, "test-token", "test-secret")
+	if err != nil {
+		t.Fatalf("NewGiteaAPI: %v", err)
+	}
+
+	sha, err := api.ResolveBranchHead(context.Background(), "octo/app", "main")
+	if err != nil {
+		t.Fatalf("ResolveBranchHead: %v", err)
+	}
+	if sha != "abc999" {
+		t.Fatalf("expected abc999, got %q", sha)
+	}
+}
+
+func TestGitea_ListOpenPullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/octo/app/pulls" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number": 9,
+					"user":   map[string]any{"login": "carol"},
+					"head":   map[string]any{"ref": "branch-a", "sha": "123abc"},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api, err := NewGiteaAPI(srv.URL, "test-token", "test-secret")
+	if err != nil {
+		t.Fatalf("NewGiteaAPI: %v", err)
+	}
+
+	prs, err := api.ListOpenPullRequests(context.Background(), "octo/app")
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 pr, got %d", len(prs))
+	}
+	if prs[0].Number != 9 || prs[0].Branch != "branch-a" || prs[0].SHA != "123abc" {
+		t.Fatalf("unexpected pr snapshot: %+v", prs[0])
+	}
+}

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -187,6 +187,50 @@ func (g *GitHubAPI) ListBranches(ctx context.Context, repo string) ([]Branch, er
 	return result, nil
 }
 
+func (g *GitHubAPI) ResolveBranchHead(ctx context.Context, repo, branch string) (string, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return "", err
+	}
+	b, _, err := g.client.Repositories.GetBranch(ctx, owner, name, branch, 0)
+	if err != nil {
+		return "", wrapGitHubError(fmt.Errorf("get github branch: %w", err))
+	}
+	return b.GetCommit().GetSHA(), nil
+}
+
+func (g *GitHubAPI) ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequestSnapshot, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	prs, _, err := g.client.PullRequests.List(ctx, owner, name, &gogithub.PullRequestListOptions{
+		State: "open",
+		ListOptions: gogithub.ListOptions{
+			PerPage: 100,
+		},
+	})
+	if err != nil {
+		return nil, wrapGitHubError(fmt.Errorf("list github pull requests: %w", err))
+	}
+	out := make([]PullRequestSnapshot, 0, len(prs))
+	for _, pr := range prs {
+		author := PullRequestAuthor{}
+		if user := pr.GetUser(); user != nil {
+			author.Login = user.GetLogin()
+			author.Type = user.GetType()
+			author.IsBot = strings.EqualFold(user.GetType(), "Bot")
+		}
+		out = append(out, PullRequestSnapshot{
+			Number: pr.GetNumber(),
+			Branch: pr.GetHead().GetRef(),
+			SHA:    pr.GetHead().GetSHA(),
+			Author: author,
+		})
+	}
+	return out, nil
+}
+
 func (g *GitHubAPI) ListTree(ctx context.Context, owner, repo, branch, path string) ([]TreeEntry, error) {
 	opts := &gogithub.RepositoryContentGetOptions{Ref: branch}
 	_, contents, _, err := g.client.Repositories.GetContents(ctx, owner, repo, path, opts)

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -303,6 +303,72 @@ func TestGitHub_ListRepos(t *testing.T) {
 	}
 }
 
+func TestGitHub_ResolveBranchHead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/octo/hello-world/branches/main" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"name": "main",
+				"commit": map[string]any{
+					"sha": "abc123def456",
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api := newTestGitHubAPI(t, srv.URL)
+	sha, err := api.ResolveBranchHead(context.Background(), "octo/hello-world", "main")
+	if err != nil {
+		t.Fatalf("ResolveBranchHead: %v", err)
+	}
+	if sha != "abc123def456" {
+		t.Fatalf("expected branch head sha abc123def456, got %q", sha)
+	}
+}
+
+func TestGitHub_ListOpenPullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/octo/hello-world/pulls" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number": 42,
+					"state":  "open",
+					"head": map[string]any{
+						"ref": "feature-x",
+						"sha": "deadbeef",
+					},
+					"user": map[string]any{
+						"login": "dependabot[bot]",
+						"type":  "Bot",
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api := newTestGitHubAPI(t, srv.URL)
+	prs, err := api.ListOpenPullRequests(context.Background(), "octo/hello-world")
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 pr, got %d", len(prs))
+	}
+	if prs[0].Number != 42 || prs[0].Branch != "feature-x" || prs[0].SHA != "deadbeef" {
+		t.Fatalf("unexpected pr snapshot: %+v", prs[0])
+	}
+	if !prs[0].Author.IsBot {
+		t.Fatalf("expected bot author, got %+v", prs[0].Author)
+	}
+}
+
 func TestGitHub_ListBranches(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/git/gitlab.go
+++ b/internal/git/gitlab.go
@@ -158,6 +158,44 @@ func (g *GitLabAPI) ListBranches(ctx context.Context, repo string) ([]Branch, er
 	return result, nil
 }
 
+func (g *GitLabAPI) ResolveBranchHead(ctx context.Context, repo, branch string) (string, error) {
+	b, _, err := g.client.Branches.GetBranch(repo, branch)
+	if err != nil {
+		return "", fmt.Errorf("get gitlab branch: %w", err)
+	}
+	if b.Commit == nil {
+		return "", fmt.Errorf("gitlab branch %q has no commit", branch)
+	}
+	return b.Commit.ID, nil
+}
+
+func (g *GitLabAPI) ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequestSnapshot, error) {
+	state := "opened"
+	prs, _, err := g.client.MergeRequests.ListProjectMergeRequests(repo, &gogitlab.ListProjectMergeRequestsOptions{
+		State: gogitlab.Ptr(state),
+		ListOptions: gogitlab.ListOptions{
+			PerPage: 100,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list gitlab merge requests: %w", err)
+	}
+	out := make([]PullRequestSnapshot, 0, len(prs))
+	for _, pr := range prs {
+		author := PullRequestAuthor{}
+		if pr.Author != nil {
+			author.Login = pr.Author.Username
+		}
+		out = append(out, PullRequestSnapshot{
+			Number: int(pr.IID),
+			Branch: pr.SourceBranch,
+			SHA:    pr.SHA,
+			Author: author,
+		})
+	}
+	return out, nil
+}
+
 func (g *GitLabAPI) ListTree(ctx context.Context, owner, repo, branch, path string) ([]TreeEntry, error) {
 	_ = ctx
 	projectPath := owner + "/" + repo

--- a/internal/git/gitlab_test.go
+++ b/internal/git/gitlab_test.go
@@ -206,6 +206,65 @@ func TestGitLab_ListBranches(t *testing.T) {
 	}
 }
 
+func TestGitLab_ResolveBranchHead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/myorg/myrepo/repository/branches/main" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"name": "main",
+				"commit": map[string]any{
+					"id": "cafebabe",
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api := newTestGitLabAPI(t, srv.URL)
+	sha, err := api.ResolveBranchHead(context.Background(), "myorg/myrepo", "main")
+	if err != nil {
+		t.Fatalf("ResolveBranchHead: %v", err)
+	}
+	if sha != "cafebabe" {
+		t.Fatalf("expected cafebabe, got %q", sha)
+	}
+}
+
+func TestGitLab_ListOpenPullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/myorg/myrepo/merge_requests" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"iid":           7,
+					"source_branch": "feat-sync",
+					"sha":           "feedface",
+					"author": map[string]any{
+						"username": "alice",
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	api := newTestGitLabAPI(t, srv.URL)
+	prs, err := api.ListOpenPullRequests(context.Background(), "myorg/myrepo")
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 merge request, got %d", len(prs))
+	}
+	if prs[0].Number != 7 || prs[0].Branch != "feat-sync" || prs[0].SHA != "feedface" {
+		t.Fatalf("unexpected merge request snapshot: %+v", prs[0])
+	}
+}
+
 func TestGitLab_VerifyWebhookSignature_Valid(t *testing.T) {
 	api := &GitLabAPI{secret: "gl-token-abc"}
 

--- a/internal/previewsync/service.go
+++ b/internal/previewsync/service.go
@@ -1,0 +1,192 @@
+package previewsync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
+)
+
+const defaultPreviewTTL = 72 * time.Hour
+
+// Store is the k8s CRUD surface needed to reconcile PreviewEnvironment CRs.
+type Store interface {
+	ListPreviewEnvironments(ctx context.Context, namespace string) ([]mortisev1alpha1.PreviewEnvironment, error)
+	CreatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
+	UpdatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
+	DeletePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
+}
+
+// ReconcileAppPreviews converges one App's PreviewEnvironment CRs onto the
+// provided open PR snapshot list using full reconcile semantics.
+func ReconcileAppPreviews(
+	ctx context.Context,
+	store Store,
+	app *mortisev1alpha1.App,
+	project *mortisev1alpha1.Project,
+	preview *mortisev1alpha1.PreviewConfig,
+	openPRs []git.PullRequestSnapshot,
+) error {
+	if app == nil || project == nil || preview == nil {
+		return nil
+	}
+
+	sourceEnv := ResolveSourceEnv(project)
+	if sourceEnv == "" {
+		return nil
+	}
+
+	existing, err := store.ListPreviewEnvironments(ctx, app.Namespace)
+	if err != nil {
+		return err
+	}
+
+	desired := make(map[int]mortisev1alpha1.PreviewEnvironment, len(openPRs))
+	for _, pr := range openPRs {
+		if pr.Number == 0 {
+			continue
+		}
+		if !preview.BotPR && pr.Author.IsBot {
+			continue
+		}
+		desired[pr.Number] = desiredPreviewEnvironment(app, project, preview, sourceEnv, pr)
+	}
+
+	existingByPR := make(map[int]*mortisev1alpha1.PreviewEnvironment)
+	for i := range existing {
+		pe := &existing[i]
+		if pe.Spec.AppRef != app.Name {
+			continue
+		}
+		existingByPR[pe.Spec.PullRequest.Number] = pe
+	}
+
+	for number, pe := range desired {
+		current := existingByPR[number]
+		if current == nil {
+			copy := pe
+			if err := store.CreatePreviewEnvironment(ctx, &copy); err != nil {
+				return err
+			}
+			continue
+		}
+		if equality.Semantic.DeepEqual(current.Spec, pe.Spec) {
+			continue
+		}
+		updated := current.DeepCopy()
+		updated.Spec = pe.Spec
+		if err := store.UpdatePreviewEnvironment(ctx, updated); err != nil {
+			return err
+		}
+	}
+
+	for number, pe := range existingByPR {
+		if _, ok := desired[number]; ok {
+			continue
+		}
+		if err := store.DeletePreviewEnvironment(ctx, pe); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func desiredPreviewEnvironment(
+	app *mortisev1alpha1.App,
+	project *mortisev1alpha1.Project,
+	preview *mortisev1alpha1.PreviewConfig,
+	sourceEnv string,
+	pr git.PullRequestSnapshot,
+) mortisev1alpha1.PreviewEnvironment {
+	sourceEnvOverride := FindAppEnv(app, sourceEnv)
+	ttl := resolveTTL(preview)
+	domain := ResolveDomainTemplate(preview.Domain, app.Name, project.Name, pr.Number)
+
+	pe := mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PreviewEnvName(app.Name, pr.Number),
+			Namespace: app.Namespace,
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			AppRef:    app.Name,
+			SourceEnv: sourceEnv,
+			PullRequest: mortisev1alpha1.PullRequestRef{
+				Number: pr.Number,
+				Branch: pr.Branch,
+				SHA:    pr.SHA,
+			},
+			Domain: domain,
+			TTL:    metav1.Duration{Duration: ttl},
+		},
+	}
+
+	if sourceEnvOverride != nil {
+		pe.Spec.Replicas = sourceEnvOverride.Replicas
+		pe.Spec.Resources = sourceEnvOverride.Resources
+		pe.Spec.Env = sourceEnvOverride.Env
+		pe.Spec.Bindings = sourceEnvOverride.Bindings
+	}
+
+	if preview.Resources.CPU != "" || preview.Resources.Memory != "" {
+		pe.Spec.Resources = preview.Resources
+	}
+
+	return pe
+}
+
+func resolveTTL(preview *mortisev1alpha1.PreviewConfig) time.Duration {
+	if preview == nil || preview.TTL == "" {
+		return defaultPreviewTTL
+	}
+	ttl, err := time.ParseDuration(preview.TTL)
+	if err != nil {
+		return defaultPreviewTTL
+	}
+	return ttl
+}
+
+func PreviewEnvName(appName string, prNumber int) string {
+	return fmt.Sprintf("%s-preview-pr-%d", appName, prNumber)
+}
+
+func ResolveDomainTemplate(template, appName, projectName string, prNumber int) string {
+	if template == "" {
+		return ""
+	}
+	result := strings.ReplaceAll(template, "{number}", fmt.Sprintf("%d", prNumber))
+	result = strings.ReplaceAll(result, "{app}", appName)
+	result = strings.ReplaceAll(result, "{project}", projectName)
+	return result
+}
+
+func FindAppEnv(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.Environment {
+	for i := range app.Spec.Environments {
+		if app.Spec.Environments[i].Name == envName {
+			return &app.Spec.Environments[i]
+		}
+	}
+	return nil
+}
+
+func ResolveSourceEnv(project *mortisev1alpha1.Project) string {
+	if project == nil {
+		return ""
+	}
+	var firstNonProd string
+	for _, env := range project.Spec.Environments {
+		if env.Name == "staging" {
+			return "staging"
+		}
+		if env.Name != "production" && firstNonProd == "" {
+			firstNonProd = env.Name
+		}
+	}
+	return firstNonProd
+}

--- a/internal/previewsync/service_test.go
+++ b/internal/previewsync/service_test.go
@@ -1,0 +1,137 @@
+package previewsync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
+)
+
+type fakeStore struct {
+	items   []mortisev1alpha1.PreviewEnvironment
+	created []mortisev1alpha1.PreviewEnvironment
+	updated []mortisev1alpha1.PreviewEnvironment
+	deleted []mortisev1alpha1.PreviewEnvironment
+}
+
+func (f *fakeStore) ListPreviewEnvironments(_ context.Context, _ string) ([]mortisev1alpha1.PreviewEnvironment, error) {
+	return append([]mortisev1alpha1.PreviewEnvironment(nil), f.items...), nil
+}
+
+func (f *fakeStore) CreatePreviewEnvironment(_ context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	f.created = append(f.created, *pe)
+	return nil
+}
+
+func (f *fakeStore) UpdatePreviewEnvironment(_ context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	f.updated = append(f.updated, *pe)
+	return nil
+}
+
+func (f *fakeStore) DeletePreviewEnvironment(_ context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	f.deleted = append(f.deleted, *pe)
+	return nil
+}
+
+func TestReconcileAppPreviews_FullReconcile(t *testing.T) {
+	store := &fakeStore{
+		items: []mortisev1alpha1.PreviewEnvironment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "web-preview-pr-1", Namespace: "pj-demo"},
+				Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+					AppRef: "web",
+					PullRequest: mortisev1alpha1.PullRequestRef{
+						Number: 1,
+						Branch: "old",
+						SHA:    "oldsha",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "web-preview-pr-2", Namespace: "pj-demo"},
+				Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+					AppRef: "web",
+					PullRequest: mortisev1alpha1.PullRequestRef{
+						Number: 2,
+						Branch: "stale",
+						SHA:    "stalesha",
+					},
+				},
+			},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "pj-demo"},
+		Spec: mortisev1alpha1.AppSpec{
+			Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+		},
+	}
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}, {Name: "staging"}},
+			Preview: &mortisev1alpha1.PreviewConfig{
+				Enabled: true,
+				Domain:  "pr-{number}-{app}.{project}.example.com",
+				TTL:     "24h",
+			},
+		},
+	}
+	openPRs := []git.PullRequestSnapshot{
+		{Number: 1, Branch: "feature-a", SHA: "sha-a"},
+		{Number: 3, Branch: "feature-c", SHA: "sha-c"},
+	}
+
+	if err := ReconcileAppPreviews(context.Background(), store, app, project, project.Spec.Preview, openPRs); err != nil {
+		t.Fatalf("ReconcileAppPreviews: %v", err)
+	}
+
+	if len(store.updated) != 1 || store.updated[0].Spec.PullRequest.Number != 1 || store.updated[0].Spec.PullRequest.SHA != "sha-a" {
+		t.Fatalf("expected PR #1 update, got %+v", store.updated)
+	}
+	if len(store.created) != 1 || store.created[0].Spec.PullRequest.Number != 3 {
+		t.Fatalf("expected PR #3 create, got %+v", store.created)
+	}
+	if store.created[0].Spec.Domain != "pr-3-web.demo.example.com" {
+		t.Fatalf("unexpected created domain: %q", store.created[0].Spec.Domain)
+	}
+	if store.created[0].Spec.TTL.Duration != 24*time.Hour {
+		t.Fatalf("unexpected created ttl: %s", store.created[0].Spec.TTL.Duration)
+	}
+	if len(store.deleted) != 1 || store.deleted[0].Spec.PullRequest.Number != 2 {
+		t.Fatalf("expected PR #2 delete, got %+v", store.deleted)
+	}
+}
+
+func TestReconcileAppPreviews_FiltersBotPRsByDefault(t *testing.T) {
+	store := &fakeStore{}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "pj-demo"},
+	}
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+		},
+	}
+	openPRs := []git.PullRequestSnapshot{
+		{
+			Number: 5,
+			Branch: "deps/update",
+			SHA:    "botsha",
+			Author: git.PullRequestAuthor{Login: "dependabot[bot]", Type: "Bot", IsBot: true},
+		},
+	}
+
+	if err := ReconcileAppPreviews(context.Background(), store, app, project, project.Spec.Preview, openPRs); err != nil {
+		t.Fatalf("ReconcileAppPreviews: %v", err)
+	}
+	if len(store.created) != 0 {
+		t.Fatalf("expected bot PR to be skipped, got creates %+v", store.created)
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -10,25 +10,24 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/git"
+	"github.com/mortise-org/mortise/internal/previewsync"
 )
 
 // Handler handles inbound git forge webhooks.
 type Handler struct {
-	k8s k8sReader
+	k8s                k8sReader
+	gitAPIFromProvider func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
 }
 
 // k8sReader is a minimal interface over the k8s client so Handler doesn't
@@ -43,11 +42,12 @@ type k8sReader interface {
 	createPreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
 	updatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
 	deletePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error
+	resolveGitTokenForApp(ctx context.Context, providerName, controlNamespace, createdBy, cachedOwner string) (git.TokenResult, error)
 }
 
 // New creates a Handler.
 func New(r k8sReader) *Handler {
-	return &Handler{k8s: r}
+	return &Handler{k8s: r, gitAPIFromProvider: git.NewGitAPIFromProvider}
 }
 
 // ServeHTTP dispatches to the chi-routed sub-router.
@@ -103,7 +103,7 @@ func (h *Handler) handleWebhook(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Construct an ephemeral GitAPI for signature verification only.
-	api, err := git.NewGitAPIFromProvider(gp, "" /* token unused */, webhookSecret)
+	api, err := h.gitAPIFromProvider(gp, "" /* token unused */, webhookSecret)
 	if err != nil {
 		log.Error(err, "build git api")
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -191,10 +191,8 @@ func (h *Handler) dispatchToApps(ctx context.Context, br BuildRequest) {
 	}
 }
 
-// dispatchPREvent handles pull_request events: creates, updates, or deletes
-// PreviewEnvironment CRDs for matching Apps. Preview is gated at the Project
-// level (SPEC §5.8): every App in a Project with preview.enabled=true
-// participates in each open PR's preview namespace.
+// dispatchPREvent handles pull_request events by reconciling previews against
+// the forge's current open-PR list for each matching App.
 func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 	log := logf.FromContext(ctx)
 
@@ -208,6 +206,7 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 	// and env-set validation all hang off the same record.
 	projectCache := make(map[string]*mortisev1alpha1.Project)
 	projectKnown := make(map[string]bool)
+	openPRCache := make(map[string][]git.PullRequestSnapshot)
 
 	matched := 0
 	for i := range apps {
@@ -248,13 +247,39 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 			continue
 		}
 
-		switch pr.Action {
-		case "opened", "synchronize":
-			h.handlePROpenOrSync(ctx, app, project, preview, pr)
-		case "closed":
-			h.handlePRClosed(ctx, app, pr)
-		default:
-			log.Info("ignoring PR action", "action", pr.Action)
+		cacheKey := gpRepoKey(pr.Provider, app.Namespace, src.Repo)
+		openPRs, ok := openPRCache[cacheKey]
+		if !ok {
+			gp, err := h.k8s.getGitProvider(ctx, app.Spec.Source.ProviderRef)
+			if err != nil {
+				log.Error(err, "get GitProvider for preview sync", "provider", app.Spec.Source.ProviderRef)
+				continue
+			}
+			createdBy := app.Annotations["mortise.dev/created-by"]
+			cachedOwner := app.Annotations["mortise.dev/git-token-owner"]
+			tokenResult, err := h.k8s.resolveGitTokenForApp(ctx, gp.Name, app.Namespace, createdBy, cachedOwner)
+			if err != nil {
+				log.Error(err, "resolve git token for preview sync", "app", app.Name, "provider", gp.Name)
+				continue
+			}
+			api, err := h.gitAPIFromProvider(gp, tokenResult.Token, "")
+			if err != nil {
+				log.Error(err, "create git API for preview sync", "app", app.Name)
+				continue
+			}
+			openPRs, err = api.ListOpenPullRequests(ctx, app.Spec.Source.Repo)
+			if err != nil {
+				log.Error(err, "list open pull requests for preview sync", "app", app.Name, "repo", app.Spec.Source.Repo)
+				continue
+			}
+			openPRCache[cacheKey] = openPRs
+		}
+		if pr.Action == "closed" {
+			openPRs = filterClosedPR(openPRs, pr.Number)
+		}
+		if err := previewsync.ReconcileAppPreviews(ctx, previewStore{reader: h.k8s}, app, project, preview, openPRs); err != nil {
+			log.Error(err, "reconcile previews from webhook", "app", app.Name, "project", project.Name)
+			continue
 		}
 		matched++
 	}
@@ -264,122 +289,18 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 	}
 }
 
-func (h *Handler) handlePROpenOrSync(ctx context.Context, app *mortisev1alpha1.App, project *mortisev1alpha1.Project, preview *mortisev1alpha1.PreviewConfig, pr PREvent) {
-	log := logf.FromContext(ctx)
-
-	// Preview envs inherit settings from a source environment. Resolve which
-	// env to clone from: prefer "staging" if it exists, otherwise the first
-	// non-production env. If the project only has "production", warn and skip.
-	sourceEnv := resolvePreviewSourceEnv(project)
-	if sourceEnv == "" {
-		log.Info("skipping preview env: project has no non-production environment to inherit from; add a staging or development environment",
-			"project", project.Name, "app", app.Name, "pr", pr.Number)
-		return
+func filterClosedPR(openPRs []git.PullRequestSnapshot, closedNumber int) []git.PullRequestSnapshot {
+	if closedNumber == 0 || len(openPRs) == 0 {
+		return openPRs
 	}
-
-	peName := previewEnvName(app.Name, pr.Number)
-
-	// Resolve domain from template.
-	domain := ""
-	if preview != nil {
-		domain = resolvePreviewDomainTemplate(preview.Domain, app.Name, project.Name, pr.Number)
-	}
-
-	// Default TTL: 72h.
-	ttlDuration := 72 * time.Hour
-	if preview != nil && preview.TTL != "" {
-		if parsed, err := time.ParseDuration(preview.TTL); err == nil {
-			ttlDuration = parsed
-		} else {
-			log.Error(err, "parse TTL, using default 72h", "ttl", preview.TTL)
+	filtered := openPRs[:0]
+	for _, pr := range openPRs {
+		if pr.Number == closedNumber {
+			continue
 		}
+		filtered = append(filtered, pr)
 	}
-
-	// Find the source env override on the App (may be nil — defaults are fine).
-	sourceEnvOverride := findAppEnv(app, sourceEnv)
-
-	// Check if PreviewEnvironment already exists.
-	existing, err := h.k8s.listPreviewEnvironments(ctx, app.Namespace)
-	if err != nil {
-		log.Error(err, "list preview environments")
-		return
-	}
-
-	for j := range existing {
-		if existing[j].Name == peName {
-			// Update SHA to trigger rebuild.
-			existing[j].Spec.PullRequest.SHA = pr.SHA
-			existing[j].Spec.PullRequest.Branch = pr.Branch
-			if err := h.k8s.updatePreviewEnvironment(ctx, &existing[j]); err != nil {
-				log.Error(err, "update preview environment", "name", peName)
-			} else {
-				log.Info("updated preview environment SHA", "name", peName, "sha", pr.SHA)
-			}
-			return
-		}
-	}
-
-	// Create new PreviewEnvironment.
-	pe := &mortisev1alpha1.PreviewEnvironment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      peName,
-			Namespace: app.Namespace,
-		},
-		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
-			AppRef:    app.Name,
-			SourceEnv: sourceEnv,
-			PullRequest: mortisev1alpha1.PullRequestRef{
-				Number: pr.Number,
-				Branch: pr.Branch,
-				SHA:    pr.SHA,
-			},
-			Domain: domain,
-			TTL:    metav1.Duration{Duration: ttlDuration},
-		},
-	}
-
-	// Inherit from source environment.
-	if sourceEnvOverride != nil {
-		pe.Spec.Replicas = sourceEnvOverride.Replicas
-		pe.Spec.Resources = sourceEnvOverride.Resources
-		pe.Spec.Env = sourceEnvOverride.Env
-		pe.Spec.Bindings = sourceEnvOverride.Bindings
-	}
-
-	// Apply project-level preview overrides.
-	if preview != nil {
-		if preview.Resources.CPU != "" || preview.Resources.Memory != "" {
-			pe.Spec.Resources = preview.Resources
-		}
-	}
-
-	if err := h.k8s.createPreviewEnvironment(ctx, pe); err != nil {
-		log.Error(err, "create preview environment", "name", peName)
-	} else {
-		log.Info("created preview environment", "name", peName, "pr", pr.Number)
-	}
-}
-
-func (h *Handler) handlePRClosed(ctx context.Context, app *mortisev1alpha1.App, pr PREvent) {
-	log := logf.FromContext(ctx)
-
-	existing, err := h.k8s.listPreviewEnvironments(ctx, app.Namespace)
-	if err != nil {
-		log.Error(err, "list preview environments for cleanup")
-		return
-	}
-
-	peName := previewEnvName(app.Name, pr.Number)
-	for j := range existing {
-		if existing[j].Name == peName {
-			if err := h.k8s.deletePreviewEnvironment(ctx, &existing[j]); err != nil {
-				log.Error(err, "delete preview environment", "name", peName)
-			} else {
-				log.Info("deleted preview environment", "name", peName)
-			}
-			return
-		}
-	}
+	return filtered
 }
 
 // branchFromRef strips the "refs/heads/" prefix from a git ref string.
@@ -723,50 +644,26 @@ func matchesWatchPaths(watchPaths, changedPaths []string) bool {
 	return false
 }
 
-// previewEnvName returns the name for a PreviewEnvironment CRD.
-func previewEnvName(appName string, prNumber int) string {
-	return fmt.Sprintf("%s-preview-pr-%d", appName, prNumber)
+func gpRepoKey(providerName, namespace, repo string) string {
+	return providerName + "|" + namespace + "|" + repo
 }
 
-// resolvePreviewDomainTemplate replaces {number}, {app}, and {project} in a domain template.
-func resolvePreviewDomainTemplate(template, appName, projectName string, prNumber int) string {
-	if template == "" {
-		return ""
-	}
-	result := strings.ReplaceAll(template, "{number}", fmt.Sprintf("%d", prNumber))
-	result = strings.ReplaceAll(result, "{app}", appName)
-	result = strings.ReplaceAll(result, "{project}", projectName)
-	return result
+type previewStore struct {
+	reader k8sReader
 }
 
-// findAppEnv returns the App's per-environment override for the named env,
-// or nil when the App declares no override for that env. Callers that need
-// defaults should treat nil as "use App defaults".
-func findAppEnv(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.Environment {
-	for i := range app.Spec.Environments {
-		if app.Spec.Environments[i].Name == envName {
-			return &app.Spec.Environments[i]
-		}
-	}
-	return nil
+func (p previewStore) ListPreviewEnvironments(ctx context.Context, namespace string) ([]mortisev1alpha1.PreviewEnvironment, error) {
+	return p.reader.listPreviewEnvironments(ctx, namespace)
 }
 
-// resolvePreviewSourceEnv picks the project environment that preview envs
-// should inherit from. It prefers "staging" if declared, otherwise falls back
-// to the first non-production environment. Returns "" if no suitable env
-// exists (i.e. the project only has "production").
-func resolvePreviewSourceEnv(project *mortisev1alpha1.Project) string {
-	if project == nil {
-		return ""
-	}
-	var firstNonProd string
-	for _, env := range project.Spec.Environments {
-		if env.Name == "staging" {
-			return "staging"
-		}
-		if env.Name != "production" && firstNonProd == "" {
-			firstNonProd = env.Name
-		}
-	}
-	return firstNonProd
+func (p previewStore) CreatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return p.reader.createPreviewEnvironment(ctx, pe)
+}
+
+func (p previewStore) UpdatePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return p.reader.updatePreviewEnvironment(ctx, pe)
+}
+
+func (p previewStore) DeletePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
+	return p.reader.deletePreviewEnvironment(ctx, pe)
 }

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,6 +34,8 @@ type fakeK8sReader struct {
 	createdPreviews []mortisev1alpha1.PreviewEnvironment
 	updatedPreviews []mortisev1alpha1.PreviewEnvironment
 	deletedPreviews []mortisev1alpha1.PreviewEnvironment
+
+	openPRs []git.PullRequestSnapshot
 }
 
 func (f *fakeK8sReader) getGitProvider(_ context.Context, name string) (*mortisev1alpha1.GitProvider, error) {
@@ -103,6 +106,48 @@ func (f *fakeK8sReader) updatePreviewEnvironment(_ context.Context, pe *mortisev
 func (f *fakeK8sReader) deletePreviewEnvironment(_ context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
 	f.deletedPreviews = append(f.deletedPreviews, *pe)
 	return nil
+}
+
+func (f *fakeK8sReader) resolveGitTokenForApp(_ context.Context, _, _, _, _ string) (git.TokenResult, error) {
+	return git.TokenResult{Token: "test-token", Email: "test@example.com"}, nil
+}
+
+func newTestHandler(kr *fakeK8sReader) *Handler {
+	h := New(kr)
+	h.gitAPIFromProvider = func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error) {
+		return &testGitAPI{openPRs: kr.openPRs}, nil
+	}
+	return h
+}
+
+type testGitAPI struct {
+	openPRs []git.PullRequestSnapshot
+}
+
+func (t *testGitAPI) RegisterWebhook(context.Context, string, git.WebhookConfig) error { return nil }
+func (t *testGitAPI) ListWebhooks(context.Context, string) ([]git.WebhookInfo, error) {
+	return nil, nil
+}
+func (t *testGitAPI) DeleteWebhook(context.Context, string, int64) error { return nil }
+func (t *testGitAPI) PostCommitStatus(context.Context, string, string, git.CommitStatus) error {
+	return nil
+}
+func (t *testGitAPI) VerifyWebhookSignature([]byte, http.Header) error { return nil }
+func (t *testGitAPI) ResolveCloneCredentials(context.Context, string) (git.GitCredentials, error) {
+	return git.GitCredentials{}, nil
+}
+func (t *testGitAPI) ListRepos(context.Context) ([]git.Repository, error) { return nil, nil }
+func (t *testGitAPI) ListBranches(context.Context, string) ([]git.Branch, error) {
+	return nil, nil
+}
+func (t *testGitAPI) ResolveBranchHead(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (t *testGitAPI) ListOpenPullRequests(context.Context, string) ([]git.PullRequestSnapshot, error) {
+	return t.openPRs, nil
+}
+func (t *testGitAPI) ListTree(context.Context, string, string, string, string) ([]git.TreeEntry, error) {
+	return nil, nil
 }
 
 func makeGitProvider(providerType mortisev1alpha1.GitProviderType, secretNS, secretName, secretKey string) *mortisev1alpha1.GitProvider {
@@ -385,7 +430,7 @@ func TestWebhook_DispatchMatrix(t *testing.T) {
 				},
 				apps: tc.apps,
 			}
-			h := New(kr)
+			h := newTestHandler(kr)
 
 			req := httptest.NewRequest(http.MethodPost, "/github-main", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -638,8 +683,9 @@ func TestGitHubPREvent_Opened_CreatesPreviewEnvironment(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 42, Branch: "feature/x", SHA: "shaopened"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -696,8 +742,9 @@ func TestGiteaPREvent_Opened_CreatesPreviewEnvironment(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"gitea": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 7, Branch: "topic/feat", SHA: "gitasha"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -740,8 +787,9 @@ func TestGitLabPREvent_Opened_CreatesPreviewEnvironment(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"gl": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 11, Branch: "feat/branch", SHA: "mrsha1"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -783,7 +831,7 @@ func TestPREvent_ProjectPreviewDisabled_NoPECreated(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -809,7 +857,7 @@ func TestPREvent_ProjectPreviewDisabled_NoPECreated(t *testing.T) {
 		apps:     []mortisev1alpha1.App{app2},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj2},
 	}
-	h2 := New(kr2)
+	h2 := newTestHandler(kr2)
 
 	req2 := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req2.Header.Set("Content-Type", "application/json")
@@ -840,8 +888,9 @@ func TestPREvent_DomainTemplate_Resolved(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 99, Branch: "br", SHA: "sha99"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -894,8 +943,9 @@ func TestPREvent_StagingInheritance(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 8, Branch: "br", SHA: "sha8"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -950,8 +1000,9 @@ func TestPREvent_PreviewResourcesOverride(t *testing.T) {
 		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 3, Branch: "br", SHA: "sha3"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1004,8 +1055,9 @@ func TestGitHubPREvent_Synchronize_UpdatesExistingPE(t *testing.T) {
 		apps:        []mortisev1alpha1.App{app},
 		projects:    map[string]*mortisev1alpha1.Project{"default": proj},
 		previewEnvs: []mortisev1alpha1.PreviewEnvironment{existing},
+		openPRs:     []git.PullRequestSnapshot{{Number: 42, Branch: "feature/x", SHA: "newsha"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1043,8 +1095,9 @@ func TestGitHubPREvent_Synchronize_NoExistingPE_Creates(t *testing.T) {
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
 		// No existing PE.
+		openPRs: []git.PullRequestSnapshot{{Number: 42, Branch: "feature/x", SHA: "sync-sha"}},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1078,6 +1131,7 @@ func TestGitHubPREvent_Closed_DeletesPE(t *testing.T) {
 			Name:      "my-app-preview-pr-42",
 			Namespace: "pj-default",
 		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{AppRef: "my-app", PullRequest: mortisev1alpha1.PullRequestRef{Number: 42}},
 	}
 	kr := &fakeK8sReader{
 		provider:    gp,
@@ -1086,7 +1140,7 @@ func TestGitHubPREvent_Closed_DeletesPE(t *testing.T) {
 		projects:    map[string]*mortisev1alpha1.Project{"default": proj},
 		previewEnvs: []mortisev1alpha1.PreviewEnvironment{existing},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1107,6 +1161,57 @@ func TestGitHubPREvent_Closed_DeletesPE(t *testing.T) {
 	}
 }
 
+func TestGitHubPREvent_Closed_DeletesPE_WhenForgeStillListsPR(t *testing.T) {
+	const secret = "whsec"
+	body := githubPRPayloadJSON("closed", 42, "feature/x", "anysha", "org/repo")
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	app, project := makePreviewGitApp("preview-app", "pj-proj", "https://github.com/org/repo", "main", "pr-{number}.example.com", "24h")
+	app.Spec.Source.ProviderRef = gp.Name
+
+	kr := &fakeK8sReader{
+		provider: gp,
+		secrets: map[string]string{
+			"mortise-system/wh-secret/value": secret,
+		},
+		apps:     []mortisev1alpha1.App{app},
+		projects: map[string]*mortisev1alpha1.Project{"proj": project},
+		previewEnvs: []mortisev1alpha1.PreviewEnvironment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "preview-app-preview-pr-42", Namespace: "pj-proj"},
+				Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+					AppRef:    app.Name,
+					SourceEnv: "staging",
+					PullRequest: mortisev1alpha1.PullRequestRef{
+						Number: 42,
+						Branch: "feature/x",
+						SHA:    "oldsha",
+					},
+				},
+			},
+		},
+		openPRs: []git.PullRequestSnapshot{
+			{Number: 42, Branch: "feature/x", SHA: "anysha"},
+		},
+	}
+	h := newTestHandler(kr)
+
+	req := httptest.NewRequest(http.MethodPost, "/github", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.deletedPreviews) != 1 {
+		t.Fatalf("expected preview delete on closed event, got %d", len(kr.deletedPreviews))
+	}
+}
+
 func TestGiteaPREvent_Closed_DeletesPE(t *testing.T) {
 	const secret = "giteaprsecret"
 	const providerName = "gitea-homelab"
@@ -1121,6 +1226,7 @@ func TestGiteaPREvent_Closed_DeletesPE(t *testing.T) {
 			Name:      "myrepo-app-preview-pr-9",
 			Namespace: "pj-gitea",
 		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{AppRef: "myrepo-app", PullRequest: mortisev1alpha1.PullRequestRef{Number: 9}},
 	}
 	kr := &fakeK8sReader{
 		provider:    gp,
@@ -1129,7 +1235,7 @@ func TestGiteaPREvent_Closed_DeletesPE(t *testing.T) {
 		projects:    map[string]*mortisev1alpha1.Project{"gitea": proj},
 		previewEnvs: []mortisev1alpha1.PreviewEnvironment{existing},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1172,6 +1278,7 @@ func TestGitLabPREvent_Closed_DeletesPE(t *testing.T) {
 					Name:      "gl-app-preview-pr-17",
 					Namespace: "pj-gl",
 				},
+				Spec: mortisev1alpha1.PreviewEnvironmentSpec{AppRef: "gl-app", PullRequest: mortisev1alpha1.PullRequestRef{Number: 17}},
 			}
 			kr := &fakeK8sReader{
 				provider:    gp,
@@ -1180,7 +1287,7 @@ func TestGitLabPREvent_Closed_DeletesPE(t *testing.T) {
 				projects:    map[string]*mortisev1alpha1.Project{"gl": proj},
 				previewEnvs: []mortisev1alpha1.PreviewEnvironment{existing},
 			}
-			h := New(kr)
+			h := newTestHandler(kr)
 
 			req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -1215,7 +1322,7 @@ func TestPREvent_Closed_NoExistingPE_Idempotent(t *testing.T) {
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
 		// No existing PE.
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1359,7 +1466,7 @@ func TestPREvent_ProjectOnlyProductionEnv_NoPECreated(t *testing.T) {
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1391,7 +1498,7 @@ func TestPREvent_NoMatchingRepo_NoPECreated(t *testing.T) {
 		apps:     []mortisev1alpha1.App{app},
 		projects: map[string]*mortisev1alpha1.Project{"default": proj},
 	}
-	h := New(kr)
+	h := newTestHandler(kr)
 
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/webhook/k8s.go
+++ b/internal/webhook/k8s.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 // K8sReader implements k8sReader using a controller-runtime client.
@@ -105,4 +106,8 @@ func (r *K8sReader) updatePreviewEnvironment(ctx context.Context, pe *mortisev1a
 // deletePreviewEnvironment deletes a PreviewEnvironment CRD.
 func (r *K8sReader) deletePreviewEnvironment(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment) error {
 	return r.client.Delete(ctx, pe)
+}
+
+func (r *K8sReader) resolveGitTokenForApp(ctx context.Context, providerName, controlNamespace, createdBy, cachedOwner string) (git.TokenResult, error) {
+	return git.ResolveGitTokenForApp(ctx, r.client, providerName, controlNamespace, createdBy, cachedOwner)
 }

--- a/test/chart/run.sh
+++ b/test/chart/run.sh
@@ -22,6 +22,7 @@ CLUSTER_NAME="mortise-chart"
 NAMESPACE="mortise-system"
 DEPS_NAMESPACE="mortise-deps"
 CHART_IMG="mortise:chart-test"
+K3D_RUNTIME_ULIMIT="${K3D_RUNTIME_ULIMIT:-nofile=1048576:1048576}"
 
 passed=0
 failed=0
@@ -68,7 +69,7 @@ wait_for_pods_ready() {
 
 info "Creating k3d cluster ${CLUSTER_NAME}..."
 k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
-k3d cluster create --config "${SCRIPT_DIR}/k3d-config.yaml" --wait
+k3d cluster create --config "${SCRIPT_DIR}/k3d-config.yaml" --runtime-ulimit "${K3D_RUNTIME_ULIMIT}" --wait
 
 info "Building operator image..."
 docker build -t "$CHART_IMG" "$REPO_ROOT" -q

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
 	import type { App, AppSpec } from '$lib/types';
 
@@ -56,6 +55,7 @@
 			spec.environments.push({ name: selectedEnv, enabled: next });
 		}
 		try {
+			const { api } = await import('$lib/api');
 			const result = await api.updateApp(project, app.metadata.name, spec);
 			specOverride = result.spec;
 		} catch (e) {
@@ -138,7 +138,7 @@
 	{/if}
 
 	{#if sectionVisible('domains')}
-		<DomainsSection {project} {app} {selectedEnv} {cloneSpec} onSpecUpdate={handleSpecUpdate} onError={handleError} />
+		<DomainsSection {project} {app} {selectedEnv} onSpecUpdate={handleSpecUpdate} onError={handleError} />
 	{/if}
 
 	{#if sectionVisible('deploy tokens')}

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -98,16 +98,6 @@
 		if (env === lastLoadedEnv && appName === lastLoadedApp) return;
 		lastLoadedEnv = env;
 		lastLoadedApp = appName;
-		// Reset transient UI state when switching environments
-		for (const s of [envSection, sharedSection, buildSection]) {
-			s.showNewRow = false;
-			s.newKey = '';
-			s.newValue = '';
-			s.rawMode = false;
-			s.rawText = '';
-			s.showPicker = false;
-			s.error = '';
-		}
 		void loadEnv(env);
 		void loadShared();
 		void loadBuildArgs();

--- a/ui/src/lib/components/drawer/settings/AdvancedSection.svelte
+++ b/ui/src/lib/components/drawer/settings/AdvancedSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec, SecretMount } from '$lib/types';
 	import { Plus, Trash2, ChevronDown } from 'lucide-svelte';
@@ -30,15 +29,10 @@
 	let savingMounts = $state(false);
 
 	$effect(() => {
-		const envName = selectedEnv;
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const env = (spec.environments?.find((e: { name: string }) => e.name === envName) as any) ?? {};
-			annotations = Object.fromEntries(Object.entries((env.annotations ?? {}) as Record<string, string>));
-			secretMounts = (env.secretMounts ?? []) as SecretMount[];
-		});
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const env = (app.spec.environments?.find(e => e.name === selectedEnv) as any) ?? {};
+		annotations = Object.fromEntries(Object.entries((env.annotations ?? {}) as Record<string, string>));
+		secretMounts = (env.secretMounts ?? []) as SecretMount[];
 	});
 
 	function addAnnotation() {

--- a/ui/src/lib/components/drawer/settings/BuildSection.svelte
+++ b/ui/src/lib/components/drawer/settings/BuildSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec } from '$lib/types';
 	import { inputCls, labelCls, sectionCls, headingCls, btnPrimary } from './styles';
@@ -24,13 +23,9 @@
 	let savingBuild = $state(false);
 
 	$effect(() => {
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			buildMode = spec.source.build?.mode ?? 'auto';
-			dockerfilePath = spec.source.build?.dockerfilePath ?? '';
-			buildContext = spec.source.build?.context ?? '';
-		});
+		buildMode = app.spec.source.build?.mode ?? 'auto';
+		dockerfilePath = app.spec.source.build?.dockerfilePath ?? '';
+		buildContext = app.spec.source.build?.context ?? '';
 	});
 
 	const srcPath = $derived(app.spec.source.path ?? '');

--- a/ui/src/lib/components/drawer/settings/DomainsSection.svelte
+++ b/ui/src/lib/components/drawer/settings/DomainsSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec, DomainsResponse } from '$lib/types';
 	import { inputCls, labelCls, sectionCls, headingCls, btnPrimary } from './styles';
@@ -8,14 +7,12 @@
 		project,
 		app,
 		selectedEnv,
-		cloneSpec,
 		onSpecUpdate,
 		onError
 	}: {
 		project: string;
 		app: App;
 		selectedEnv: string;
-		cloneSpec: () => AppSpec;
 		onSpecUpdate: (spec: AppSpec) => void;
 		onError: (msg: string) => void;
 	} = $props();
@@ -31,23 +28,17 @@
 	let tlsClusterIssuer = $state('');
 	let tlsSecretName = $state('');
 	let savingTls = $state(false);
-	const certEnvStatus = $derived(app.status?.environments?.find(e => e.name === selectedEnv));
 
 	$effect(() => {
 		if (selectedEnv) void loadDomains();
 	});
 
 	$effect(() => {
-		const envName = selectedEnv;
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			const env = spec.environments?.find((e: { name: string }) => e.name === envName) as
-				| { tls?: { clusterIssuer?: string; secretName?: string } }
-				| undefined;
-			tlsClusterIssuer = env?.tls?.clusterIssuer ?? '';
-			tlsSecretName = env?.tls?.secretName ?? '';
-		});
+		const env = app.spec.environments?.find(e => e.name === selectedEnv) as
+			| { tls?: { clusterIssuer?: string; secretName?: string } }
+			| undefined;
+		tlsClusterIssuer = env?.tls?.clusterIssuer ?? '';
+		tlsSecretName = env?.tls?.secretName ?? '';
 	});
 
 	async function loadDomains() {
@@ -129,15 +120,14 @@
 
 		savingPrimary = true;
 		try {
-			const spec = cloneSpec();
-			spec.environments = spec.environments ?? [];
-			const idx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
+			const envs = [...(app.spec.environments ?? [])];
+			const idx = envs.findIndex(e => e.name === selectedEnv);
 			if (idx >= 0) {
-				spec.environments[idx] = { ...spec.environments[idx], domain };
+				envs[idx] = { ...envs[idx], domain };
 			} else {
-				spec.environments.push({ name: selectedEnv, domain });
+				envs.push({ name: selectedEnv, domain });
 			}
-			const result = await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, { ...app.spec, environments: envs });
 			onSpecUpdate(result.spec);
 			domains = domains ? { ...domains, primary: domain } : { primary: domain, custom: [] };
 			editingPrimary = false;
@@ -152,13 +142,12 @@
 		if (!selectedEnv) return;
 		savingPrimary = true;
 		try {
-			const spec = cloneSpec();
-			spec.environments = spec.environments ?? [];
-			const idx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
+			const envs = [...(app.spec.environments ?? [])];
+			const idx = envs.findIndex(e => e.name === selectedEnv);
 			if (idx >= 0) {
-				spec.environments[idx] = { ...spec.environments[idx], domain: '' };
+				envs[idx] = { ...envs[idx], domain: '' };
 			}
-			const result = await api.updateApp(project, app.metadata.name, spec);
+			const result = await api.updateApp(project, app.metadata.name, { ...app.spec, environments: envs });
 			onSpecUpdate(result.spec);
 			domains = domains ? { ...domains, primary: '' } : { primary: '', custom: [] };
 		} catch (e) {
@@ -172,7 +161,7 @@
 		if (!selectedEnv) return;
 		savingTls = true;
 		try {
-			const spec = cloneSpec();
+			const spec = JSON.parse(JSON.stringify(app.spec)) as AppSpec;
 			spec.environments = spec.environments ?? [];
 			let envIdx = spec.environments.findIndex((e: { name: string }) => e.name === selectedEnv);
 			if (envIdx < 0) {
@@ -195,20 +184,6 @@
 
 <div class={sectionCls}>
 	<h3 class={headingCls}>Domains</h3>
-
-	{#if certEnvStatus?.certificateStatus === 'Pending'}
-		<div class="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-xs text-warning">
-			Certificate pending{certEnvStatus.certificateMessage ? ` — ${certEnvStatus.certificateMessage}` : ''}
-		</div>
-	{:else if certEnvStatus?.certificateStatus === 'Failed'}
-		<div class="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
-			Certificate failed{certEnvStatus.certificateMessage ? ` — ${certEnvStatus.certificateMessage}` : ''}
-		</div>
-	{:else if certEnvStatus?.certificateStatus === 'Ready'}
-		<div class="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-xs text-success">
-			TLS certificate active
-		</div>
-	{/if}
 
 	{#if !domains?.primary && !domains?.auto && (!domains?.custom || domains.custom.length === 0)}
 		<p class="text-xs text-gray-500">No domains configured. Add a domain to make this app reachable.</p>

--- a/ui/src/lib/components/drawer/settings/NetworkingSection.svelte
+++ b/ui/src/lib/components/drawer/settings/NetworkingSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec } from '$lib/types';
 	import { inputCls, labelCls, sectionCls, headingCls, btnPrimary } from './styles';
@@ -23,12 +22,8 @@
 	let saving = $state(false);
 
 	$effect(() => {
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			netPublic = spec.network?.public ?? true;
-			netPort = String(spec.network?.port ?? '');
-		});
+		netPublic = app.spec.network?.public ?? true;
+		netPort = String(app.spec.network?.port ?? '');
 	});
 
 	async function saveNetworking() {

--- a/ui/src/lib/components/drawer/settings/ScaleSection.svelte
+++ b/ui/src/lib/components/drawer/settings/ScaleSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec } from '$lib/types';
 	import { inputCls, labelCls, sectionCls, headingCls, btnPrimary } from './styles';
@@ -26,15 +25,10 @@
 	let saving = $state(false);
 
 	$effect(() => {
-		const envName = selectedEnv;
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			const env = spec.environments?.find((e: { name: string }) => e.name === envName);
-			scaleReplicas = String(env?.replicas ?? 1);
-			scaleCpu = env?.resources?.cpu ?? '';
-			scaleMemory = env?.resources?.memory ?? '';
-		});
+		const env = app.spec.environments?.find(e => e.name === selectedEnv);
+		scaleReplicas = String(env?.replicas ?? 1);
+		scaleCpu = env?.resources?.cpu ?? '';
+		scaleMemory = env?.resources?.memory ?? '';
 	});
 
 	async function saveScale() {

--- a/ui/src/lib/components/drawer/settings/SourceSection.svelte
+++ b/ui/src/lib/components/drawer/settings/SourceSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte';
 	import { api } from '$lib/api';
 	import type { App, AppSpec } from '$lib/types';
 	import { ChevronDown } from 'lucide-svelte';
@@ -36,17 +35,14 @@
 	let showAdvancedPull = $state(false);
 
 	$effect(() => {
-		void app.metadata.name;
-		untrack(() => {
-			const spec = cloneSpec();
-			srcRepo = spec.source.repo ?? '';
-			srcBranch = spec.source.branch ?? '';
-			srcPath = spec.source.path ?? '';
-			srcImage = spec.source.image ?? '';
-			srcPullSecretRef = spec.source.pullSecretRef ?? '';
-		});
+		srcRepo = app.spec.source.repo ?? '';
+		srcBranch = app.spec.source.branch ?? '';
+		srcPath = app.spec.source.path ?? '';
+		srcImage = app.spec.source.image ?? '';
+		srcPullSecretRef = app.spec.source.pullSecretRef ?? '';
 	});
 
+	import { onMount } from 'svelte';
 	onMount(async () => {
 		await loadPullCredentials();
 	});


### PR DESCRIPTION
## Summary
- sync manual rebuilds to the latest branch head SHA before starting builds
- add shared preview reconcile logic for webhook and app-triggered backfill across GitHub, GitLab, and Gitea/Forgejo
- preserve immediate preview deletion on closed PR webhooks and harden k3d test harness limits for local integration runs

Closes #276
Closes #284

## Root Cause
- rebuilds could rely on stale `mortise.dev/revision` state when webhook delivery was missed
- preview creation and cleanup logic only lived in the webhook path, so missed events and project/app config changes could leave preview environments drifted
- the shared reconcile refactor initially regressed closed-webhook deletion because a forge re-list could still report the PR as open

## Validation
- make test
- make test-charts
- staticcheck ./...
- cd ui && npm run build
- make test-integration