### PR TITLE
[codex] fix pull credential cleanup and ownership

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -588,6 +588,24 @@ definitions:
       to:
         type: string
     type: object
+  api.pullCredentialsRequest:
+    properties:
+      password:
+        type: string
+      registry:
+        type: string
+      username:
+        type: string
+    type: object
+  api.pullCredentialsResponse:
+    properties:
+      hasPassword:
+        type: boolean
+      registry:
+        type: string
+      username:
+        type: string
+    type: object
   api.resetPasswordRequest:
     properties:
       password:
@@ -4277,6 +4295,139 @@ paths:
       summary: Promote an app between environments
       tags:
       - rollback
+  /projects/{project}/apps/{app}/pull-credentials:
+    delete:
+      description: Removes Mortise-managed registry pull credentials from every project
+        environment and clears the App pull secret reference
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete pull credentials for an app
+      tags:
+      - apps
+    get:
+      description: Returns registry pull credential metadata for an app without returning
+        the password value
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.pullCredentialsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get pull credentials for an app
+      tags:
+      - apps
+    post:
+      consumes:
+      - application/json
+      description: Creates or updates Mortise-managed registry pull credentials for
+        every project environment and records the reserved pull secret on the App
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      - description: Registry pull credentials
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.pullCredentialsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.pullCredentialsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set pull credentials for an app
+      tags:
+      - apps
   /projects/{project}/apps/{app}/rebuild:
     post:
       description: Resolve the current branch head, sync mortise.dev/revision to that
@@ -5044,8 +5195,9 @@ paths:
       consumes:
       - application/json
       description: 'Creates a new environment pre-populated with the source''s config
-        (CRD overrides + Secret-level env vars) for every app. Retry-safe: returns
-        200 if the target already exists.'
+        for every app. CRD overrides are cloned on the App, while Secret-backed env
+        vars remain in the Secret layer. Retry-safe: returns 200 if the target already
+        exists.'
       parameters:
       - description: Project name
         in: path

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,7 +17,6 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
-	"github.com/mortise-org/mortise/internal/constants"
 )
 
 // normalizeRepoURL expands short-form "owner/repo" strings to a full git URL.
@@ -320,14 +318,6 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
-	project, ok := s.getProject(w, r)
-	if !ok {
-		return
-	}
-	if err := s.deleteAppPullSecrets(r.Context(), project, app.Name); err != nil {
-		writeError(w, r, err)
-		return
-	}
 
 	if err := s.client.Delete(r.Context(), &app); err != nil {
 		writeError(w, r, err)
@@ -337,28 +327,6 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, projectName, "delete", "app", app.Name, "Deleted app "+app.Name, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
-}
-
-func (s *Server) deleteAppPullSecrets(ctx context.Context, project *mortisev1alpha1.Project, appName string) error {
-	secretName := pullSecretName(appName)
-	for _, env := range project.Spec.Environments {
-		envNs := constants.EnvNamespace(project.Name, env.Name)
-		var secret corev1.Secret
-		err := s.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: envNs}, &secret)
-		if errors.IsNotFound(err) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		if secret.Labels["app.kubernetes.io/managed-by"] != "mortise" {
-			continue
-		}
-		if err := s.client.Delete(ctx, &secret); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
 }
 
 // writeError maps k8s API errors to HTTP status codes.

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +18,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
+	"github.com/mortise-org/mortise/internal/constants"
 )
 
 // normalizeRepoURL expands short-form "owner/repo" strings to a full git URL.
@@ -318,6 +320,14 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return
+	}
+	if err := s.deleteAppPullSecrets(r.Context(), project, app.Name); err != nil {
+		writeError(w, r, err)
+		return
+	}
 
 	if err := s.client.Delete(r.Context(), &app); err != nil {
 		writeError(w, r, err)
@@ -327,6 +337,28 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, projectName, "delete", "app", app.Name, "Deleted app "+app.Name, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) deleteAppPullSecrets(ctx context.Context, project *mortisev1alpha1.Project, appName string) error {
+	secretName := pullSecretName(appName)
+	for _, env := range project.Spec.Environments {
+		envNs := constants.EnvNamespace(project.Name, env.Name)
+		var secret corev1.Secret
+		err := s.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: envNs}, &secret)
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if secret.Labels["app.kubernetes.io/managed-by"] != "mortise" {
+			continue
+		}
+		if err := s.client.Delete(ctx, &secret); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // writeError maps k8s API errors to HTTP status codes.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -588,6 +588,24 @@ definitions:
       to:
         type: string
     type: object
