### PR TITLE
[codex] fix logs and activity environment validation

### DIFF
--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -107,13 +107,9 @@ func (s *Server) ListPlatformActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	perProject := limit
-	if len(projects) > 1 {
-		perProject = max(limit/len(projects), 1)
-	}
 	var merged []activity.Event
 	for _, project := range projects {
-		events, err := s.activityStore.List(r.Context(), project, perProject)
+		events, err := s.activityStore.List(r.Context(), project, limit)
 		if err != nil {
 			writeError(w, r, err)
 			return

--- a/internal/api/activity_test.go
+++ b/internal/api/activity_test.go
@@ -215,6 +215,61 @@ func TestListPlatformActivityMergedAcrossProjects(t *testing.T) {
 	}
 }
 
+func TestListPlatformActivityReturnsNewestEventsGlobally(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	seedProject(t, k8sClient, "alpha")
+	seedProject(t, k8sClient, "beta")
+	store := activity.NewConfigMapStore(k8sClient)
+	base := time.Now()
+	for i := 0; i < 10; i++ {
+		if err := store.Append(context.Background(), activity.Event{
+			Timestamp:    base.Add(time.Duration(10-i) * time.Minute),
+			Actor:        "a@example.com",
+			Action:       "deploy",
+			ResourceKind: "app",
+			ResourceName: "api",
+			Project:      "alpha",
+			Message:      "Alpha event",
+		}); err != nil {
+			t.Fatalf("append alpha event %d: %v", i, err)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		if err := store.Append(context.Background(), activity.Event{
+			Timestamp:    base.Add(time.Duration(-(i + 1)) * time.Hour),
+			Actor:        "b@example.com",
+			Action:       "deploy",
+			ResourceKind: "app",
+			ResourceName: "web",
+			Project:      "beta",
+			Message:      "Beta event",
+		}); err != nil {
+			t.Fatalf("append beta event %d: %v", i, err)
+		}
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/activity?limit=10", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var events []activityEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&events); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(events) != 10 {
+		t.Fatalf("expected 10 events, got %d", len(events))
+	}
+	for i, event := range events {
+		if event.Project != "alpha" {
+			t.Fatalf("event %d project = %q, want alpha for all newest events", i, event.Project)
+		}
+	}
+}
+
 func TestListPlatformActivityHonorsProjectAccess(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv, _ := newTestServerAs(t, k8sClient, auth.RoleMember)

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -492,6 +492,34 @@ func (s *Server) resolveAppEnv(w http.ResponseWriter, r *http.Request) (*mortise
 	return &app, env, true
 }
 
+// resolveDefaultedAppEnv validates the defaulted env query against the
+// project declaration and the app's explicit opt-out rules.
+func (s *Server) resolveDefaultedAppEnv(w http.ResponseWriter, r *http.Request) (*mortisev1alpha1.App, string, bool) {
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return nil, "", false
+	}
+	appName := chi.URLParam(r, "app")
+	env := envFromQuery(r)
+	if indexOfEnv(project, env) < 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
+			"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
+			env, project.Name, project.Name)})
+		return nil, "", false
+	}
+
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: projectNs(project)}, &app); err != nil {
+		writeError(w, r, err)
+		return nil, "", false
+	}
+	if !appParticipatesInEnv(&app, env) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("environment %q is disabled for app %q", env, appName)})
+		return nil, "", false
+	}
+	return &app, env, true
+}
+
 // ensureEnvironment returns a pointer to the named environment, creating it if
 // it doesn't exist.
 func ensureEnvironment(app *mortisev1alpha1.App, name string) *mortisev1alpha1.Environment {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -79,28 +79,30 @@ func (s *Server) handleBuildLogs(w http.ResponseWriter, r *http.Request) {
 	key := types.NamespacedName{Namespace: ns, Name: name}
 
 	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), key, &app); err == nil {
-		if app.Status.Phase == mortisev1alpha1.AppPhaseBuilding || app.Status.CurrentBuildRunName != "" {
-			if run, err := s.resolveCurrentAppBuildRun(r.Context(), ns, &app); err == nil && run != nil {
-				if resp, ok, err := s.getBuildRunLogsResponse(r.Context(), run); err == nil && ok {
-					writeJSON(w, http.StatusOK, resp)
-					return
-				}
-			}
-		}
-		if app.Status.Phase != mortisev1alpha1.AppPhaseBuilding && app.Status.LastBuildRunName != "" {
-			if run, err := s.resolveLastAppBuildRun(r.Context(), ns, &app, ""); err == nil && run != nil {
-				if resp, ok, err := s.getBuildRunLogsResponse(r.Context(), run); err == nil && ok {
-					writeJSON(w, http.StatusOK, resp)
-					return
-				}
-			}
-		}
-		if run, err := s.resolveLastAppBuildRun(r.Context(), ns, &app, app.Status.CurrentBuildRunName); err == nil && run != nil {
+	if err := s.client.Get(r.Context(), key, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if app.Status.Phase == mortisev1alpha1.AppPhaseBuilding || app.Status.CurrentBuildRunName != "" {
+		if run, err := s.resolveCurrentAppBuildRun(r.Context(), ns, &app); err == nil && run != nil {
 			if resp, ok, err := s.getBuildRunLogsResponse(r.Context(), run); err == nil && ok {
 				writeJSON(w, http.StatusOK, resp)
 				return
 			}
+		}
+	}
+	if app.Status.Phase != mortisev1alpha1.AppPhaseBuilding && app.Status.LastBuildRunName != "" {
+		if run, err := s.resolveLastAppBuildRun(r.Context(), ns, &app, ""); err == nil && run != nil {
+			if resp, ok, err := s.getBuildRunLogsResponse(r.Context(), run); err == nil && ok {
+				writeJSON(w, http.StatusOK, resp)
+				return
+			}
+		}
+	}
+	if run, err := s.resolveLastAppBuildRun(r.Context(), ns, &app, app.Status.CurrentBuildRunName); err == nil && run != nil {
+		if resp, ok, err := s.getBuildRunLogsResponse(r.Context(), run); err == nil && ok {
+			writeJSON(w, http.StatusOK, resp)
+			return
 		}
 	}
 
@@ -140,13 +142,15 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionRead) {
 		return
 	}
-	ns, projectName, ok := s.resolveProject(w, r)
+	_, projectName, ok := s.resolveProject(w, r)
 	if !ok {
 		return
 	}
-	name := chi.URLParam(r, "app")
-
-	env := envFromQuery(r)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
+		return
+	}
+	name := app.Name
 	follow := r.URL.Query().Get("follow") == "true"
 	previous := r.URL.Query().Get("previous") == "true"
 	pinnedPod := r.URL.Query().Get("pod")
@@ -174,13 +178,6 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 	// If both are set, prefer sinceTime and drop sinceSeconds.
 	if sinceTime != nil {
 		sinceSeconds = nil
-	}
-
-	// Resolve the App CRD (404 if missing). CRD lives in the control ns.
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
-		return
 	}
 
 	// Workload pods live in the per-env namespace.

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -778,3 +778,51 @@ func TestHandleBuildLogsNoTrackerNoConfigMap(t *testing.T) {
 		t.Errorf("expected empty lines, got %v", linesAny)
 	}
 }
