### PR TITLE
fix: preserve admin bootstrap token path in integration login helper

### DIFF
--- a/test/helpers/mortise_api.go
+++ b/test/helpers/mortise_api.go
@@ -36,7 +36,31 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 	if err != nil {
 		t.Fatalf("mortise: POST /api/auth/setup: %v", err)
 	}
-	setupResp.Body.Close()
+
+	var setupAuth struct {
+		Token string `json:"token"`
+	}
+	func() {
+		defer setupResp.Body.Close()
+		if setupResp.StatusCode == http.StatusCreated {
+			if err := json.NewDecoder(setupResp.Body).Decode(&setupAuth); err != nil {
+				t.Fatalf("mortise: decode /api/auth/setup response: %v", err)
+			}
+			if setupAuth.Token == "" {
+				t.Fatal("mortise: empty token in setup response")
+			}
+			return
+		}
+		if setupResp.StatusCode == http.StatusConflict {
+			return
+		}
+		b, _ := io.ReadAll(setupResp.Body)
+		t.Fatalf("mortise: POST /api/auth/setup status %d: %s",
+			setupResp.StatusCode, string(b))
+	}()
+	if setupAuth.Token != "" {
+		return setupAuth.Token
+	}
 
 	type creds struct {
 		email    string

--- a/test/helpers/mortise_api.go
+++ b/test/helpers/mortise_api.go
@@ -51,12 +51,7 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 			}
 			return
 		}
-		if setupResp.StatusCode == http.StatusConflict {
-			return
-		}
-		b, _ := io.ReadAll(setupResp.Body)
-		t.Fatalf("mortise: POST /api/auth/setup status %d: %s",
-			setupResp.StatusCode, string(b))
+		_, _ = io.Copy(io.Discard, setupResp.Body)
 	}()
 	if setupAuth.Token != "" {
 		return setupAuth.Token

--- a/test/helpers/mortise_api_test.go
+++ b/test/helpers/mortise_api_test.go
@@ -1,0 +1,65 @@
+package helpers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLoginAsAdminReturnsSetupTokenWithoutLoginRetry(t *testing.T) {
+	var loginCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/setup":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": "setup-token",
+				"user":  map[string]any{"email": "admin@example.com"},
+			})
+		case "/api/auth/login":
+			loginCalls.Add(1)
+			http.Error(w, `{"error":"unexpected login"}`, http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	token := LoginAsAdmin(t, srv.URL, "admin@example.com", "password123")
+	if token != "setup-token" {
+		t.Fatalf("expected setup token, got %q", token)
+	}
+	if got := loginCalls.Load(); got != 0 {
+		t.Fatalf("expected no login retry after successful setup, got %d call(s)", got)
+	}
+}
+
+func TestLoginAsAdminFallsBackToLoginAfterSetupConflict(t *testing.T) {
+	var loginCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/setup":
+			http.Error(w, `{"error":"setup already complete"}`, http.StatusConflict)
+		case "/api/auth/login":
+			loginCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": "login-token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	token := LoginAsAdmin(t, srv.URL, "admin@example.com", "password123")
+	if token != "login-token" {
+		t.Fatalf("expected login token, got %q", token)
+	}
+	if got := loginCalls.Load(); got != 1 {
+		t.Fatalf("expected one login attempt after setup conflict, got %d", got)
+	}
+}

--- a/test/helpers/mortise_api_test.go
+++ b/test/helpers/mortise_api_test.go
@@ -63,3 +63,29 @@ func TestLoginAsAdminFallsBackToLoginAfterSetupConflict(t *testing.T) {
 		t.Fatalf("expected one login attempt after setup conflict, got %d", got)
 	}
 }
+
+func TestLoginAsAdminTreatsSetupAsBestEffort(t *testing.T) {
+	var loginCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/setup":
+			http.Error(w, `{"error":"transient setup failure"}`, http.StatusInternalServerError)
+		case "/api/auth/login":
+			loginCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": "login-token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	token := LoginAsAdmin(t, srv.URL, "admin@example.com", "password123")
+	if token != "login-token" {
+		t.Fatalf("expected login token, got %q", token)
+	}
+	if got := loginCalls.Load(); got != 1 {
+		t.Fatalf("expected one login attempt after setup failure, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- reuse the `/api/auth/setup` token when first-user bootstrap succeeds
- keep `LoginAsAdmin` setup fully best-effort for reused clusters and races
- add focused helper regressions for setup-success and setup-fallback paths

## Root cause
Commit `c42db71` made `LoginAsAdmin` treat `/api/auth/setup` as fully best-effort, but it also discarded the successful `201 Created` response and immediately retried `/api/auth/login`. On a fresh integration cluster, that reintroduced the cache-sync race that `feb1f32` had explicitly avoided in the setup path, which surfaced as `TestGiteaOAuthFlow` failing with `POST /api/auth/login` returning `401 invalid credentials`.

## Validation
- `go test ./test/helpers -count=1`

## Notes
- This change is intentionally in the integration test helper path; the failing CI signal occurred before the OAuth flow itself began.