### PR TITLE
[codex] fix proxy connect listener race

### DIFF
--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -21,6 +21,8 @@ import (
 	"github.com/mortise-org/mortise/internal/constants"
 )
 
+var proxyListen = net.Listen
+
 type retryTransport struct {
 	base     http.RoundTripper
 	retries  int
@@ -127,18 +129,17 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	envNs := constants.EnvNamespace(projectName, env)
 	key := proxyKey(projectName, appName, env)
 
-	// If already proxying, return the existing URL.
 	s.proxies.mu.Lock()
 	if entry, exists := s.proxies.proxies[key]; exists {
 		s.proxies.mu.Unlock()
 		writeJSON(w, http.StatusOK, entry)
 		return
 	}
-	s.proxies.mu.Unlock()
 
 	// Resolve app CRD (control ns) to get the port.
 	var app mortisev1alpha1.App
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+		s.proxies.mu.Unlock()
 		writeJSON(w, http.StatusNotFound, errorResponse{"app not found"})
 		return
 	}
@@ -151,13 +152,15 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	target := fmt.Sprintf("http://%s.%s.svc:%d", appName, envNs, port)
 	targetURL, err := url.Parse(target)
 	if err != nil {
+		s.proxies.mu.Unlock()
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"invalid proxy target"})
 		return
 	}
 
 	// Allocate a random port and start listening.
-	listener, err := net.Listen("tcp", proxyBindAddress+":0")
+	listener, err := proxyListen("tcp", proxyBindAddress+":0")
 	if err != nil {
+		s.proxies.mu.Unlock()
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to allocate port: " + err.Error()})
 		return
 	}
@@ -188,7 +191,6 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		listener: listener,
 	}
 
-	s.proxies.mu.Lock()
 	s.proxies.proxies[key] = entry
 	s.proxies.mu.Unlock()
 

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -79,6 +79,10 @@ type appProxyEntry struct {
 	listener net.Listener
 }
 
+type proxyPending struct {
+	done chan struct{}
+}
+
 const proxyBindAddress = "127.0.0.1"
 
 // appProxyManager manages per-app reverse proxy listeners. Each app gets its