+  api.pullCredentialsRequest:
+    properties:
+      password:
+        type: string
+      registry:
+        type: string
+      username:
+        type: string
+    type: object
+  api.pullCredentialsResponse:
+    properties:
+      hasPassword:
+        type: boolean
+      registry:
+        type: string
+      username:
+        type: string
+    type: object
   api.resetPasswordRequest:
     properties:
       password:
@@ -4277,6 +4295,139 @@ paths:
       summary: Promote an app between environments
       tags:
       - rollback
+  /projects/{project}/apps/{app}/pull-credentials:
+    delete:
+      description: Removes Mortise-managed registry pull credentials from every project
+        environment and clears the App pull secret reference
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete pull credentials for an app
+      tags:
+      - apps
+    get:
+      description: Returns registry pull credential metadata for an app without returning
+        the password value
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.pullCredentialsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get pull credentials for an app
+      tags:
+      - apps
+    post:
+      consumes:
+      - application/json
+      description: Creates or updates Mortise-managed registry pull credentials for
+        every project environment and records the reserved pull secret on the App
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      - description: Registry pull credentials
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.pullCredentialsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.pullCredentialsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set pull credentials for an app
+      tags:
+      - apps
   /projects/{project}/apps/{app}/rebuild:
     post:
       description: Resolve the current branch head, sync mortise.dev/revision to that
@@ -5044,8 +5195,9 @@ paths:
       consumes:
       - application/json
       description: 'Creates a new environment pre-populated with the source''s config
-        (CRD overrides + Secret-level env vars) for every app. Retry-safe: returns
-        200 if the target already exists.'
+        for every app. CRD overrides are cloned on the App, while Secret-backed env
+        vars remain in the Secret layer. Retry-safe: returns 200 if the target already
+        exists.'
       parameters:
       - description: Project name
         in: path

