### PR TITLE
[codex] fix deploy environment targeting and auth

### DIFF
--- a/internal/api/deploy.go
+++ b/internal/api/deploy.go
@@ -96,29 +96,46 @@ func (s *Server) Deploy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
+	project, ok := s.getProject(w, r)
+	if !ok {
 		return
 	}
-
 	if req.Environment != "" {
 		if msg := validateDNSLabel("environment", req.Environment, 63); msg != "" {
 			writeJSON(w, http.StatusBadRequest, errorResponse{msg})
 			return
 		}
-		found := false
-		for i := range app.Spec.Environments {
-			if app.Spec.Environments[i].Name == req.Environment {
-				app.Spec.Environments[i].Image = req.Image
-				found = true
-				break
-			}
-		}
-		if !found {
-			writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("environment %q not found in app spec", req.Environment)})
+		if indexOfEnv(project, req.Environment) < 0 {
+			writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
+				"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
+				req.Environment, project.Name, project.Name)})
 			return
 		}
+	}
+
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if p := PrincipalFromContext(r.Context()); p != nil && req.Environment == "" {
+		for _, env := range project.Spec.Environments {
+			if !appParticipatesInEnv(&app, env.Name) {
+				continue
+			}
+			if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName, Environment: env.Name}, authz.ActionUpdate) {
+				return
+			}
+		}
+	}
+	if req.Environment != "" && !appParticipatesInEnv(&app, req.Environment) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("app %q is not enabled in environment %q", app.Name, req.Environment)})
+		return
+	}
+
+	if req.Environment != "" {
+		env := ensureEnvironment(&app, req.Environment)
+		env.Image = req.Image
 	} else {
 		app.Spec.Source.Image = req.Image
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -525,11 +525,178 @@ func TestDeploy(t *testing.T) {
 	}
 }
 
+func TestDeployEnvironmentUpdatesOnlyTargetOverride(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default", "staging", "production")
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "deploy-target",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+			"environments": []map[string]any{
+				{"name": "production", "image": "nginx:1.25.1"},
+			},
+		},
+	})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-target/deploy", map[string]any{
+		"environment": "staging",
+		"image":       "nginx:1.26.0",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("deploy staging: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var app mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "deploy-target", Namespace: "pj-default"}, &app); err != nil {
+		t.Fatalf("get app after deploy: %v", err)
+	}
+	if app.Spec.Source.Image != "nginx:1.25.0" {
+		t.Fatalf("global image changed unexpectedly: got %s", app.Spec.Source.Image)
+	}
+	var stagingImage, productionImage string
+	for _, env := range app.Spec.Environments {
+		switch env.Name {
+		case "staging":
+			stagingImage = env.Image
+		case "production":
+			productionImage = env.Image
+		}
+	}
+	if stagingImage != "nginx:1.26.0" {
+		t.Fatalf("staging image = %q, want nginx:1.26.0", stagingImage)
+	}
+	if productionImage != "nginx:1.25.1" {
+		t.Fatalf("production image changed unexpectedly: got %q", productionImage)
+	}
+}
+
+func TestDeployRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default", "production")
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "deploy-target",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-target/deploy", map[string]any{
+		"environment": "staging",
+		"image":       "nginx:1.26.0",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeployRestrictedEnvironmentRequiresEnvAwareAuthz(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "default", "staging", "production")
+	var project mortisev1alpha1.Project
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "default"}, &project); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	for i := range project.Spec.Environments {
+		if project.Spec.Environments[i].Name == "production" {
+			project.Spec.Environments[i].Restricted = true
+		}
+	}
+	if err := k8sClient.Update(context.Background(), &project); err != nil {
+		t.Fatalf("update project restrictions: %v", err)
+	}
+
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleMember)
+	h := srv.Handler()
+	seedProjectMember(t, k8sClient, "default", "member@example.com", mortisev1alpha1.ProjectRoleDeveloper)
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "deploy-target",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-target/deploy", map[string]any{
+		"environment": "production",
+		"image":       "nginx:1.26.0",
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for restricted env deploy, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeployWithoutEnvironmentIsForbiddenWhenRestrictedEnvParticipates(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "default", "staging", "production")
+	var project mortisev1alpha1.Project
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "default"}, &project); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	for i := range project.Spec.Environments {
+		if project.Spec.Environments[i].Name == "production" {
+			project.Spec.Environments[i].Restricted = true
+		}
+	}
+	if err := k8sClient.Update(context.Background(), &project); err != nil {
+		t.Fatalf("update project restrictions: %v", err)
+	}
+
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleMember)
+	h := srv.Handler()
+	seedProjectMember(t, k8sClient, "default", "member@example.com", mortisev1alpha1.ProjectRoleDeveloper)
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "deploy-target",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-target/deploy", map[string]any{
+		"image": "nginx:1.26.0",
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for global deploy touching restricted envs, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeployRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "deploy-target",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+			"environments": []map[string]any{
+				{"name": "staging", "enabled": disabled},
+			},
+		},
+	})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-target/deploy", map[string]any{
+		"environment": "staging",
+		"image":       "nginx:1.26.0",
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled app env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestDeployPerEnvironment(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
+	seedProject(t, k8sClient, "default", "staging", "production")
 
 	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
 		"name": "env-deploy-target",

--- a/test/helpers/mortise_api.go
+++ b/test/helpers/mortise_api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // LoginAsAdmin returns a Mortise JWT for an admin principal identified by
@@ -95,21 +96,37 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 		return out.Token, status, "", nil
 	}
 
