### PR TITLE
[codex] Fix release usability issues #279 #280 #281 #290 #295

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -375,8 +375,9 @@ func main() {
 	}
 
 	if err := (&controller.ProjectReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "Project")
 		os.Exit(1)

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -230,7 +230,7 @@ func TestUpdateAppRetriesConflict(t *testing.T) {
 	baseClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(project, app).Build()
 	s := &Server{
 		client: &appUpdateConflictClient{Client: baseClient, fired: &fired},
-		authz:  allowAllPolicy{},
+		authz:  allowAllAppsPolicy{},
 	}
 
 	req := httptest.NewRequest(http.MethodPut, "/api/projects/default/apps/update-conflict", bytes.NewBufferString(`{"source":{"type":"image","image":"nginx:1.26.0"}}`))
@@ -260,9 +260,9 @@ func TestUpdateAppRetriesConflict(t *testing.T) {
 	}
 }
 
-type allowAllPolicy struct{}
+type allowAllAppsPolicy struct{}
 
-func (allowAllPolicy) Authorize(context.Context, auth.Principal, authz.Resource, authz.Action) (bool, error) {
+func (allowAllAppsPolicy) Authorize(context.Context, auth.Principal, authz.Resource, authz.Action) (bool, error) {
 	return true, nil
 }
 

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -1,15 +1,24 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/authz"
 )
 
 func TestNormalizeRepoURL(t *testing.T) {
@@ -193,4 +202,86 @@ func TestCreateAppRequestUnmarshalJSON_WrappedTakesPrecedence(t *testing.T) {
 	if req.Spec.Source.Image != "nginx:1.27" {
 		t.Errorf("source.image: got %q, want %q", req.Spec.Source.Image, "nginx:1.27")
 	}
+}
+
+func TestUpdateAppRetriesConflict(t *testing.T) {
+	if err := mortisev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Status:     mortisev1alpha1.ProjectStatus{Namespace: "pj-default"},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "update-conflict",
+			Namespace: "pj-default",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:  mortisev1alpha1.SourceTypeImage,
+				Image: "nginx:1.25.0",
+			},
+		},
+	}
+
+	fired := false
+	baseClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(project, app).Build()
+	s := &Server{
+		client: &appUpdateConflictClient{Client: baseClient, fired: &fired},
+		authz:  allowAllPolicy{},
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/projects/default/apps/update-conflict", bytes.NewBufferString(`{"source":{"type":"image","image":"nginx:1.26.0"}}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("project", "default")
+	routeCtx.URLParams.Add("app", "update-conflict")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, principalKey, &auth.Principal{Email: "test@example.com", Role: auth.RoleAdmin})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.UpdateApp(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("update app with retried conflict: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !fired {
+		t.Fatal("expected synthetic conflict to fire on first update")
+	}
+
+	var updated mortisev1alpha1.App
+	if err := baseClient.Get(context.Background(), ctrlclient.ObjectKey{Name: "update-conflict", Namespace: "pj-default"}, &updated); err != nil {
+		t.Fatalf("get app after update: %v", err)
+	}
+	if updated.Spec.Source.Image != "nginx:1.26.0" {
+		t.Fatalf("expected updated image after conflict retry, got %q", updated.Spec.Source.Image)
+	}
+}
+
+type allowAllPolicy struct{}
+
+func (allowAllPolicy) Authorize(context.Context, auth.Principal, authz.Resource, authz.Action) (bool, error) {
+	return true, nil
+}
+
+type appUpdateConflictClient struct {
+	ctrlclient.Client
+	fired *bool
+}
+
+func (c *appUpdateConflictClient) Update(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+	if app, ok := obj.(*mortisev1alpha1.App); ok && !*c.fired {
+		*c.fired = true
+		if err := c.Client.Update(ctx, obj, opts...); err != nil {
+			return err
+		}
+		return apierrors.NewConflict(
+			mortisev1alpha1.GroupVersion.WithResource("apps").GroupResource(),
+			app.Name,
+			fmt.Errorf("synthetic conflict"),
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
 }

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -3,14 +3,16 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 
 	"github.com/go-chi/chi/v5"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
@@ -48,6 +50,15 @@ type projectEnvResponse struct {
 type createProjectEnvRequest struct {
 	Name         string `json:"name"`
 	DisplayOrder int    `json:"displayOrder,omitempty"`
+}
+
+type projectEnvExistsError struct {
+	project string
+	name    string
+}
+
+func (e *projectEnvExistsError) Error() string {
+	return fmt.Sprintf("environment %q already exists on project %q", e.name, e.project)
 }
 
 // patchProjectEnvRequest is the JSON body for PATCH .../environments/{name}.
@@ -143,18 +154,14 @@ func (s *Server) CreateProjectEnvironment(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusBadRequest, errorResponse{msg})
 		return
 	}
-	for _, existing := range project.Spec.Environments {
-		if existing.Name == req.Name {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("environment %q already exists on project %q", req.Name, project.Name)})
+
+	created, err := s.createProjectEnvironment(r.Context(), project.Name, req)
+	if err != nil {
+		var existsErr *projectEnvExistsError
+		if errors.As(err, &existsErr) {
+			writeJSON(w, http.StatusConflict, errorResponse{existsErr.Error()})
 			return
 		}
-	}
-
-	project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
-		Name:         req.Name,
-		DisplayOrder: req.DisplayOrder,
-	})
-	if err := s.client.Update(r.Context(), project); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -162,10 +169,33 @@ func (s *Server) CreateProjectEnvironment(w http.ResponseWriter, r *http.Request
 	s.recordActivity(r, projectName, "create", "environment", req.Name, "Created project environment "+req.Name, "")
 
 	writeJSON(w, http.StatusCreated, projectEnvResponse{
-		Name:         req.Name,
-		DisplayOrder: req.DisplayOrder,
+		Name:         created.Name,
+		DisplayOrder: created.DisplayOrder,
 		Health:       EnvHealthUnknown,
 	})
+}
+
+func (s *Server) createProjectEnvironment(ctx context.Context, projectName string, req createProjectEnvRequest) (mortisev1alpha1.ProjectEnvironment, error) {
+	created := mortisev1alpha1.ProjectEnvironment{
+		Name:         req.Name,
+		DisplayOrder: req.DisplayOrder,
+	}
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current mortisev1alpha1.Project
+		if err := s.client.Get(ctx, types.NamespacedName{Name: projectName}, &current); err != nil {
+			return err
+		}
+		for _, existing := range current.Spec.Environments {
+			if existing.Name == req.Name {
+				return &projectEnvExistsError{project: current.Name, name: req.Name}
+			}
+		}
+		current.Spec.Environments = append(current.Spec.Environments, created)
+		return s.client.Update(ctx, &current)
+	}); err != nil {
+		return mortisev1alpha1.ProjectEnvironment{}, err
+	}
+	return created, nil
 }
 
 // UpdateProjectEnvironment edits the display order and/or renames an env.
