### PR TITLE
[codex] fix deploy token cleanup on app delete

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -324,6 +325,11 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.deleteAppDeployTokens(r.Context(), ns, app.Name); err != nil {
+		writeError(w, r, err)
+		return
+	}
+
 	if err := s.client.Delete(r.Context(), &app); err != nil {
 		writeError(w, r, err)
 		return
@@ -332,6 +338,25 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, projectName, "delete", "app", app.Name, "Deleted app "+app.Name, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) deleteAppDeployTokens(ctx context.Context, ns, appName string) error {
+	var tokens corev1.SecretList
+	if err := s.client.List(ctx, &tokens,
+		client.InNamespace(ns),
+		client.MatchingLabels{
+			"mortise.dev/deploy-token": "true",
+			"mortise.dev/app":          appName,
+		},
+	); err != nil {
+		return err
+	}
+	for i := range tokens.Items {
+		if err := s.client.Delete(ctx, &tokens.Items[i]); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // writeError maps k8s API errors to HTTP status codes.

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -325,12 +325,12 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.deleteAppDeployTokens(r.Context(), ns, app.Name); err != nil {
+	if err := s.client.Delete(r.Context(), &app); err != nil {
 		writeError(w, r, err)
 		return
 	}
 
-	if err := s.client.Delete(r.Context(), &app); err != nil {
+	if err := s.deleteAppDeployTokens(r.Context(), ns, app.Name); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -514,6 +514,64 @@ func TestDeleteApp(t *testing.T) {
 	}
 }
 
+func TestDeleteAppRemovesAppDeployTokensOnly(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "delete-me",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	projectToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-token-pj-keep",
+			Namespace: ns,
+			Labels: map[string]string{
+				"mortise.dev/deploy-token":  "true",
+				"mortise.dev/project-token": "true",
+			},
+		},
+		Data: map[string][]byte{"token-hash": []byte("hash")},
+	}
+	if err := k8sClient.Create(context.Background(), projectToken); err != nil {
+		t.Fatalf("create project token secret: %v", err)
+	}
+
+	appToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-token-delete-me-ci",
+			Namespace: ns,
+			Labels: map[string]string{
+				"mortise.dev/deploy-token": "true",
+				"mortise.dev/app":          "delete-me",
+				"mortise.dev/environment":  "production",
+				"mortise.dev/token-name":   "ci",
+			},
+		},
+		Data: map[string][]byte{"token-hash": []byte("hash")},
+	}
+	if err := k8sClient.Create(context.Background(), appToken); err != nil {
+		t.Fatalf("create app token secret: %v", err)
+	}
+
+	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/delete-me", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete app with tokens: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: appToken.Name, Namespace: ns}, &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected app token secret to be deleted, got %v", err)
+	}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: projectToken.Name, Namespace: ns}, &corev1.Secret{}); err != nil {
+		t.Fatalf("expected project token secret to remain, got %v", err)
+	}
+}
+
 func TestDeploy(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -42,6 +42,17 @@ type gitfake struct {
 	branchHead string
 }
 
+type appDeleteFailingClient struct {
+	client.Client
+}
+
+func (c *appDeleteFailingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if _, ok := obj.(*mortisev1alpha1.App); ok {
+		return apierrors.NewInternalError(fmt.Errorf("forced app delete failure"))
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
 func (g *gitfake) RegisterWebhook(context.Context, string, git.WebhookConfig) error { return nil }
 func (g *gitfake) ListWebhooks(context.Context, string) ([]git.WebhookInfo, error)  { return nil, nil }
 func (g *gitfake) DeleteWebhook(context.Context, string, int64) error               { return nil }
@@ -569,6 +580,51 @@ func TestDeleteAppRemovesAppDeployTokensOnly(t *testing.T) {
 	}
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: projectToken.Name, Namespace: ns}, &corev1.Secret{}); err != nil {
 		t.Fatalf("expected project token secret to remain, got %v", err)
+	}
+}
+
+func TestDeleteAppPreservesDeployTokensWhenAppDeleteFails(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, &appDeleteFailingClient{Client: k8sClient})
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "delete-me",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	appToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-token-delete-me-ci",
+			Namespace: ns,
+			Labels: map[string]string{
+				"mortise.dev/deploy-token": "true",
+				"mortise.dev/app":          "delete-me",
+				"mortise.dev/environment":  "production",
+				"mortise.dev/token-name":   "ci",
+			},
+		},
+		Data: map[string][]byte{"token-hash": []byte("hash")},
+	}
+	if err := k8sClient.Create(context.Background(), appToken); err != nil {
+		t.Fatalf("create app token secret: %v", err)
+	}
+
+	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/delete-me", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("delete app with forced failure: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: appToken.Name, Namespace: ns}, &corev1.Secret{}); err != nil {
+		t.Fatalf("expected app token secret to remain after failed delete, got %v", err)
+	}
+
+	var app mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "delete-me", Namespace: ns}, &app); err != nil {
+		t.Fatalf("expected app to remain after failed delete, got %v", err)
 	}
 }
 

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -592,6 +592,44 @@ var _ = Describe("App Controller", func() {
 			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(8080)))
 		})
 