--- a/internal/api/pull_credentials.go
+++ b/internal/api/pull_credentials.go
@@ -69,6 +69,22 @@ func buildDockerConfigJSON(registry, username, password string) []byte {
 
 // SetPullCredentials creates or updates a dockerconfigjson Secret in every env
 // namespace for the app, then sets PullSecretRef on the App CRD.
+// @Summary Set pull credentials for an app
+// @Description Creates or updates Mortise-managed registry pull credentials for every project environment and records the reserved pull secret on the App
+// @Tags apps
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param app path string true "App name"
+// @Param body body pullCredentialsRequest true "Registry pull credentials"
+// @Success 200 {object} pullCredentialsResponse
+// @Failure 400 {object} errorResponse
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Failure 409 {object} errorResponse
+// @Router /projects/{project}/apps/{app}/pull-credentials [post]
 func (s *Server) SetPullCredentials(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {
@@ -161,6 +177,18 @@ func (s *Server) SetPullCredentials(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetPullCredentials returns pull credential metadata (never the password).
+// @Summary Get pull credentials for an app
+// @Description Returns registry pull credential metadata for an app without returning the password value
+// @Tags apps
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param app path string true "App name"
+// @Success 200 {object} pullCredentialsResponse
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project}/apps/{app}/pull-credentials [get]
 func (s *Server) GetPullCredentials(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {
@@ -213,6 +241,18 @@ func (s *Server) GetPullCredentials(w http.ResponseWriter, r *http.Request) {
 
 // DeletePullCredentials removes the Mortise-managed pull secret from all env
 // namespaces and clears PullSecretRef on the App CRD.
+// @Summary Delete pull credentials for an app
+// @Description Removes Mortise-managed registry pull credentials from every project environment and clears the App pull secret reference
+// @Tags apps
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param app path string true "App name"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} errorResponse
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project}/apps/{app}/pull-credentials [delete]
 func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {

--- a/internal/api/pull_credentials.go
+++ b/internal/api/pull_credentials.go
@@ -3,11 +3,12 @@ package api
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 )
+
+var errPullSecretOwnedByUser = errors.New("reserved pull secret already exists and is not Mortise-managed")
 
 // pullCredentialsRequest is the JSON body for setting pull credentials.
 type pullCredentialsRequest struct {
@@ -112,7 +115,11 @@ func (s *Server) SetPullCredentials(w http.ResponseWriter, r *http.Request) {
 	// Create or update the pull secret in each env namespace.
 	for _, env := range project.Spec.Environments {
 		envNs := constants.EnvNamespace(projectName, env.Name)
-		if err := s.upsertPullSecret(r, envNs, secretName, appName, dockerJSON); err != nil {
+		if err := s.upsertPullSecret(r, envNs, secretName, projectName, appName, env.Name, dockerJSON); err != nil {
+			if errors.Is(err, errPullSecretOwnedByUser) {
+				writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
+				return
+			}
 			writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to create pull secret in " + envNs + ": " + err.Error()})
 			return
 		}
@@ -145,6 +152,11 @@ func (s *Server) GetPullCredentials(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	appName := chi.URLParam(r, "app")
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
 
 	// Get project to find an env namespace to read the secret from.
 	project, ok := s.getProject(w, r)
@@ -161,7 +173,7 @@ func (s *Server) GetPullCredentials(w http.ResponseWriter, r *http.Request) {
 
 	var secret corev1.Secret
 	err := s.client.Get(r.Context(), types.NamespacedName{Name: secretName, Namespace: envNs}, &secret)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		writeJSON(w, http.StatusOK, pullCredentialsResponse{})
 		return
 	}
@@ -211,7 +223,7 @@ func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 		envNs := constants.EnvNamespace(projectName, env.Name)
 		var secret corev1.Secret
 		err := s.client.Get(r.Context(), types.NamespacedName{Name: secretName, Namespace: envNs}, &secret)
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {
@@ -221,7 +233,7 @@ func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 		if secret.Labels["app.kubernetes.io/managed-by"] != "mortise" {
 			continue
 		}
-		if err := s.client.Delete(r.Context(), &secret); err != nil && !errors.IsNotFound(err) {
+		if err := s.client.Delete(r.Context(), &secret); err != nil && !apierrors.IsNotFound(err) {
 			writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to delete pull secret: " + err.Error()})
 			return
 		}
@@ -243,13 +255,15 @@ func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 }
 
 // upsertPullSecret creates or updates a dockerconfigjson Secret.
-func (s *Server) upsertPullSecret(r *http.Request, namespace, name, appName string, dockerJSON []byte) error {
+func (s *Server) upsertPullSecret(r *http.Request, namespace, name, projectName, appName, envName string, dockerJSON []byte) error {
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
 				constants.AppNameLabel:         appName,
+				constants.ProjectLabel:         projectName,
+				constants.EnvironmentLabel:     envName,
 				"app.kubernetes.io/managed-by": "mortise",
 			},
 		},
@@ -261,11 +275,14 @@ func (s *Server) upsertPullSecret(r *http.Request, namespace, name, appName stri
 
 	var existing corev1.Secret
 	err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: namespace}, &existing)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return s.client.Create(r.Context(), desired)
 	}
 	if err != nil {
 		return err
+	}
+	if existing.Labels["app.kubernetes.io/managed-by"] != "mortise" {
+		return errPullSecretOwnedByUser
 	}
 
 	existing.Data = desired.Data

--- a/internal/api/pull_credentials.go
+++ b/internal/api/pull_credentials.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
@@ -112,6 +113,18 @@ func (s *Server) SetPullCredentials(w http.ResponseWriter, r *http.Request) {
 	secretName := pullSecretName(appName)
 	dockerJSON := buildDockerConfigJSON(req.Registry, req.Username, req.Password)
 
+	for _, env := range project.Spec.Environments {
+		envNs := constants.EnvNamespace(projectName, env.Name)
+		if err := s.ensureReservedPullSecretAvailable(r, envNs, secretName); err != nil {
+			if errors.Is(err, errPullSecretOwnedByUser) {
+				writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to validate pull secret in " + envNs + ": " + err.Error()})
+			return
+		}
+	}
+
 	// Create or update the pull secret in each env namespace.
 	for _, env := range project.Spec.Environments {
 		envNs := constants.EnvNamespace(projectName, env.Name)
@@ -126,8 +139,13 @@ func (s *Server) SetPullCredentials(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set PullSecretRef on the App CRD.
-	app.Spec.Source.PullSecretRef = secretName
-	if err := s.client.Update(r.Context(), &app); err != nil {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+			return err
+		}
+		app.Spec.Source.PullSecretRef = secretName
+		return s.client.Update(r.Context(), &app)
+	}); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -252,6 +270,21 @@ func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 		"Removed pull credentials for "+appName, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) ensureReservedPullSecretAvailable(r *http.Request, namespace, name string) error {
+	var existing corev1.Secret
+	err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: namespace}, &existing)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if existing.Labels["app.kubernetes.io/managed-by"] != "mortise" {
+		return errPullSecretOwnedByUser
+	}
+	return nil
 }
 
 // upsertPullSecret creates or updates a dockerconfigjson Secret.

--- a/internal/api/pull_credentials_test.go
+++ b/internal/api/pull_credentials_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/mortise-org/mortise/internal/constants"
 )
 
-func TestPullCredentialsCRUDAndDeleteAppCleanup(t *testing.T) {
+func TestPullCredentialsCRUDAndDeleteAppDefersCleanupToController(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
@@ -76,8 +77,8 @@ func TestPullCredentialsCRUDAndDeleteAppCleanup(t *testing.T) {
 			Name:      "web-pull-secret",
 			Namespace: constants.EnvNamespace("default", env),
 		}, &secret)
-		if err == nil {
-			t.Fatalf("expected pull secret for %s to be deleted", env)
+		if err != nil {
+			t.Fatalf("expected pull secret for %s to remain until controller GC, got %v", env, err)
 		}
 	}
 }
@@ -86,9 +87,10 @@ func TestSetPullCredentialsRejectsUserManagedReservedSecret(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
+	const projectName = "reserved-secret-conflict"
+	seedProject(t, k8sClient, projectName)
 
-	create := doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+	create := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps", map[string]any{
 		"name": "web",
 		"spec": map[string]any{
 			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
@@ -101,7 +103,7 @@ func TestSetPullCredentialsRejectsUserManagedReservedSecret(t *testing.T) {
 	userSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "web-pull-secret",
-			Namespace: constants.EnvNamespace("default", "production"),
+			Namespace: constants.EnvNamespace(projectName, "production"),
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"example.com":{"username":"user","password":"pw"}}}`)},
@@ -110,7 +112,7 @@ func TestSetPullCredentialsRejectsUserManagedReservedSecret(t *testing.T) {
 		t.Fatalf("create user-managed secret: %v", err)
 	}
 
-	set := doRequest(h, http.MethodPost, "/api/projects/default/apps/web/pull-credentials", map[string]any{
+	set := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps/web/pull-credentials", map[string]any{
 		"registry": "ghcr.io",
 		"username": "octo",
 		"password": "secret",
@@ -120,11 +122,88 @@ func TestSetPullCredentialsRejectsUserManagedReservedSecret(t *testing.T) {
 	}
 
 	var secret corev1.Secret
-	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "web-pull-secret", Namespace: constants.EnvNamespace("default", "production")}, &secret); err != nil {
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "web-pull-secret", Namespace: constants.EnvNamespace(projectName, "production")}, &secret); err != nil {
 		t.Fatalf("get user-managed secret: %v", err)
 	}
 	if secret.Labels["app.kubernetes.io/managed-by"] == "mortise" {
 		t.Fatal("user-managed secret was unexpectedly adopted")
+	}
+}
+
+func TestSetPullCredentialsPreflightsAllEnvironmentsBeforeWriting(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	const projectName = "reserved-secret-preflight"
+	seedProject(t, k8sClient, projectName, "staging", "production")
+
+	create := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps", map[string]any{
+		"name": "web",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create app: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	userSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-pull-secret",
+			Namespace: constants.EnvNamespace(projectName, "production"),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"example.com":{"username":"user","password":"pw"}}}`)},
+	}
+	if err := k8sClient.Create(context.Background(), userSecret); err != nil {
+		t.Fatalf("create conflicting user-managed secret: %v", err)
+	}
+
+	set := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps/web/pull-credentials", map[string]any{
+		"registry": "ghcr.io",
+		"username": "octo",
+		"password": "secret",
+	})
+	if set.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for user-managed reserved secret, got %d: %s", set.Code, set.Body.String())
+	}
+
+	for _, env := range []string{"staging", "production"} {
+		var secret corev1.Secret
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      "web-pull-secret",
+			Namespace: constants.EnvNamespace(projectName, env),
+		}, &secret)
+		if env == "staging" {
+			if !apierrors.IsNotFound(err) {
+				t.Fatalf("expected staging secret to remain untouched, got %v", err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("get conflicting production secret: %v", err)
+		}
+		if secret.Labels["app.kubernetes.io/managed-by"] == "mortise" {
+			t.Fatal("user-managed production secret was unexpectedly adopted")
+		}
+	}
+
+	var app struct {
+		Spec struct {
+			Source struct {
+				PullSecretRef string `json:"pullSecretRef"`
+			} `json:"source"`
+		} `json:"spec"`
+	}
+	getApp := doRequest(h, http.MethodGet, "/api/projects/"+projectName+"/apps/web", nil)
+	if getApp.Code != http.StatusOK {
+		t.Fatalf("get app: expected 200, got %d: %s", getApp.Code, getApp.Body.String())
+	}
+	if err := json.NewDecoder(getApp.Body).Decode(&app); err != nil {
+		t.Fatalf("decode app: %v", err)
+	}
+	if app.Spec.Source.PullSecretRef != "" {
+		t.Fatalf("pullSecretRef = %q, want empty on conflict", app.Spec.Source.PullSecretRef)
 	}
 }
 