@@ -309,7 +339,7 @@ func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request
 
 	project.Spec.Environments = append(project.Spec.Environments[:idx], project.Spec.Environments[idx+1:]...)
 	if err := s.client.Update(r.Context(), project); err != nil {
-		if errors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
 			return
 		}
@@ -455,7 +485,7 @@ func (s *Server) cloneEnvToApp(ctx context.Context, ns, appName, sourceName, tar
 		secret, err := s.clientset.CoreV1().Secrets(sourceEnvNs).Get(ctx, envstore.AppEnvSecretName(appName), metav1.GetOptions{})
 		if err == nil {
 			secretVars = envstore.SecretToEnvs(secret)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("read source env vars for app %q: %w", appName, err)
 		}
 	}
@@ -544,7 +574,7 @@ func (s *Server) cloneEnvToApp(ctx context.Context, ns, appName, sourceName, tar
 		if updateErr == nil {
 			return nil
 		}
-		if !errors.IsConflict(updateErr) || attempt == maxConflictRetries-1 {
+		if !apierrors.IsConflict(updateErr) || attempt == maxConflictRetries-1 {
 			return fmt.Errorf("clone env overrides for app %q: %w", appName, updateErr)
 		}
 	}
@@ -562,7 +592,7 @@ func (s *Server) getProject(w http.ResponseWriter, r *http.Request) (*mortisev1a
 
 	var project mortisev1alpha1.Project
 	err := s.client.Get(r.Context(), types.NamespacedName{Name: projectName}, &project)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("project %q not found", projectName)})
 		return nil, false
 	}

--- a/internal/api/project_envs_test.go
+++ b/internal/api/project_envs_test.go
@@ -3,15 +3,53 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/auth"
 )
+
+type projectCreateConflictClient struct {
+	client.Client
+	fired bool
+}
+
+func (c *projectCreateConflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	project, ok := obj.(*mortisev1alpha1.Project)
+	if !ok || project.Name != "demo" || c.fired {
+		return c.Client.Update(ctx, obj, opts...)
+	}
+
+	c.fired = true
+
+	var live mortisev1alpha1.Project
+	if err := c.Client.Get(ctx, types.NamespacedName{Name: project.Name}, &live); err != nil {
+		return err
+	}
+	for i := range live.Spec.Environments {
+		if live.Spec.Environments[i].Name == "production" {
+			live.Spec.Environments[i].Restricted = true
+			break
+		}
+	}
+	if err := c.Client.Update(ctx, &live); err != nil {
+		return err
+	}
+
+	return apierrors.NewConflict(
+		schema.GroupResource{Group: mortisev1alpha1.GroupVersion.Group, Resource: "projects"},
+		project.Name,
+		fmt.Errorf("simulated conflict"),
+	)
+}
 
 // TestListProjectEnvironmentsEmptyProject verifies that listing envs on a
 // project with no apps returns the project's env list with unknown health.
