### PR TITLE
[codex] fix gitprovider webhook secret reads

### DIFF
--- a/internal/api/gitproviders.go
+++ b/internal/api/gitproviders.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -263,7 +264,15 @@ func (s *Server) GetWebhookSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	v := string(secret.Data[gp.Spec.WebhookSecretRef.Key])
+	raw, ok := secret.Data[gp.Spec.WebhookSecretRef.Key]
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{
+			fmt.Sprintf("secret %s/%s does not contain key %q", gp.Spec.WebhookSecretRef.Namespace, gp.Spec.WebhookSecretRef.Name, gp.Spec.WebhookSecretRef.Key),
+		})
+		return
+	}
+
+	v := string(raw)
 	writeJSON(w, http.StatusOK, map[string]string{"webhookSecret": v})
 }
 

--- a/internal/api/gitproviders_test.go
+++ b/internal/api/gitproviders_test.go
@@ -273,6 +273,52 @@ func TestGetWebhookSecretForbiddenForMember(t *testing.T) {
 	}
 }
 
+func TestGetWebhookSecretMissingReferencedKeyReturns404(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ctx := context.Background()
+
+	_ = k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"},
+	})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-webhook",
+			Namespace: "mortise-system",
+		},
+		Data: map[string][]byte{
+			"other-key": []byte("present-but-wrong"),
+		},
+	}
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		t.Fatalf("create secret: %v", err)
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-main"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type:     mortisev1alpha1.GitProviderTypeGitHub,
+			Host:     "https://github.com",
+			ClientID: "test-id",
+			WebhookSecretRef: &mortisev1alpha1.SecretRef{
+				Namespace: "mortise-system",
+				Name:      "custom-webhook",
+				Key:       "webhookSecret",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, gp); err != nil {
+		t.Fatalf("create gitprovider: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/gitproviders/github-main/webhook-secret", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestDeleteGitProviderHappyPath verifies that deletion removes the CRD and
 // the managed webhook secret.
 func TestDeleteGitProviderHappyPath(t *testing.T) {


### PR DESCRIPTION
## Summary
- return `404` when a git provider references a webhook secret key that does not exist instead of returning `200` with an empty value
- preserve the existing `200` empty response only for the explicit `WebhookSecretRef == nil` case
- add API regression coverage for the broken referenced-key path

## Testing
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'TestGetWebhookSecret(MissingReferencedKeyReturns404|ForbiddenForMember)' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
