### PR TITLE
[codex] fix webhook provider routing and preview cleanup

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -164,6 +164,9 @@ func (h *Handler) dispatchToApps(ctx context.Context, br BuildRequest) {
 		if src.Type != mortisev1alpha1.SourceTypeGit {
 			continue
 		}
+		if src.ProviderRef != "" && src.ProviderRef != br.Provider {
+			continue
+		}
 		if !repoMatches(src.Repo, br.Repo) {
 			continue
 		}
@@ -215,6 +218,9 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 		if src.Type != mortisev1alpha1.SourceTypeGit {
 			continue
 		}
+		if src.ProviderRef != "" && src.ProviderRef != pr.Provider {
+			continue
+		}
 		if !repoMatches(src.Repo, pr.Repo) {
 			continue
 		}
@@ -244,6 +250,13 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 		}
 		preview := project.Spec.Preview
 		if preview == nil || !preview.Enabled {
+			if pr.Action == "closed" {
+				if err := h.deletePreviewForPR(ctx, app, pr.Number); err != nil {
+					log.Error(err, "delete preview after close with previews disabled", "app", app.Name, "project", projectName, "number", pr.Number)
+					continue
+				}
+				matched++
+			}
 			continue
 		}
 
@@ -287,6 +300,26 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 	if matched == 0 {
 		log.Info("no matching apps for PR event", "repo", pr.Repo, "number", pr.Number)
 	}
+}
+
+func (h *Handler) deletePreviewForPR(ctx context.Context, app *mortisev1alpha1.App, number int) error {
+	if app == nil || number == 0 {
+		return nil
+	}
+	existing, err := h.k8s.listPreviewEnvironments(ctx, app.Namespace)
+	if err != nil {
+		return err
+	}
+	for i := range existing {
+		pe := &existing[i]
+		if pe.Spec.AppRef != app.Name || pe.Spec.PullRequest.Number != number {
+			continue
+		}
+		if err := h.k8s.deletePreviewEnvironment(ctx, pe); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func filterClosedPR(openPRs []git.PullRequestSnapshot, closedNumber int) []git.PullRequestSnapshot {

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -594,6 +594,48 @@ func TestWebhook_WatchPathsGating(t *testing.T) {
 	}
 }
 
+func TestWebhook_PushHonorsProviderRef(t *testing.T) {
+	const secret = "secret"
+
+	providerAApp := makeGitApp("app-a", "pj-a", "https://github.com/org/repo", "main")
+	providerAApp.Spec.Source.ProviderRef = "provider-a"
+	providerBApp := makeGitApp("app-b", "pj-a", "https://github.com/org/repo", "main")
+	providerBApp.Spec.Source.ProviderRef = "provider-b"
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"ref":   "refs/heads/main",
+		"after": "sha-provider-a",
+		"repository": map[string]string{
+			"full_name": "org/repo",
+		},
+	})
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	kr := &fakeK8sReader{
+		provider: gp,
+		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
+		apps:     []mortisev1alpha1.App{providerAApp, providerBApp},
+	}
+	h := New(kr)
+
+	req := httptest.NewRequest(http.MethodPost, "/provider-a", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := kr.patched["pj-a/app-a"]; got != "sha-provider-a" {
+		t.Fatalf("provider-a app patched sha = %q, want sha-provider-a", got)
+	}
+	if _, ok := kr.patched["pj-a/app-b"]; ok {
+		t.Fatalf("provider-b app should not be patched from provider-a webhook: %+v", kr.patched)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // PR event tests
 // ---------------------------------------------------------------------------
@@ -872,6 +914,103 @@ func TestPREvent_ProjectPreviewDisabled_NoPECreated(t *testing.T) {
 	}
 	if len(kr2.createdPreviews) != 0 {
 		t.Errorf("expected no PE created with preview.enabled=false, got %d", len(kr2.createdPreviews))
+	}
+}
+
+func TestPREvent_OpenedHonorsProviderRef(t *testing.T) {
+	const secret = "prsecret"
+	body := githubPRPayloadJSON("opened", 42, "feature/x", "shaopened", "org/repo")
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	appA, proj := makePreviewGitApp("app-a", "pj-default", "https://github.com/org/repo", "main", "pr-{number}.{app}.example.com", "24h")
+	appA.Spec.Source.ProviderRef = "provider-a"
+	appB, _ := makePreviewGitApp("app-b", "pj-default", "https://github.com/org/repo", "main", "pr-{number}.{app}.example.com", "24h")
+	appB.Spec.Source.ProviderRef = "provider-b"
+
+	kr := &fakeK8sReader{
+		provider: gp,
+		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
+		apps:     []mortisev1alpha1.App{appA, appB},
+		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+		openPRs:  []git.PullRequestSnapshot{{Number: 42, Branch: "feature/x", SHA: "shaopened"}},
+	}
+	h := newTestHandler(kr)
+
+	req := httptest.NewRequest(http.MethodPost, "/provider-a", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.createdPreviews) != 1 {
+		t.Fatalf("expected exactly 1 preview create, got %d", len(kr.createdPreviews))
+	}
+	if got := kr.createdPreviews[0].Spec.AppRef; got != "app-a" {
+		t.Fatalf("preview created for app %q, want app-a", got)
+	}
+}
+
+func TestPREvent_ClosedDeletesPreviewWhenPreviewDisabled(t *testing.T) {
+	const secret = "prsecret"
+	body := githubPRPayloadJSON("closed", 42, "feature/x", "closedsha", "org/repo")
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	app := makeGitApp("my-app", "pj-default", "https://github.com/org/repo", "main")
+	app.Spec.Source.ProviderRef = "provider-a"
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{
+				{Name: "production"},
+				{Name: "staging"},
+			},
+			Preview: &mortisev1alpha1.PreviewConfig{Enabled: false, Domain: "pr-{number}.example.com"},
+		},
+	}
+	existing := mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app-preview-pr-42",
+			Namespace: "pj-default",
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			AppRef: "my-app",
+			PullRequest: mortisev1alpha1.PullRequestRef{
+				Number: 42,
+				Branch: "feature/x",
+				SHA:    "oldsha",
+			},
+		},
+	}
+	kr := &fakeK8sReader{
+		provider:    gp,
+		secrets:     map[string]string{"mortise-system/wh-secret/value": secret},
+		apps:        []mortisev1alpha1.App{app},
+		projects:    map[string]*mortisev1alpha1.Project{"default": project},
+		previewEnvs: []mortisev1alpha1.PreviewEnvironment{existing},
+	}
+	h := newTestHandler(kr)
+
+	req := httptest.NewRequest(http.MethodPost, "/provider-a", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.deletedPreviews) != 1 {
+		t.Fatalf("expected 1 preview delete, got %d", len(kr.deletedPreviews))
+	}
+	if kr.deletedPreviews[0].Name != "my-app-preview-pr-42" {
+		t.Fatalf("deleted preview = %q, want my-app-preview-pr-42", kr.deletedPreviews[0].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
- scope push and pull-request webhook dispatch to apps whose `spec.source.providerRef` matches the provider route that received the event
- keep PR close events deleting preview environments even after a project has preview creation disabled
- add focused webhook handler regressions for both behaviors

## Testing
- `go test ./internal/webhook -run 'Test(Webhook_PushHonorsProviderRef|PREvent_OpenedHonorsProviderRef|PREvent_ClosedDeletesPreviewWhenPreviewDisabled)' -count=1`
- `go test ./internal/webhook -count=1`