@@ -168,6 +206,57 @@ func TestCreateProjectEnvironment(t *testing.T) {
 	added := proj.Spec.Environments[1]
 	if added.Name != "staging" || added.DisplayOrder != 5 {
 		t.Errorf("unexpected env on spec: %+v", added)
+	}
+}
+
+func TestCreateProjectEnvironmentPreservesConcurrentProjectUpdate(t *testing.T) {
+	baseClient := setupEnvtest(t)
+	seedProject(t, baseClient, "demo")
+
+	conflictClient := &projectCreateConflictClient{Client: baseClient}
+	srv := newAdminServer(t, conflictClient)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPost, "/api/projects/demo/environments", map[string]any{
+		"name":         "staging",
+		"displayOrder": 5,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if !conflictClient.fired {
+		t.Fatalf("expected simulated conflict to fire")
+	}
+
+	var proj mortisev1alpha1.Project
+	if err := baseClient.Get(context.Background(), types.NamespacedName{Name: "demo"}, &proj); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	if len(proj.Spec.Environments) != 2 {
+		t.Fatalf("expected 2 envs in spec, got %d", len(proj.Spec.Environments))
+	}
+
+	var production, staging *mortisev1alpha1.ProjectEnvironment
+	for i := range proj.Spec.Environments {
+		env := &proj.Spec.Environments[i]
+		switch env.Name {
+		case "production":
+			production = env
+		case "staging":
+			staging = env
+		}
+	}
+	if production == nil {
+		t.Fatalf("production env missing: %+v", proj.Spec.Environments)
+	}
+	if staging == nil {
+		t.Fatalf("staging env missing: %+v", proj.Spec.Environments)
+	}
+	if !production.Restricted {
+		t.Errorf("expected concurrent production update to be preserved")
+	}
+	if staging.DisplayOrder != 5 {
+		t.Errorf("staging displayOrder = %d, want 5", staging.DisplayOrder)
 	}
 }
 

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -145,15 +145,14 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if err := r.gcAppAcrossEnvs(ctx, &app); err != nil {
 				return ctrl.Result{}, fmt.Errorf("gc app across envs: %w", err)
 			}
-			controllerutil.RemoveFinalizer(&app, appFinalizer)
-			if err := r.Update(ctx, &app); err != nil {
+			if err := r.removeAppFinalizerWithRetry(ctx, req.NamespacedName); err != nil {
 				return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
 			}
 		}
 		return ctrl.Result{}, nil
 	}
 	if controllerutil.AddFinalizer(&app, appFinalizer) {
-		if err := r.Update(ctx, &app); err != nil {
+		if err := r.addAppFinalizerWithRetry(ctx, req.NamespacedName); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
 		}
 	}
@@ -367,6 +366,34 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 // appFinalizer is the finalizer string applied to every App. Cleared only
 // after cross-namespace cleanup of workload resources completes.
 const appFinalizer = "mortise.dev/app-finalizer"
+
+func (r *AppReconciler) addAppFinalizerWithRetry(ctx context.Context, key types.NamespacedName) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := r.Get(ctx, key, &fresh); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(&fresh, appFinalizer) {
+			return nil
+		}
+		controllerutil.AddFinalizer(&fresh, appFinalizer)
+		return r.Update(ctx, &fresh)
+	})
+}
+
+func (r *AppReconciler) removeAppFinalizerWithRetry(ctx context.Context, key types.NamespacedName) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := r.Get(ctx, key, &fresh); err != nil {
+			return err
+		}
+		if !controllerutil.ContainsFinalizer(&fresh, appFinalizer) {
+			return nil
+		}
+		controllerutil.RemoveFinalizer(&fresh, appFinalizer)
+		return r.Update(ctx, &fresh)
+	})
+}
 
 // reconcileGitSource handles the build-from-source path for source.type=git apps
 // without blocking the reconcile worker. On the first reconcile of a new

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -290,15 +290,16 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, &app, env.Name, allHosts); err != nil {
-					app.Status.Phase = mortisev1alpha1.AppPhaseFailed
-					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-						Type:               "DomainCollision",
-						Status:             metav1.ConditionTrue,
-						Reason:             "DomainInUse",
-						Message:            err.Error(),
-						ObservedGeneration: app.Generation,
-					})
-					if updateErr := r.Status().Update(ctx, &app); updateErr != nil {
+					if updateErr := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
+						status.Phase = mortisev1alpha1.AppPhaseFailed
+						meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+							Type:               "DomainCollision",
+							Status:             metav1.ConditionTrue,
+							Reason:             "DomainInUse",
+							Message:            err.Error(),
+							ObservedGeneration: app.Generation,
+						})
+					}); updateErr != nil {
 						log.Error(updateErr, "update status after domain collision")
 					}
 					return ctrl.Result{}, nil
