### PR TITLE
[codex] guard last owner and admin role changes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -240,8 +240,8 @@ domain" concept does not exist.
 | **Admin** | |
 | `GET /api/admin/users` | list platform users |
 | `POST /api/admin/users` | create user |
-| `PATCH /api/admin/users/{email}` | update user role |
-| `DELETE /api/admin/users/{email}` | delete user |
+| `PATCH /api/admin/users/{email}` | update user role; rejects demoting the last platform admin |
+| `DELETE /api/admin/users/{email}` | delete user; rejects deleting the last platform admin |
 | `POST /api/admin/users/{email}/password` | reset user password |
 | **Git providers** | |
 | `GET /api/gitproviders` | list git providers |
@@ -1062,6 +1062,9 @@ Platform roles:
 | **member** | Can create projects; project-level permissions depend on `ProjectMember` role within each project. |
 | **viewer** | Read-only. |
 
+The platform must always retain at least one `admin`. API requests that would
+demote or delete the last platform admin are rejected with `400 Bad Request`.
+
 Project roles (`ProjectMember` CRD, per project):
 
 | Role | Can do |
@@ -1069,6 +1072,9 @@ Project roles (`ProjectMember` CRD, per project):
 | **owner** | Full project control (apps, members, tokens, project settings). |
 | **developer** | App lifecycle operations, but no member/token management; cannot delete app/project. Restricted envs are read-only. |
 | **viewer** | Read-only in project. |
+
+Each project must always retain at least one `owner`. API requests that would
+demote the last owner are rejected with `400 Bad Request`.
 
 **Restricted environments.** When `environments[].restricted: true` on a
 `Project`, Developer-role members have read-only access to that environment.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2021,7 +2021,8 @@ paths:
       - users
   /admin/users/{email}:
     delete:
-      description: Removes a platform user. Admin-only. Returns 400 when the target user is the last platform admin.
+      description: Removes a platform user. Admin-only. Returns 400 when the target
+        user is the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -2055,7 +2056,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes a platform user's role. Admin-only. Returns 400 when the change would demote the last platform admin.
+      description: Changes a platform user's role. Admin-only. Returns 400 when the
+        change would demote the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -4902,7 +4904,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes the role of an existing project member. Returns 400 when the change would demote the last project owner.
+      description: Changes the role of an existing project member. Returns 400 when
+        the change would demote the last project owner.
       parameters:
       - description: Project name
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2021,7 +2021,7 @@ paths:
       - users
   /admin/users/{email}:
     delete:
-      description: Removes a platform user. Admin-only.
+      description: Removes a platform user. Admin-only. Returns 400 when the target user is the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -2055,7 +2055,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes a platform user's role. Admin-only.
+      description: Changes a platform user's role. Admin-only. Returns 400 when the change would demote the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -4902,7 +4902,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes the role of an existing project member
+      description: Changes the role of an existing project member. Returns 400 when the change would demote the last project owner.
       parameters:
       - description: Project name
         in: path