-	for i, c := range loginOrder {
-		token, status, body, err := tryLogin(c)
-		if err != nil {
-			t.Fatalf("mortise: POST /api/auth/login: %v", err)
-		}
-		if status == http.StatusOK {
-			if token == "" {
-				t.Fatal("mortise: empty token in login response")
+	// When another parallel test wins /api/auth/setup first, the loser can
+	// briefly observe 409 from setup before the new admin secret is readable by
+	// /api/auth/login. Retry boundedly instead of failing on that transient 401.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		lastStatus := 0
+		lastBody := ""
+		for i, c := range loginOrder {
+			token, status, body, err := tryLogin(c)
+			if err != nil {
+				t.Fatalf("mortise: POST /api/auth/login: %v", err)
 			}
-			return token
+			if status == http.StatusOK {
+				if token == "" {
+					t.Fatal("mortise: empty token in login response")
+				}
+				return token
+			}
+			lastStatus = status
+			lastBody = body
+			if status == http.StatusUnauthorized && i < len(loginOrder)-1 {
+				continue
+			}
+			if status != http.StatusUnauthorized {
+				t.Fatalf("mortise: POST /api/auth/login status %d: %s", status, body)
+			}
 		}
-		if status == http.StatusUnauthorized && i < len(loginOrder)-1 {
-			continue
+		if time.Now().After(deadline) {
+			t.Fatalf("mortise: POST /api/auth/login status %d: %s", lastStatus, lastBody)
 		}
-		t.Fatalf("mortise: POST /api/auth/login status %d: %s", status, body)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	t.Fatal("mortise: unable to login with available admin credentials")

--- a/test/helpers/mortise_api.go
+++ b/test/helpers/mortise_api.go
@@ -128,7 +128,4 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-
-	t.Fatal("mortise: unable to login with available admin credentials")
-	return ""
 }

--- a/test/helpers/mortise_api_test.go
+++ b/test/helpers/mortise_api_test.go
@@ -64,6 +64,35 @@ func TestLoginAsAdminFallsBackToLoginAfterSetupConflict(t *testing.T) {
 	}
 }
 
+func TestLoginAsAdminRetriesUnauthorizedAfterSetupConflict(t *testing.T) {
+	var loginCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/setup":
+			http.Error(w, `{"error":"setup already complete"}`, http.StatusConflict)
+		case "/api/auth/login":
+			if loginCalls.Add(1) == 1 {
+				http.Error(w, `{"error":"invalid credentials"}`, http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": "login-token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	token := LoginAsAdmin(t, srv.URL, "admin@example.com", "password123")
+	if token != "login-token" {
+		t.Fatalf("expected login token, got %q", token)
+	}
+	if got := loginCalls.Load(); got < 2 {
+		t.Fatalf("expected retry after unauthorized login, got %d call(s)", got)
+	}
+}
+
 func TestLoginAsAdminTreatsSetupAsBestEffort(t *testing.T) {
 	var loginCalls atomic.Int32
 


### PR DESCRIPTION
## Summary
- validate deploy target environments against the project before mutating app state
- write env-targeted deploys to `spec.environments[].image` and synthesize the override when the app participates implicitly
- enforce restricted-env authz for both explicit env deploys and global deploys that would touch restricted environments

## Root cause
The deploy handler had drifted from the app/env model. It validated authz with optional environment context, but it still treated missing app overrides as missing environments and allowed global deploys to bypass restricted-env checks by omitting `environment`.

## Validation
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'TestDeploy' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