@@ -381,6 +382,23 @@ func (r *AppReconciler) addAppFinalizerWithRetry(ctx context.Context, key types.
 	})
 }
 
+func (r *AppReconciler) setAppAnnotationWithRetry(ctx context.Context, key types.NamespacedName, annotationKey, annotationValue string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := r.Get(ctx, key, &fresh); err != nil {
+			return err
+		}
+		if fresh.Annotations == nil {
+			fresh.Annotations = map[string]string{}
+		}
+		if fresh.Annotations[annotationKey] == annotationValue {
+			return nil
+		}
+		fresh.Annotations[annotationKey] = annotationValue
+		return r.Update(ctx, &fresh)
+	})
+}
+
 func (r *AppReconciler) removeAppFinalizerWithRetry(ctx context.Context, key types.NamespacedName) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var fresh mortisev1alpha1.App
@@ -449,7 +467,7 @@ func (r *AppReconciler) prepareGitSource(ctx context.Context, app *mortisev1alph
 			app.Annotations = make(map[string]string)
 		}
 		app.Annotations["mortise.dev/git-token-owner"] = tokenResult.Email
-		if err := r.Update(ctx, app); err != nil {
+		if err := r.setAppAnnotationWithRetry(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, "mortise.dev/git-token-owner", tokenResult.Email); err != nil {
 			log.Error(err, "failed to cache git-token-owner annotation")
 		}
 	}
@@ -890,17 +908,27 @@ func buildContextOf(app *mortisev1alpha1.App) mortisev1alpha1.BuildContext {
 // status, and returns an error so the reconciler requeues.
 func (r *AppReconciler) setFailedCondition(ctx context.Context, app *mortisev1alpha1.App, reason, msg string) error {
 	log := logf.FromContext(ctx)
+	transitionTime := metav1.NewTime(r.clock().Now())
+	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+		status.Phase = mortisev1alpha1.AppPhaseFailed
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:               "BuildSucceeded",
+			Status:             metav1.ConditionFalse,
+			Reason:             reason,
+			Message:            msg,
+			LastTransitionTime: transitionTime,
+		})
+	}); err != nil {
+		log.Error(err, "update failed status")
+	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseFailed
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildSucceeded",
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            msg,
-		LastTransitionTime: metav1.NewTime(r.clock().Now()),
+		LastTransitionTime: transitionTime,
 	})
-	if err := r.Status().Update(ctx, app); err != nil {
-		log.Error(err, "update failed status")
-	}
 	return fmt.Errorf("%s: %s", reason, msg)
 }
 
@@ -2409,7 +2437,17 @@ func (r *AppReconciler) setWebhookCondition(ctx context.Context, app *mortisev1a
 		ObservedGeneration: app.Generation,
 		LastTransitionTime: transitionTime,
 	})
-	return r.Status().Update(ctx, app)
+
+	return r.updateAppStatus(ctx, app, func(appStatus *mortisev1alpha1.AppStatus) {
+		meta.SetStatusCondition(&appStatus.Conditions, metav1.Condition{
+			Type:               webhookConditionType,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: app.Generation,
+			LastTransitionTime: transitionTime,
+		})
+	})
 }
 
 // checkPodCrashLoopInEnv checks pods for CrashLoopBackOff within a single env
@@ -3329,15 +3367,16 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, app, env.Name, allHosts); err != nil {
-					app.Status.Phase = mortisev1alpha1.AppPhaseFailed
-					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-						Type:               "DomainCollision",
-						Status:             metav1.ConditionTrue,
-						Reason:             "DomainInUse",
-						Message:            err.Error(),
-						ObservedGeneration: app.Generation,
-					})
-					if updateErr := r.Status().Update(ctx, app); updateErr != nil {
+					if updateErr := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+						status.Phase = mortisev1alpha1.AppPhaseFailed
+						meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+							Type:               "DomainCollision",
+							Status:             metav1.ConditionTrue,
+							Reason:             "DomainInUse",
+							Message:            err.Error(),
+							ObservedGeneration: app.Generation,
+						})
+					}); updateErr != nil {
 						log.Error(updateErr, "update status after domain collision")
 					}
 					return ctrl.Result{}, nil
@@ -3353,8 +3392,9 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 	}
 
 	// External apps are always Ready — there is no workload to wait for.
-	app.Status.Phase = mortisev1alpha1.AppPhaseReady
-	if err := r.Status().Update(ctx, app); err != nil {
+	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+		status.Phase = mortisev1alpha1.AppPhaseReady
+	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
 	}
 	return ctrl.Result{}, nil

--- a/internal/controller/controller_conflict_test.go
+++ b/internal/controller/controller_conflict_test.go
@@ -359,22 +359,6 @@ func (c *appUpdateConflictClient) Update(ctx context.Context, obj client.Object,
 	return c.Client.Update(ctx, obj, opts...)
 }
 