--- a/internal/api/pull_credentials_test.go
+++ b/internal/api/pull_credentials_test.go
@@ -1,0 +1,157 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+func TestPullCredentialsCRUDAndDeleteAppCleanup(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default", "staging", "production")
+
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "web",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create app: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	set := doRequest(h, http.MethodPost, "/api/projects/default/apps/web/pull-credentials", map[string]any{
+		"registry": "ghcr.io",
+		"username": "octo",
+		"password": "secret",
+	})
+	if set.Code != http.StatusOK {
+		t.Fatalf("set pull credentials: expected 200, got %d: %s", set.Code, set.Body.String())
+	}
+
+	for _, env := range []string{"staging", "production"} {
+		var secret corev1.Secret
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      "web-pull-secret",
+			Namespace: constants.EnvNamespace("default", env),
+		}, &secret)
+		if err != nil {
+			t.Fatalf("get pull secret for %s: %v", env, err)
+		}
+		if secret.Labels[constants.ProjectLabel] != "default" {
+			t.Fatalf("pull secret project label = %q, want default", secret.Labels[constants.ProjectLabel])
+		}
+		if secret.Labels[constants.EnvironmentLabel] != env {
+			t.Fatalf("pull secret env label = %q, want %s", secret.Labels[constants.EnvironmentLabel], env)
+		}
+	}
+
+	get := doRequest(h, http.MethodGet, "/api/projects/default/apps/web/pull-credentials", nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("get pull credentials: expected 200, got %d: %s", get.Code, get.Body.String())
+	}
+	var resp map[string]any
+	_ = json.NewDecoder(get.Body).Decode(&resp)
+	if resp["registry"] != "ghcr.io" || resp["username"] != "octo" {
+		t.Fatalf("unexpected pull credentials response: %+v", resp)
+	}
+
+	del := doRequest(h, http.MethodDelete, "/api/projects/default/apps/web", nil)
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete app: expected 200, got %d: %s", del.Code, del.Body.String())
+	}
+
+	for _, env := range []string{"staging", "production"} {
+		var secret corev1.Secret
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      "web-pull-secret",
+			Namespace: constants.EnvNamespace("default", env),
+		}, &secret)
+		if err == nil {
+			t.Fatalf("expected pull secret for %s to be deleted", env)
+		}
+	}
+}
+
+func TestSetPullCredentialsRejectsUserManagedReservedSecret(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "web",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create app: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	userSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-pull-secret",
+			Namespace: constants.EnvNamespace("default", "production"),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"example.com":{"username":"user","password":"pw"}}}`)},
+	}
+	if err := k8sClient.Create(context.Background(), userSecret); err != nil {
+		t.Fatalf("create user-managed secret: %v", err)
+	}
+
+	set := doRequest(h, http.MethodPost, "/api/projects/default/apps/web/pull-credentials", map[string]any{
+		"registry": "ghcr.io",
+		"username": "octo",
+		"password": "secret",
+	})
+	if set.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for user-managed reserved secret, got %d: %s", set.Code, set.Body.String())
+	}
+
+	var secret corev1.Secret
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "web-pull-secret", Namespace: constants.EnvNamespace("default", "production")}, &secret); err != nil {
+		t.Fatalf("get user-managed secret: %v", err)
+	}
+	if secret.Labels["app.kubernetes.io/managed-by"] == "mortise" {
+		t.Fatal("user-managed secret was unexpectedly adopted")
+	}
+}
+
+func TestGetPullCredentialsMissingAppReturns404(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+
+	staleSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ghost-pull-secret",
+			Namespace: constants.EnvNamespace("default", "production"),
+			Labels: map[string]string{
+				constants.AppNameLabel:         "ghost",
+				"app.kubernetes.io/managed-by": "mortise",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"ghcr.io":{"username":"octo","password":"pw"}}}`)},
+	}
+	if err := k8sClient.Create(context.Background(), staleSecret); err != nil {
+		t.Fatalf("create stale secret: %v", err)
+	}
+
+	get := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/pull-credentials", nil)
+	if get.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing app, got %d: %s", get.Code, get.Body.String())
+	}
+}

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -47,6 +47,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/build"
+	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/envstore"
 	"github.com/mortise-org/mortise/internal/git"
 	"github.com/mortise-org/mortise/internal/ingress"