@@ -86,6 +90,7 @@ const proxyBindAddress = "127.0.0.1"
 type appProxyManager struct {
 	mu      sync.Mutex
 	proxies map[string]*appProxyEntry // key: "project/app/env"
+	pending map[string]*proxyPending
 }
 
 func proxyKey(project, app, env string) string {
@@ -93,7 +98,10 @@ func proxyKey(project, app, env string) string {
 }
 
 func newAppProxyManager() *appProxyManager {
-	return &appProxyManager{proxies: make(map[string]*appProxyEntry)}
+	return &appProxyManager{
+		proxies: make(map[string]*appProxyEntry),
+		pending: make(map[string]*proxyPending),
+	}
 }
 
 // handleConnect starts a reverse proxy listener for an app on an auto-allocated
@@ -129,19 +137,67 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	envNs := constants.EnvNamespace(projectName, env)
 	key := proxyKey(projectName, appName, env)
 
-	s.proxies.mu.Lock()
-	if entry, exists := s.proxies.proxies[key]; exists {
+	for {
+		s.proxies.mu.Lock()
+		if entry, exists := s.proxies.proxies[key]; exists {
+			s.proxies.mu.Unlock()
+			writeJSON(w, http.StatusOK, entry)
+			return
+		}
+		if pending, exists := s.proxies.pending[key]; exists {
+			s.proxies.mu.Unlock()
+			select {
+			case <-pending.done:
+				continue
+			case <-r.Context().Done():
+				writeJSON(w, http.StatusRequestTimeout, errorResponse{"request canceled while waiting for proxy"})
+				return
+			}
+		}
+		pending := &proxyPending{done: make(chan struct{})}
+		s.proxies.pending[key] = pending
 		s.proxies.mu.Unlock()
+		entry, err := s.createProxyEntry(r, ns, appName, envNs, key, log)
+		s.proxies.mu.Lock()
+		if err == nil {
+			s.proxies.proxies[key] = entry
+		}
+		delete(s.proxies.pending, key)
+		close(pending.done)
+		s.proxies.mu.Unlock()
+		if err != nil {
+			var status int
+			var msg string
+			switch {
+			case errors.Is(err, errProxyAppNotFound):
+				status = http.StatusNotFound
+				msg = "app not found"
+			case errors.Is(err, errProxyInvalidTarget):
+				status = http.StatusInternalServerError
+				msg = "invalid proxy target"
+			default:
+				status = http.StatusInternalServerError
+				msg = err.Error()
+			}
+			writeJSON(w, status, errorResponse{msg})
+			return
+		}
+		log.Info("started app proxy", "app", key, "port", entry.Port, "target", entry.URL)
 		writeJSON(w, http.StatusOK, entry)
 		return
 	}
+}
 
+var (
+	errProxyAppNotFound   = errors.New("app not found")
+	errProxyInvalidTarget = errors.New("invalid proxy target")
+)
+
+func (s *Server) createProxyEntry(r *http.Request, ns, appName, envNs, key string, log interface{ Info(string, ...any) }) (*appProxyEntry, error) {
 	// Resolve app CRD (control ns) to get the port.
 	var app mortisev1alpha1.App
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
-		s.proxies.mu.Unlock()
-		writeJSON(w, http.StatusNotFound, errorResponse{"app not found"})
-		return
+		return nil, errProxyAppNotFound
 	}
 
 	port := app.Spec.Network.Port
@@ -152,17 +208,13 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	target := fmt.Sprintf("http://%s.%s.svc:%d", appName, envNs, port)
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		s.proxies.mu.Unlock()
-		writeJSON(w, http.StatusInternalServerError, errorResponse{"invalid proxy target"})
-		return
+		return nil, errProxyInvalidTarget
 	}
 
 	// Allocate a random port and start listening.
 	listener, err := proxyListen("tcp", proxyBindAddress+":0")
 	if err != nil {
-		s.proxies.mu.Unlock()
-		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to allocate port: " + err.Error()})
-		return
+		return nil, fmt.Errorf("failed to allocate port: %w", err)
 	}
 	allocatedPort := listener.Addr().(*net.TCPAddr).Port
 
@@ -185,17 +237,11 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	entry := &appProxyEntry{
+	return &appProxyEntry{
 		Port:     allocatedPort,
 		URL:      fmt.Sprintf("http://localhost:%d", allocatedPort),
 		listener: listener,
-	}
-
-	s.proxies.proxies[key] = entry
-	s.proxies.mu.Unlock()
-
-	log.Info("started app proxy", "app", key, "port", allocatedPort, "target", target)
-	writeJSON(w, http.StatusOK, entry)
+	}, nil
 }
 
 // handleDisconnect stops the proxy for an app.

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -68,7 +68,10 @@ func newProxyRaceServer(t *testing.T) *Server {
 	project := &mortisev1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: mortisev1alpha1.ProjectSpec{
-			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production", DisplayOrder: 0}},
+			Environments: []mortisev1alpha1.ProjectEnvironment{
+				{Name: "production", DisplayOrder: 0},
+				{Name: "staging", DisplayOrder: 1},
+			},
 		},
 		Status: mortisev1alpha1.ProjectStatus{Namespace: constants.ControlNamespace("default")},
 	}
@@ -79,15 +82,22 @@ func newProxyRaceServer(t *testing.T) *Server {
 			Network: mortisev1alpha1.NetworkConfig{Port: 8080},
 		},
 	}
+	apiApp := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: constants.ControlNamespace("default")},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 9090},
+		},
+	}
 
-	return NewServer(fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(project, app).Build(), nil, nil, nil, nil, nil, nil, allowAllPolicy{})
+	return NewServer(fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(project, app, apiApp).Build(), nil, nil, nil, nil, nil, nil, allowAllPolicy{})
 }
 