-type namespaceAlreadyExistsClient struct {
-	client.Client
-	fired bool
-}
-
-func (c *namespaceAlreadyExistsClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if ns, ok := obj.(*corev1.Namespace); ok && !c.fired {
-		c.fired = true
-		if err := c.Client.Create(ctx, ns.DeepCopy(), opts...); err != nil {
-			return err
-		}
-		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, ns.Name)
-	}
-	return c.Client.Create(ctx, obj, opts...)
-}
-
 type staleNamespaceCacheClient struct {
 	client.Client
 	fired       bool

--- a/internal/controller/controller_conflict_test.go
+++ b/internal/controller/controller_conflict_test.go
@@ -1,0 +1,173 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+func TestAddAppFinalizerWithRetry(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	conflicts := &appUpdateConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	if err := r.addAppFinalizerWithRetry(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}); err != nil {
+		t.Fatalf("add finalizer: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient update conflict")
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if !containsString(fresh.Finalizers, appFinalizer) {
+		t.Fatalf("expected %q finalizer, got %v", appFinalizer, fresh.Finalizers)
+	}
+}
+
+func TestRemoveAppFinalizerWithRetry(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "demo",
+			Namespace:  "pj-default-project",
+			Finalizers: []string{appFinalizer},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	conflicts := &appUpdateConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	if err := r.removeAppFinalizerWithRetry(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}); err != nil {
+		t.Fatalf("remove finalizer: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient update conflict")
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if containsString(fresh.Finalizers, appFinalizer) {
+		t.Fatalf("expected %q finalizer removed, got %v", appFinalizer, fresh.Finalizers)
+	}
+}
+
+func TestEnsureNamespaceHandlesAlreadyExistsFromConcurrentCreate(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "demo",
+			UID:  types.UID("project-uid"),
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(project).Build()
+	createRace := &namespaceAlreadyExistsClient{Client: base}
+
+	r := &ProjectReconciler{Client: createRace, Scheme: scheme}
+	nsName := constants.EnvNamespace(project.Name, "production")
+	if err := r.ensureNamespace(ctx, project, nsName, namespaceSpec{
+		role:    constants.NamespaceRoleEnv,
+		envName: "production",
+	}); err != nil {
+		t.Fatalf("ensure namespace: %v", err)
+	}
+	if !createRace.fired {
+		t.Fatal("expected create conflict interception")
+	}
+
+	var ns corev1.Namespace
+	if err := base.Get(ctx, types.NamespacedName{Name: nsName}, &ns); err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	if ns.Labels[constants.ProjectLabel] != project.Name {
+		t.Fatalf("expected project label %q, got %q", project.Name, ns.Labels[constants.ProjectLabel])
+	}
+	if len(ns.OwnerReferences) != 1 || ns.OwnerReferences[0].UID != project.UID {
+		t.Fatalf("expected namespace owner ref for project %q, got %+v", project.Name, ns.OwnerReferences)
+	}
+}
+
+type appUpdateConflictClient struct {
+	client.Client
+	fired bool
+}
+
+func (c *appUpdateConflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*mortisev1alpha1.App); ok && !c.fired {
+		c.fired = true
+		if err := c.Client.Update(ctx, obj, opts...); err != nil {
+			return err
+		}
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: mortisev1alpha1.GroupVersion.Group, Resource: "apps"},
+			obj.GetName(),
+			context.DeadlineExceeded,
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+type namespaceAlreadyExistsClient struct {
+	client.Client
+	fired bool
+}
+
+func (c *namespaceAlreadyExistsClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if ns, ok := obj.(*corev1.Namespace); ok && !c.fired {
+		c.fired = true
+		if err := c.Client.Create(ctx, ns.DeepCopy(), opts...); err != nil {
+			return err
+		}
+		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, ns.Name)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/controller_conflict_test.go
+++ b/internal/controller/controller_conflict_test.go
@@ -2,9 +2,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +24,9 @@ func TestAddAppFinalizerWithRetry(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
 	}
 
 	app := &mortisev1alpha1.App{
@@ -101,9 +106,9 @@ func TestEnsureNamespaceHandlesAlreadyExistsFromConcurrentCreate(t *testing.T) {
 		},
 	}
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(project).Build()
-	createRace := &namespaceAlreadyExistsClient{Client: base}
+	createRace := &staleNamespaceCacheClient{Client: base}
 
-	r := &ProjectReconciler{Client: createRace, Scheme: scheme}
+	r := &ProjectReconciler{Client: createRace, APIReader: base, Scheme: scheme}
 	nsName := constants.EnvNamespace(project.Name, "production")
 	if err := r.ensureNamespace(ctx, project, nsName, namespaceSpec{
 		role:    constants.NamespaceRoleEnv,
@@ -113,6 +118,9 @@ func TestEnsureNamespaceHandlesAlreadyExistsFromConcurrentCreate(t *testing.T) {
 	}
 	if !createRace.fired {
 		t.Fatal("expected create conflict interception")
+	}
+	if createRace.createCalls != 1 {
+		t.Fatalf("expected one create attempt, got %d", createRace.createCalls)
 	}
 
 	var ns corev1.Namespace
@@ -124,6 +132,210 @@ func TestEnsureNamespaceHandlesAlreadyExistsFromConcurrentCreate(t *testing.T) {
 	}
 	if len(ns.OwnerReferences) != 1 || ns.OwnerReferences[0].UID != project.UID {
 		t.Fatalf("expected namespace owner ref for project %q, got %+v", project.Name, ns.OwnerReferences)
+	}
+}
+
+func TestSetFailedConditionRetriesStatusConflict(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-build-fail",
+			Namespace: "pj-default-project",
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(app).WithObjects(app).Build()
+	conflicts := &appStatusConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	err := r.setFailedCondition(ctx, app, "BuildFailed", "dockerfile missing")
+	if err == nil || err.Error() != "BuildFailed: dockerfile missing" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient status conflict")
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		t.Fatalf("expected failed phase, got %q", fresh.Status.Phase)
+	}
+	cond := findStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Reason != "BuildFailed" || cond.Message != "dockerfile missing" {
+		t.Fatalf("unexpected failed condition: %+v", cond)
+	}
+}
+
+func TestSetWebhookConditionRetriesStatusConflict(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-webhook",
+			Namespace: "pj-default-project",
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(app).WithObjects(app).Build()
+	conflicts := &appStatusConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	if err := r.setWebhookCondition(ctx, app, metav1.ConditionFalse, "WebhookAuthFailed", "missing webhook scope"); err != nil {
+		t.Fatalf("set webhook condition: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient status conflict")
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	cond := findStatusCondition(fresh.Status.Conditions, webhookConditionType)
+	if cond == nil || cond.Reason != "WebhookAuthFailed" || cond.Message != "missing webhook scope" {
+		t.Fatalf("unexpected webhook condition: %+v", cond)
+	}
+}
+
+func TestReconcileExternalSourceReadyRetriesStatusConflict(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ext-ready",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type: mortisev1alpha1.SourceTypeExternal,
+				External: &mortisev1alpha1.ExternalSource{
+					Host: "redis.provider.cloud",
+					Port: 6379,
+				},
+			},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(app).WithObjects(app).Build()
+	conflicts := &appStatusConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	var fresh mortisev1alpha1.App
+	if err := conflicts.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if _, err := r.reconcileExternalSource(ctx, &fresh); err != nil {
+		t.Fatalf("reconcile external source: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient status conflict")
+	}
+
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app after reconcile: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected ready phase, got %q", fresh.Status.Phase)
+	}
+}
+
+func TestReconcileExternalSourceDomainCollisionRetriesStatusConflict(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add networking scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", UID: types.UID("project-uid")},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ext-public",
+			Namespace: "pj-demo",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type: mortisev1alpha1.SourceTypeExternal,
+				External: &mortisev1alpha1.ExternalSource{
+					Host: "admin.managed-db.example.com",
+					Port: 443,
+				},
+			},
+			Network: mortisev1alpha1.NetworkConfig{Public: true},
+			Environments: []mortisev1alpha1.Environment{{
+				Name:   "production",
+				Domain: "db-admin.example.com",
+			}},
+		},
+	}
+	collision := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other",
+			Namespace: "pj-other-production",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "mortise",
+				constants.AppNameLabel:         "other-app",
+				constants.ProjectLabel:         "other",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{Host: "db-admin.example.com"}},
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app).
+		WithObjects(project, app, collision).
+		Build()
+	conflicts := &appStatusConflictClient{Client: base}
+
+	r := &AppReconciler{Client: conflicts, Scheme: scheme}
+	var fresh mortisev1alpha1.App
+	if err := conflicts.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if _, err := r.reconcileExternalSource(ctx, &fresh); err != nil {
+		t.Fatalf("reconcile external source: %v", err)
+	}
+	if !conflicts.fired {
+		t.Fatal("expected transient status conflict")
+	}
+
+	if err := base.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app after reconcile: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		t.Fatalf("expected failed phase, got %q", fresh.Status.Phase)
+	}
+	cond := findStatusCondition(fresh.Status.Conditions, "DomainCollision")
+	if cond == nil || cond.Reason != "DomainInUse" {
+		t.Fatalf("unexpected domain collision condition: %+v", cond)
 	}
 }
 