--- a/internal/api/members.go
+++ b/internal/api/members.go
@@ -201,7 +201,7 @@ func (s *Server) AddMember(w http.ResponseWriter, r *http.Request) {
 // UpdateMember changes the role of an existing project member.
 //
 // @Summary Update a project member's role
-// @Description Changes the role of an existing project member
+// @Description Changes the role of an existing project member. Returns 400 when the change would demote the last project owner.
 // @Tags members
 // @Accept json
 // @Produce json

--- a/internal/api/members.go
+++ b/internal/api/members.go
@@ -246,6 +246,26 @@ func (s *Server) UpdateMember(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	if member.Spec.Role == mortisev1alpha1.ProjectRoleOwner && mortisev1alpha1.ProjectRole(req.Role) != mortisev1alpha1.ProjectRoleOwner {
+		var allMembers mortisev1alpha1.ProjectMemberList
+		if err := s.client.List(r.Context(), &allMembers,
+			client.InNamespace(ns),
+			client.MatchingLabels{"mortise.dev/member": "true"},
+		); err != nil {
+			writeError(w, r, err)
+			return
+		}
+		ownerCount := 0
+		for _, m := range allMembers.Items {
+			if m.Spec.Role == mortisev1alpha1.ProjectRoleOwner {
+				ownerCount++
+			}
+		}
+		if ownerCount <= 1 {
+			writeJSON(w, http.StatusBadRequest, errorResponse{"cannot demote the last owner of a project"})
+			return
+		}
+	}
 
 	member.Spec.Role = mortisev1alpha1.ProjectRole(req.Role)
 	if err := s.client.Update(r.Context(), &member); err != nil {

--- a/internal/api/members_api_test.go
+++ b/internal/api/members_api_test.go
@@ -1,0 +1,41 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestUpdateMemberRejectsDemotingLastOwner(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	seedProject(t, k8sClient, "default")
+	seedProjectMember(t, k8sClient, "default", "owner@example.com", mortisev1alpha1.ProjectRoleOwner)
+
+	w := doRequest(h, http.MethodPatch, "/api/projects/default/members/owner@example.com", map[string]any{
+		"role": "developer",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateMemberAllowsDemotingOwnerWhenAnotherOwnerExists(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	seedProject(t, k8sClient, "default")
+	seedProjectMember(t, k8sClient, "default", "owner1@example.com", mortisev1alpha1.ProjectRoleOwner)
+	seedProjectMember(t, k8sClient, "default", "owner2@example.com", mortisev1alpha1.ProjectRoleOwner)
+
+	w := doRequest(h, http.MethodPatch, "/api/projects/default/members/owner1@example.com", map[string]any{
+		"role": "developer",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2021,7 +2021,8 @@ paths:
       - users
   /admin/users/{email}:
     delete:
-      description: Removes a platform user. Admin-only. Returns 400 when the target user is the last platform admin.
+      description: Removes a platform user. Admin-only. Returns 400 when the target
+        user is the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -2055,7 +2056,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes a platform user's role. Admin-only. Returns 400 when the change would demote the last platform admin.
+      description: Changes a platform user's role. Admin-only. Returns 400 when the
+        change would demote the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -4902,7 +4904,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes the role of an existing project member. Returns 400 when the change would demote the last project owner.
+      description: Changes the role of an existing project member. Returns 400 when
+        the change would demote the last project owner.
       parameters:
       - description: Project name
         in: path

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2021,7 +2021,7 @@ paths:
       - users
   /admin/users/{email}:
     delete:
-      description: Removes a platform user. Admin-only.
+      description: Removes a platform user. Admin-only. Returns 400 when the target user is the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -2055,7 +2055,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes a platform user's role. Admin-only.
+      description: Changes a platform user's role. Admin-only. Returns 400 when the change would demote the last platform admin.
       parameters:
       - description: User email
         in: path
@@ -4902,7 +4902,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Changes the role of an existing project member
+      description: Changes the role of an existing project member. Returns 400 when the change would demote the last project owner.
       parameters:
       - description: Project name
         in: path

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -175,6 +175,23 @@ func (s *Server) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	if auth.Role(secret.Data["role"]) == auth.RoleAdmin && auth.Role(req.Role) != auth.RoleAdmin {
+		users, err := s.auth.ListUsers(r.Context())
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+			return
+		}
+		adminCount := 0
+		for _, user := range users {
+			if user.Role == auth.RoleAdmin {
+				adminCount++
+			}
+		}
+		if adminCount <= 1 {
+			writeJSON(w, http.StatusBadRequest, errorResponse{"cannot demote the last platform admin"})
+			return
+		}
+	}
 
 	secret.Data["role"] = []byte(req.Role)
 	if err := s.client.Update(r.Context(), &secret); err != nil {
@@ -210,6 +227,26 @@ func (s *Server) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	email := chi.URLParam(r, "email")
 	if email == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"email is required"})
+		return
+	}
+	users, err := s.auth.ListUsers(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+		return
+	}
+	adminCount := 0
+	targetIsAdmin := false
+	for _, user := range users {
+		if user.Role != auth.RoleAdmin {
+			continue
+		}
+		adminCount++
+		if user.Email == email || user.ID == email {
+			targetIsAdmin = true
+		}
+	}
+	if targetIsAdmin && adminCount <= 1 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"cannot delete the last platform admin"})
 		return
 	}
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -129,7 +129,7 @@ func (s *Server) CreateUser(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Update a user's role
-// @Description Changes a platform user's role. Admin-only.
+// @Description Changes a platform user's role. Admin-only. Returns 400 when the change would demote the last platform admin.
 // @Tags users
 // @Accept json
 // @Produce json
@@ -207,7 +207,7 @@ func (s *Server) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Delete a user
-// @Description Removes a platform user. Admin-only.
+// @Description Removes a platform user. Admin-only. Returns 400 when the target user is the last platform admin.
 // @Tags users
 // @Security BearerAuth
 // @Param email path string true "User email"

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -1,0 +1,86 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/mortise-org/mortise/internal/api"
+	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/authz"
+)
+
+func TestUpdateUserRoleRejectsDemotingLastAdmin(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPatch, "/api/admin/users/test@example.com", map[string]any{
+		"role": "member",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteUserRejectsDeletingLastAdmin(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodDelete, "/api/admin/users/test@example.com", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateUserRoleAllowsDemotingAdminWhenAnotherAdminExists(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	srv, token := newTestServer(t, k8sClient)
+	h := srv.Handler()
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	if err := authProvider.CreateUser(ctx, "second-admin@example.com", "testpass2", auth.RoleAdmin); err != nil {
+		t.Fatalf("create second admin: %v", err)
+	}
+
+	w := doRequestWithToken(h, http.MethodPatch, "/api/admin/users/test@example.com", map[string]any{
+		"role": "member",
+	}, token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteUserAllowsDeletingAdminWhenAnotherAdminExists(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	if err := authProvider.CreateUser(ctx, "admin1@example.com", "testpass1", auth.RoleAdmin); err != nil {
+		t.Fatalf("create admin1: %v", err)
+	}
+	if err := authProvider.CreateUser(ctx, "admin2@example.com", "testpass2", auth.RoleAdmin); err != nil {
+		t.Fatalf("create admin2: %v", err)
+	}
+	principal, err := authProvider.Authenticate(ctx, auth.Credentials{Email: "admin1@example.com", Password: "testpass1"})
+	if err != nil {
+		t.Fatalf("authenticate admin1: %v", err)
+	}
+	token, err := jwtHelper.GenerateToken(ctx, principal)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	w := doRequestWithToken(h, http.MethodDelete, "/api/admin/users/admin1@example.com", nil, token)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- reject demoting the final project owner through `PATCH /projects/{project}/members/{email}`
- reject demoting or deleting the final platform admin through the admin user API
- add reject-path and allow-path API coverage so valid changes still work when another owner/admin exists

## Testing
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'Test(UpdateMemberRejectsDemotingLastOwner|UpdateMemberAllowsDemotingOwnerWhenAnotherOwnerExists|UpdateUserRoleRejectsDemotingLastAdmin|UpdateUserRoleAllowsDemotingAdminWhenAnotherAdminExists|DeleteUserRejectsDeletingLastAdmin|DeleteUserAllowsDeletingAdminWhenAnotherAdminExists)' -count=1`
- `KUBEBUILDER_ASSETS="/tmp/mortise-pr-exec-fixes/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -count=1`