@@ -336,6 +337,31 @@ var _ = Describe("App Controller", func() {
 			}, &dep)).To(Succeed())
 			Expect(dep.ResourceVersion).To(Equal(rvBefore))
 			Expect(dep.Spec.Template.Spec.Volumes).To(BeNil())
+		})
+
+		It("collects Mortise-managed pull secrets during finalizer GC", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName + "-pull-secret",
+					Namespace: envNsProduction,
+					Labels: map[string]string{
+						constants.AppNameLabel:         appName,
+						constants.ProjectLabel:         "default-project",
+						constants.EnvironmentLabel:     "production",
+						"app.kubernetes.io/managed-by": "mortise",
+					},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"ghcr.io":{"username":"octo","password":"pw"}}}`)},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			Expect(reconciler.gcAppAcrossEnvs(ctx, app)).To(Succeed())
+
+			var got corev1.Secret
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: envNsProduction}, &got)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expected pull secret to be deleted, got %v", err)
 		})
 
 		It("should create an Ingress with TLS for the domain", func() {


### PR DESCRIPTION
## Summary
- clean up Mortise-managed pull credential secrets when apps are deleted
- prevent reserved pull secret takeover when a user-managed secret already exists
- return `404` for pull credential reads on missing apps and cover the behavior with API/controller tests

## Testing
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api ./internal/controller -run 'TestPullCredentials|TestGetPullCredentialsMissingAppReturns404|TestSetPullCredentialsRejectsUserManagedReservedSecret' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api ./internal/controller -count=1`