@@ -161,6 +373,69 @@ func (c *namespaceAlreadyExistsClient) Create(ctx context.Context, obj client.Ob
 		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, ns.Name)
 	}
 	return c.Client.Create(ctx, obj, opts...)
+}
+
+type staleNamespaceCacheClient struct {
+	client.Client
+	fired       bool
+	createCalls int
+}
+
+func (c *staleNamespaceCacheClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.Namespace); ok {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *staleNamespaceCacheClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if ns, ok := obj.(*corev1.Namespace); ok {
+		c.createCalls++
+		if c.createCalls > 1 {
+			return fmt.Errorf("unexpected recursive create for namespace %s", ns.Name)
+		}
+		c.fired = true
+		if err := c.Client.Create(ctx, ns.DeepCopy(), opts...); err != nil {
+			return err
+		}
+		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, ns.Name)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+type appStatusConflictClient struct {
+	client.Client
+	fired bool
+}
+
+func (c *appStatusConflictClient) Status() client.SubResourceWriter {
+	return &appStatusConflictWriter{SubResourceWriter: c.Client.Status(), parent: c}
+}
+
+type appStatusConflictWriter struct {
+	client.SubResourceWriter
+	parent *appStatusConflictClient
+}
+
+func (w *appStatusConflictWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if _, ok := obj.(*mortisev1alpha1.App); ok && !w.parent.fired {
+		w.parent.fired = true
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: mortisev1alpha1.GroupVersion.Group, Resource: "apps/status"},
+			obj.GetName(),
+			context.DeadlineExceeded,
+		)
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+func findStatusCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -108,7 +108,8 @@ func asNamespaceResolveError(err error) (*namespaceResolveError, bool) {
 // delete, and propagates env-set changes to owned Apps.
 type ProjectReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	APIReader client.Reader
 }
 
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=projects,verbs=get;list;watch;create;update;patch;delete
@@ -326,11 +327,16 @@ func (r *ProjectReconciler) ensureNamespace(ctx context.Context, project *mortis
 		}
 		if err := r.Create(ctx, desired); err != nil {
 			if errors.IsAlreadyExists(err) {
-				return r.ensureNamespace(ctx, project, nsName, spec)
+				if err := r.namespaceReader().Get(ctx, types.NamespacedName{Name: nsName}, &existing); err != nil {
+					return fmt.Errorf("get namespace after already exists: %w", err)
+				}
+				getErr = nil
+			} else {
+				return fmt.Errorf("create namespace: %w", err)
 			}
-			return fmt.Errorf("create namespace: %w", err)
+		} else {
+			return nil
 		}
-		return nil
 	}
 	if getErr != nil {
 		return fmt.Errorf("get namespace: %w", getErr)
@@ -413,6 +419,13 @@ func (r *ProjectReconciler) checkControlNamespaceUniqueness(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+func (r *ProjectReconciler) namespaceReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // gcStaleEnvNamespaces deletes any env namespace labelled for this project but

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -325,6 +325,9 @@ func (r *ProjectReconciler) ensureNamespace(ctx context.Context, project *mortis
 			return fmt.Errorf("set owner ref on namespace: %w", err)
 		}
 		if err := r.Create(ctx, desired); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return r.ensureNamespace(ctx, project, nsName, spec)
+			}
 			return fmt.Errorf("create namespace: %w", err)
 		}
 		return nil

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -31,16 +31,17 @@
 		}
 		lastSeenSpec = app.spec;
 	});