-func proxyRaceRequest(method, target string) *http.Request {
+func proxyRaceRequest(method, target, app string) *http.Request {
 	req := httptest.NewRequest(method, target, nil)
 	routeCtx := chi.NewRouteContext()
 	routeCtx.URLParams.Add("project", "default")
-	routeCtx.URLParams.Add("app", "web")
+	routeCtx.URLParams.Add("app", app)
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
 	ctx = context.WithValue(ctx, principalKey, &auth.Principal{Email: "test@example.com", Role: auth.RoleAdmin})
 	return req.WithContext(ctx)
@@ -141,7 +151,7 @@ func TestHandleConnectCreatesOneListenerPerKey(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	go func() {
 		defer wg.Done()
-		srv.handleConnect(rec1, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production"))
+		srv.handleConnect(rec1, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production", "web"))
 	}()
 
 	select {
@@ -152,7 +162,7 @@ func TestHandleConnectCreatesOneListenerPerKey(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		srv.handleConnect(rec2, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production"))
+		srv.handleConnect(rec2, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production", "web"))
 	}()
 
 	time.Sleep(150 * time.Millisecond)
@@ -184,5 +194,90 @@ func TestHandleConnectCreatesOneListenerPerKey(t *testing.T) {
 	}
 	if resp1.URL != resp2.URL {
 		t.Fatalf("expected one shared proxy URL, got %q and %q", resp1.URL, resp2.URL)
+	}
+}
+
+func TestHandleConnectDoesNotSerializeDifferentKeys(t *testing.T) {
+	srv := newProxyRaceServer(t)
+	t.Cleanup(func() { closeProxyEntries(srv) })
+
+	origListen := proxyListen
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	var listenCalls atomic.Int32
+	var listenersMu sync.Mutex
+	var listeners []net.Listener
+	proxyListen = func(network, addr string) (net.Listener, error) {
+		call := listenCalls.Add(1)
+		switch call {
+		case 1:
+			close(firstEntered)
+			<-releaseFirst
+		case 2:
+			close(secondEntered)
+		}
+		ln, err := origListen(network, addr)
+		if err == nil {
+			listenersMu.Lock()
+			listeners = append(listeners, ln)
+			listenersMu.Unlock()
+		}
+		return ln, err
+	}
+	defer func() {
+		proxyListen = origListen
+		listenersMu.Lock()
+		defer listenersMu.Unlock()
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	}()
+
+	rec1 := httptest.NewRecorder()
+	rec2 := httptest.NewRecorder()
+	done1 := make(chan struct{})
+	done2 := make(chan struct{})
+	go func() {
+		defer close(done1)
+		srv.handleConnect(rec1, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production", "web"))
+	}()
+	select {
+	case <-firstEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first key did not begin listener creation")
+	}
+
+	go func() {
+		defer close(done2)
+		srv.handleConnect(rec2, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/api/connect?env=staging", "api"))
+	}()
+
+	select {
+	case <-secondEntered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("different proxy key was blocked by unrelated in-flight connect")
+	}
+	if got := listenCalls.Load(); got != 2 {
+		t.Fatalf("expected two listener creations for different keys, got %d", got)
+	}
+
+	select {
+	case <-done2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("different-key connect did not complete independently")
+	}
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected different-key connect to return 200, got %d", rec2.Code)
+	}
+
+	close(releaseFirst)
+	select {
+	case <-done1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first connect did not complete after release")
+	}
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("expected first-key connect to return 200, got %d", rec1.Code)
 	}
 }

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -1,8 +1,25 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/authz"
+	"github.com/mortise-org/mortise/internal/constants"
 )
 
 func TestProxyKeyIncludesEnv(t *testing.T) {
@@ -31,5 +48,141 @@ func TestProxyBindAddressIsLoopback(t *testing.T) {
 	}
 	if !ip.IsLoopback() {
 		t.Errorf("proxyBindAddress must be loopback, got %s", proxyBindAddress)
+	}
+}
+
+type allowAllPolicy struct{}
+
+func (allowAllPolicy) Authorize(context.Context, auth.Principal, authz.Resource, authz.Action) (bool, error) {
+	return true, nil
+}
+
+func newProxyRaceServer(t *testing.T) *Server {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production", DisplayOrder: 0}},
+		},
+		Status: mortisev1alpha1.ProjectStatus{Namespace: constants.ControlNamespace("default")},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: constants.ControlNamespace("default")},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+			Network: mortisev1alpha1.NetworkConfig{Port: 8080},
+		},
+	}
+
+	return NewServer(fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(project, app).Build(), nil, nil, nil, nil, nil, nil, allowAllPolicy{})
+}
+
+func proxyRaceRequest(method, target string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("project", "default")
+	routeCtx.URLParams.Add("app", "web")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, principalKey, &auth.Principal{Email: "test@example.com", Role: auth.RoleAdmin})
+	return req.WithContext(ctx)
+}
+
+func closeProxyEntries(srv *Server) {
+	srv.proxies.mu.Lock()
+	defer srv.proxies.mu.Unlock()
+	for key, entry := range srv.proxies.proxies {
+		_ = entry.listener.Close()
+		delete(srv.proxies.proxies, key)
+	}
+}
+
+func TestHandleConnectCreatesOneListenerPerKey(t *testing.T) {
+	srv := newProxyRaceServer(t)
+	t.Cleanup(func() { closeProxyEntries(srv) })
+
+	origListen := proxyListen
+	var listenCalls atomic.Int32
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var listenersMu sync.Mutex
+	var listeners []net.Listener
+	proxyListen = func(network, addr string) (net.Listener, error) {
+		call := listenCalls.Add(1)
+		if call == 1 {
+			close(firstEntered)
+			<-releaseFirst
+		}
+		ln, err := origListen(network, addr)
+		if err == nil {
+			listenersMu.Lock()
+			listeners = append(listeners, ln)
+			listenersMu.Unlock()
+		}
+		return ln, err
+	}
+	defer func() {
+		proxyListen = origListen
+		listenersMu.Lock()
+		defer listenersMu.Unlock()
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	rec1 := httptest.NewRecorder()
+	rec2 := httptest.NewRecorder()
+	go func() {
+		defer wg.Done()
+		srv.handleConnect(rec1, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production"))
+	}()
+
+	select {
+	case <-firstEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first connect did not reach listener creation")
+	}
+
+	go func() {
+		defer wg.Done()
+		srv.handleConnect(rec2, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/connect?env=production"))
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	if got := listenCalls.Load(); got != 1 {
+		t.Fatalf("expected one listener creation for same key, got %d", got)
+	}
+
+	close(releaseFirst)
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("connect calls did not complete")
+	}
+
+	if rec1.Code != http.StatusOK || rec2.Code != http.StatusOK {
+		t.Fatalf("expected both connect calls to return 200, got %d and %d", rec1.Code, rec2.Code)
+	}
+	var resp1, resp2 appProxyEntry
+	if err := json.NewDecoder(rec1.Body).Decode(&resp1); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if resp1.URL != resp2.URL {
+		t.Fatalf("expected one shared proxy URL, got %q and %q", resp1.URL, resp2.URL)
 	}
 }


### PR DESCRIPTION
## Summary
- serialize same-process proxy connect creation so one key only creates one listener
- add a deterministic concurrency regression using a blocked listener seam
- ensure concurrent same-key connects return the same proxy URL instead of leaking an orphan listener

## Root cause
`handleConnect` checked for an existing proxy under lock, dropped the lock, then performed app lookup and `Listen` before storing the entry. Two concurrent requests for the same key could both create listeners and only the last one stayed tracked.

## Validation
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'Test(HandleConnectCreatesOneListenerPerKey|Proxy)' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
