### PR TITLE
[codex] fix deploy token app and env validation

### DIFF
--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,10 +61,12 @@ type createProjectTokenRequest struct {
 // @Failure 409 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/tokens [post]
 func (s *Server) CreateToken(w http.ResponseWriter, r *http.Request) {
-	ns, projectName, ok := s.resolveProject(w, r)
+	project, ok := s.getProject(w, r)
 	if !ok {
 		return
 	}
+	ns := projectNs(project)
+	projectName := project.Name
 	if !s.authorize(w, r, authz.Resource{Kind: "token", Namespace: ns, Project: projectName}, authz.ActionCreate) {
 		return
 	}
@@ -78,8 +81,28 @@ func (s *Server) CreateToken(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"name is required"})
 		return
 	}
+	if msg := validateDNSLabel("name", req.Name, 63); msg != "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{msg})
+		return
+	}
 	if req.Environment == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"environment is required"})
+		return
+	}
+	if indexOfEnv(project, req.Environment) < 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
+			"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
+			req.Environment, project.Name, project.Name)})
+		return
+	}
+
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if !appParticipatesInEnv(&app, req.Environment) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("app %q is not enabled in environment %q", app.Name, req.Environment)})
 		return
 	}
 
@@ -147,6 +170,11 @@ func (s *Server) ListTokens(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	appName := chi.URLParam(r, "app")
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
 
 	var list corev1.SecretList
 	if err := s.client.List(r.Context(), &list,

--- a/internal/api/tokens_handler_test.go
+++ b/internal/api/tokens_handler_test.go
@@ -7,26 +7,33 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 )
+
+func seedTokenApp(t *testing.T, k8sClient client.Client, projectNS, appName string, envs ...mortisev1alpha1.Environment) {
+	t.Helper()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: projectNS},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+		},
+	}
+	if len(envs) > 0 {
+		app.Spec.Environments = envs
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+}
 
 func TestTokenCRUDHappyPath(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
 	ns := seedProject(t, k8sClient, "default")
-
-	ctx := context.Background()
-	app := &mortisev1alpha1.App{
-		ObjectMeta: metav1.ObjectMeta{Name: "webapp", Namespace: ns},
-		Spec: mortisev1alpha1.AppSpec{
-			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
-		},
-	}
-	if err := k8sClient.Create(ctx, app); err != nil {
-		t.Fatalf("create app: %v", err)
-	}
+	seedTokenApp(t, k8sClient, ns, "webapp")
 
 	// Create token.
 	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
@@ -113,6 +120,38 @@ func TestCreateTokenInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestCreateTokenInvalidName(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedTokenApp(t, k8sClient, ns, "webapp")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "CI Deploy",
+		"environment": "production",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateTokenAllowsDeclaredEnvWithoutAppOverride(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	seedTokenApp(t, k8sClient, ns, "webapp")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "ci-staging",
+		"environment": "staging",
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for declared env without override, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestDeleteTokenNotFound(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
@@ -136,5 +175,65 @@ func TestCreateTokenMissingProject(t *testing.T) {
 	})
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing project, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateTokenMissingAppReturns404(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/ghost/tokens", map[string]any{
+		"name":        "ci",
+		"environment": "production",
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing app, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateTokenRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "production")
+	seedTokenApp(t, k8sClient, ns, "webapp")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "ci",
+		"environment": "staging",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateTokenRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "production", "staging")
+	disabled := false
+	seedTokenApp(t, k8sClient, ns, "webapp", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "ci",
+		"environment": "staging",
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled app env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListTokensMissingAppReturns404(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/tokens", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing app, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- validate app deploy token creation against the real app and declared project environments
- reject token creation for app environments explicitly disabled with `enabled: false`
- require token listing to target a real app and validate token names up front

## Root cause
The deploy token handlers trusted path/body data too loosely. They could mint tokens for phantom apps or undeclared environments, treat missing apps as an empty token list, and surface raw Kubernetes naming errors instead of stable API validation failures.

## Validation
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'Test(Token|CreateToken|ListTokens)' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