-	function cloneSpec(): AppSpec { return JSON.parse(JSON.stringify(specOverride ?? app.spec)); }
+	const effectiveSpec = $derived(specOverride ?? app.spec);
+	function cloneSpec(): AppSpec { return JSON.parse(JSON.stringify(effectiveSpec)); }
 
 	function handleSpecUpdate(spec: AppSpec) {
 		specOverride = spec;
 	}
 
 	const selectedEnv = $derived(
-		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
+		store.currentEnv(project) || effectiveSpec.environments?.[0]?.name || 'production'
 	);
-	const envEntry = $derived(app.spec.environments?.find(e => e.name === selectedEnv));
+	const envEntry = $derived(effectiveSpec.environments?.find(e => e.name === selectedEnv));
 	const envEnabled = $derived(envEntry?.enabled !== false);
 	let togglingEnabled = $state(false);
 

--- a/ui/tests/e2e/environments.spec.ts
+++ b/ui/tests/e2e/environments.spec.ts
@@ -393,9 +393,16 @@ test.describe('app drawer env interpolation', () => {
     await enabledSwitch.scrollIntoViewIfNeeded();
     await expect(enabledSwitch).toBeVisible({ timeout: 10_000 });
     await expect(enabledSwitch).toBeEnabled({ timeout: 10_000 });
+    await expect(enabledSwitch).toHaveAttribute('aria-checked', 'true', { timeout: 5_000 });
 
-    // Click to disable the env and verify via API.
+    // Click to disable the env. The drawer should reflect the saved state
+    // immediately, before any prop refresh or page reload.
     await enabledSwitch.click();
+    await expect(enabledSwitch).toHaveAttribute('aria-checked', 'false', { timeout: 10_000 });
+    await expect(enabledSwitch).toHaveClass(/bg-surface-600/, { timeout: 10_000 });
+    await expect(enabledSwitch.locator('span')).toHaveClass(/translate-x-0\.5/, { timeout: 10_000 });
+
+    // Verify via API that the persisted spec matches the local UI state.
     await expect(async () => {
       const app = await getAppViaAPI(request, token, project, appName);
       const spec = app.spec as { environments?: Array<{ name: string; enabled?: boolean }> };
@@ -416,6 +423,9 @@ test.describe('app drawer env interpolation', () => {
 
     // Click to re-enable.
     await enabledSwitch.click();
+    await expect(enabledSwitch).toHaveAttribute('aria-checked', 'true', { timeout: 10_000 });
+    await expect(enabledSwitch).toHaveClass(/bg-accent/, { timeout: 10_000 });
+    await expect(enabledSwitch.locator('span')).toHaveClass(/translate-x-4\.5/, { timeout: 10_000 });
     await expect(async () => {
       const app = await getAppViaAPI(request, token, project, appName);
       const spec = app.spec as { environments?: Array<{ name: string; enabled?: boolean }> };


### PR DESCRIPTION
## Summary
This consolidates the fixes and regression coverage requested in hq-53t for issues #279, #280, #281, #290, and #295, plus the follow-up controller hardening needed after the first `#311` UI E2E CI failure.

## What changed
- Added a focused `UpdateApp` conflict-retry regression for `#279` proving the API survives a one-shot optimistic-lock conflict and persists the requested spec update.
- Fixed `#280` in the settings drawer by deriving the environment toggle state from the effective local spec (`specOverride ?? app.spec`) instead of stale props, and tightened the focused Playwright regression so the switch state must update immediately in the UI before any reload.
- Fixed `#281` by moving project environment creation to a retrying read-modify-write path against the live `Project`, with duplicate detection on each retry, and added focused envtest coverage that simulates a concurrent project update so the default `production` environment is preserved while `staging` is added.
- Hardened controller reconcile paths that were still dropping state under full-suite load by retrying `App` finalizer updates on conflict and treating concurrent project namespace creation as idempotent.
- Added controller tests covering finalizer update conflicts and concurrent namespace creation.
- Verified that the current `main` baseline already addresses `#290` via durable `BuildRun` state rather than in-memory-only build tracking, and already addresses `#295` via latched webhook registration/failure state keyed by stable inputs. This PR keeps those as verified regressions rather than duplicating existing tests.

## Root cause
- `#279`: the bug was previously caused by full-object update conflicts during concurrent controller writes; current server code already retries, but a focused regression test was missing.
- `#280`: the UI toggle rendered from `app.spec` while saves updated `specOverride`, so the persisted change could succeed while the switch stayed visually stale.
- `#281`: the create-environment path appended to a stale `Project.Spec.Environments` snapshot and called `client.Update`, which could drop concurrent controller/API changes.
- Follow-up `#311` CI failure: under full UI E2E load, controller reconcile conflicts around `App` finalizer updates and project namespace creation could abort downstream reconciliation work. That left later requests observing missing derived state, which matched the cross-signal integration failure where cloned env secrets stayed empty even though the cloned spec values were correct.
- `#290`: current `main` already persists build execution state through `BuildRun` objects.
- `#295`: current `main` already latches webhook registration success/failure in status conditions instead of retrying permanent failures forever.

## Validation
- `KUBEBUILDER_ASSETS=/Users/meesh/gt-codex/mortise/polecats/nitro/mortise/bin/k8s/1.35.0-darwin-arm64 go test ./internal/api -run '^(TestUpdateApp|TestUpdateAppRetriesConflict|TestCreateProjectEnvironment|TestCreateProjectEnvironmentPreservesConcurrentProjectUpdate|TestCreateProjectEnvironmentDuplicate|TestCreateProjectEnvironmentInvalidName|TestCreateProjectEnvironmentAsMemberForbidden)$'`
- `go test ./internal/controller -run '^(TestAddAppFinalizerWithRetry|TestRemoveAppFinalizerWithRetry|TestEnsureNamespaceHandlesAlreadyExistsFromConcurrentCreate)$'`
- `go test -tags=integration ./test/integration -run TestEnvironmentCloneCreatesEnvWithConfig -count=1`
- `npm run check` in `ui/`
- `CI=1 MORTISE_BASE_URL=http://localhost:8091 MORTISE_ADMIN_EMAIL=admin@local MORTISE_ADMIN_PASSWORD=admin123 npx playwright test`

## Polecat ownership
The code landed through real Gas Town polecat branches and was then integrated into crew3:
- `mo-wisp-eeg` / `nitro`: `#279` regression coverage
- `mo-wisp-0eh` / `rust`: `#280` UI fix and focused E2E tightening
- `mo-wisp-clk` / `chrome`: `#281` API fix and focused envtest coverage
- `mo-ab4` / `guzzle`: controller reconcile hardening after the draft PR CI failure