+		It("removes app deploy token secrets during finalizer GC without touching project tokens", func() {
+			appToken := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deploy-token-test-nginx-ci",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"mortise.dev/deploy-token": "true",
+						"mortise.dev/app":          appName,
+						"mortise.dev/environment":  "production",
+						"mortise.dev/token-name":   "ci",
+					},
+				},
+				Data: map[string][]byte{"token-hash": []byte("hash")},
+			}
+			Expect(k8sClient.Create(ctx, appToken)).To(Succeed())
+
+			projectToken := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deploy-token-pj-keep",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"mortise.dev/deploy-token":  "true",
+						"mortise.dev/project-token": "true",
+					},
+				},
+				Data: map[string][]byte{"token-hash": []byte("hash")},
+			}
+			Expect(k8sClient.Create(ctx, projectToken)).To(Succeed())
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			Expect(reconciler.gcAppAcrossEnvs(ctx, app)).To(Succeed())
+
+			var got corev1.Secret
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: appToken.Name, Namespace: namespace}, &got)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expected app deploy token secret to be deleted, got %v", err)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: projectToken.Name, Namespace: namespace}, &got)).To(Succeed())
+		})
+
 		It("should not rewrite a volume-less Deployment on repeated reconcile", func() {
 			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 			req := reconcile.Request{

--- a/internal/controller/app_env_gc.go
+++ b/internal/controller/app_env_gc.go
@@ -50,6 +50,10 @@ func (r *AppReconciler) gcAppAcrossEnvs(ctx context.Context, app *mortisev1alpha
 		constants.AppNameLabel: app.Name,
 		constants.ProjectLabel: projectName,
 	}
+	tokenSelector := client.MatchingLabels{
+		"mortise.dev/deploy-token": "true",
+		"mortise.dev/app":          app.Name,
+	}
 
 	if err := r.deleteMatching(ctx, &appsv1.DeploymentList{}, selector); err != nil {
 		return fmt.Errorf("gc deployments: %w", err)
@@ -74,6 +78,9 @@ func (r *AppReconciler) gcAppAcrossEnvs(ctx context.Context, app *mortisev1alpha
 	}
 	if err := r.deleteMatching(ctx, &corev1.PersistentVolumeClaimList{}, selector); err != nil {
 		return fmt.Errorf("gc pvcs: %w", err)
+	}
+	if err := r.deleteMatching(ctx, &corev1.SecretList{}, tokenSelector, client.InNamespace(app.Namespace)); err != nil {
+		return fmt.Errorf("gc app deploy tokens: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- delete app-scoped deploy token secrets when an app is removed through the REST API
- extend App finalizer GC to remove app-scoped deploy token secrets for non-API deletion paths too
- add regression coverage that preserves project-scoped deploy tokens while removing app-scoped ones

## Root cause
App deploy tokens were stored as standalone Secrets in the project control namespace with no owner reference and labels that did not match the existing finalizer GC selector. Deleting an app left valid deploy credentials behind, which could leak into same-name app recreations.

## Validation
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api ./internal/controller -count=1`