+
+func TestHandleBuildLogsMissingAppReturns404EvenWithLegacyConfigMap(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	nsName := seedProject(t, k8sClient, "default")
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buildlogs-ghost",
+			Namespace: nsName,
+			Annotations: map[string]string{
+				"mortise.dev/build-status": "Succeeded",
+			},
+		},
+		Data: map[string]string{"lines": "stale line"},
+	}
+	if err := k8sClient.Create(context.Background(), cm); err != nil {
+		t.Fatalf("create stale configmap: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/build-logs", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing app, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleLogsRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "logs-env-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/logs-env-app/logs?env=staging", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
-	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/platformconfig"
@@ -60,18 +58,15 @@ func (s *Server) handleMetricsCurrent(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionRead) {
 		return
 	}
-	ns, projectName, ok := s.resolveProject(w, r)
+	_, projectName, ok := s.resolveProject(w, r)
 	if !ok {
 		return
 	}
-	name := chi.URLParam(r, "app")
-	env := envFromQuery(r)
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
 		return
 	}
+	name := app.Name
 
 	if current, ok, err := s.currentMetricsFromAdapter(r, projectName, name, env); err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{"available": false, "error": err.Error()})
@@ -204,23 +199,20 @@ func (s *Server) handleMetricsHistory(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionRead) {
 		return
 	}
-	ns, projectName, ok := s.resolveProject(w, r)
+	_, projectName, ok := s.resolveProject(w, r)
 	if !ok {
 		return
 	}
-	name := chi.URLParam(r, "app")
-	env := envFromQuery(r)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
+		return
+	}
+	name := app.Name
 
 	start := r.URL.Query().Get("start")
 	end := r.URL.Query().Get("end")
 	if start == "" || end == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"start and end are required"})
-		return
-	}
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
 		return
 	}
 
@@ -279,23 +271,20 @@ func (s *Server) handleLogHistory(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionRead) {
 		return
 	}
-	ns, projectName, ok := s.resolveProject(w, r)
+	_, projectName, ok := s.resolveProject(w, r)
 	if !ok {
 		return
 	}
-	name := chi.URLParam(r, "app")
-	env := envFromQuery(r)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
+		return
+	}
+	name := app.Name
 
 	start := r.URL.Query().Get("start")
 	end := r.URL.Query().Get("end")
 	if start == "" || end == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"start and end are required"})
-		return
-	}
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
 		return
 	}
 

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -265,6 +265,28 @@ func TestMetricsCurrentNonexistentProject(t *testing.T) {
 	}
 }
 
+func TestMetricsCurrentRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "mc-bad-env", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/mc-bad-env/metrics/current?env=staging", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestMetricsCurrentRequiresAuth(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
@@ -486,6 +508,28 @@ func TestMetricsHistoryNonexistentApp(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/metrics?env=production&start=1700000000&end=1700003600", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMetricsHistoryRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "mh-bad-env", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/mh-bad-env/metrics?env=staging&start=1700000000&end=1700003600", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -758,6 +802,28 @@ func TestLogHistoryNonexistentApp(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/logs/history?env=production&start=1700000000&end=1700003600", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLogHistoryRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "lh-bad-env", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/lh-bad-env/logs/history?env=staging&start=1700000000&end=1700003600", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject undeclared or disabled environments across app observability endpoints instead of proxying/streating them as live namespaces
- return `404` for app build-log requests after the app is gone even if stale legacy log ConfigMaps remain
- return the globally newest platform activity events instead of sampling each project evenly first

## Testing
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'Test(ListPlatformActivityReturnsNewestEventsGlobally|HandleBuildLogsMissingAppReturns404EvenWithLegacyConfigMap|HandleLogsRejectsUndeclaredEnvironment|MetricsCurrentRejectsUndeclaredEnvironment|MetricsHistoryRejectsUndeclaredEnvironment|LogHistoryRejectsUndeclaredEnvironment)' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
