### PR TITLE
[codex] fix #316 viewer project visibility

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2654,8 +2654,8 @@ paths:
       - platform
   /projects:
     get:
-      description: Returns projects the caller has access to. Admins see all; members
-        see only their projects.
+      description: Returns projects the caller has access to. Admins see all; other
+        users see only their projects.
       produces:
       - application/json
       responses:

--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -133,7 +133,7 @@ func (s *Server) readableProjects(r *http.Request) ([]string, error) {
 	}
 
 	principal := PrincipalFromContext(r.Context())
-	if principal != nil && (principal.Role == auth.RoleAdmin || principal.Role == auth.RoleViewer) {
+	if principal != nil && principal.Role == auth.RoleAdmin {
 		out := make([]string, 0, len(projectList.Items))
 		for i := range projectList.Items {
 			out = append(out, projectList.Items[i].Name)

--- a/internal/api/activity_test.go
+++ b/internal/api/activity_test.go
@@ -320,6 +320,58 @@ func TestListPlatformActivityHonorsProjectAccess(t *testing.T) {
 	}
 }
 
+func TestListPlatformActivityAsViewerHonorsProjectMembership(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	const allowedProject = "viewer-allowed-316"
+	const blockedProject = "viewer-blocked-316"
+	seedProject(t, k8sClient, allowedProject)
+	seedProject(t, k8sClient, blockedProject)
+	seedProjectMember(t, k8sClient, allowedProject, "test@example.com", mortisev1alpha1.ProjectRoleViewer)
+
+	store := activity.NewConfigMapStore(k8sClient)
+	if err := store.Append(context.Background(), activity.Event{
+		Timestamp:    time.Now().Add(-2 * time.Minute),
+		Actor:        "test@example.com",
+		Action:       "deploy",
+		ResourceKind: "app",
+		ResourceName: "ok",
+		Project:      allowedProject,
+		Message:      "Allowed event",
+	}); err != nil {
+		t.Fatalf("append allowed event: %v", err)
+	}
+	if err := store.Append(context.Background(), activity.Event{
+		Timestamp:    time.Now().Add(-1 * time.Minute),
+		Actor:        "other@example.com",
+		Action:       "deploy",
+		ResourceKind: "app",
+		ResourceName: "nope",
+		Project:      blockedProject,
+		Message:      "Blocked event",
+	}); err != nil {
+		t.Fatalf("append blocked event: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/activity?limit=10", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var events []activityEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&events); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 visible event, got %d", len(events))
+	}
+	if events[0].Project != allowedProject {
+		t.Fatalf("expected only allowed project event, got project=%q", events[0].Project)
+	}
+}
+
 func TestListPlatformActivityLimitValidation(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2654,8 +2654,8 @@ paths:
       - platform
   /projects:
     get:
-      description: Returns projects the caller has access to. Admins see all; members
-        see only their projects.
+      description: Returns projects the caller has access to. Admins see all; other
+        users see only their projects.
       produces:
       - application/json
       responses:

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
-	"github.com/mortise-org/mortise/internal/auth"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 )
@@ -216,7 +215,7 @@ func (s *Server) CheckProjectNameAvailable(w http.ResponseWriter, r *http.Reques
 }
 
 // @Summary List projects
-// @Description Returns projects the caller has access to. Admins see all; members see only their projects.
+// @Description Returns projects the caller has access to. Admins see all; other users see only their projects.
 // @Tags projects
 // @Produce json
 // @Security BearerAuth
@@ -225,9 +224,9 @@ func (s *Server) CheckProjectNameAvailable(w http.ResponseWriter, r *http.Reques
 // @Failure 403 {object} errorResponse
 // @Router /projects [get]
 //
-// ListProjects returns Projects the caller has access to. Admins and platform
-// viewers see all projects; regular members see only projects where they hold
-// a ProjectMember.
+// ListProjects returns Projects the caller has access to. Admins see all
+// projects; viewers and members see only projects where they hold a
+// ProjectMember.
 func (s *Server) ListProjects(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "project"}, authz.ActionRead) {
 		return
@@ -249,40 +248,22 @@ func (s *Server) ListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	principal := PrincipalFromContext(r.Context())
-
-	// Admins and platform viewers see everything.
-	if principal != nil && (principal.Role == auth.RoleAdmin || principal.Role == auth.RoleViewer) {
-		resp := make([]projectResponse, 0, len(list.Items))
-		for i := range list.Items {
-			resp = append(resp, toProjectResponse(&list.Items[i], allApps.Items))
-		}
-		writeJSON(w, http.StatusOK, resp)
-		return
-	}
-
-	// For regular members, build a set of projects where this user has membership.
-	var allMembers mortisev1alpha1.ProjectMemberList
-	if err := s.client.List(r.Context(), &allMembers,
-		client.MatchingLabels{"mortise.dev/member": "true"},
-	); err != nil {
+	readableProjects, err := s.readableProjects(r)
+	if err != nil {
 		writeError(w, r, err)
 		return
 	}
-	memberProjects := make(map[string]bool, len(allMembers.Items))
-	if principal != nil {
-		for _, m := range allMembers.Items {
-			if m.Spec.Email == principal.Email {
-				memberProjects[m.Spec.Project] = true
-			}
-		}
+	readable := make(map[string]struct{}, len(readableProjects))
+	for _, name := range readableProjects {
+		readable[name] = struct{}{}
 	}
 
 	resp := make([]projectResponse, 0, len(list.Items))
 	for i := range list.Items {
-		if memberProjects[list.Items[i].Name] {
-			resp = append(resp, toProjectResponse(&list.Items[i], allApps.Items))
+		if _, ok := readable[list.Items[i].Name]; !ok {
+			continue
 		}
+		resp = append(resp, toProjectResponse(&list.Items[i], allApps.Items))
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -129,6 +129,49 @@ func TestListProjectsAsMember(t *testing.T) {
 	}
 }
 
+func TestListProjectsAsViewerWithMembership(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	const visibleProject = "viewer-visible-316"
+	const hiddenProject = "viewer-hidden-316"
+	seedProject(t, k8sClient, visibleProject)
+	seedProject(t, k8sClient, hiddenProject)
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	seedProjectMember(t, k8sClient, visibleProject, "test@example.com", mortisev1alpha1.ProjectRoleViewer)
+
+	w := doRequest(h, http.MethodGet, "/api/projects", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for viewer listing projects, got %d: %s", w.Code, w.Body.String())
+	}
+	var projects []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&projects)
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project (only the one with membership), got %d", len(projects))
+	}
+	if projects[0]["name"] != visibleProject {
+		t.Fatalf("expected visible project, got %+v", projects)
+	}
+}
+
+func TestListProjectsAsViewerWithoutMembership(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "viewer-empty-visible-316")
+	seedProject(t, k8sClient, "viewer-empty-hidden-316")
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodGet, "/api/projects", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for viewer listing projects, got %d: %s", w.Code, w.Body.String())
+	}
+	var projects []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&projects)
+	if len(projects) != 0 {
+		t.Fatalf("expected 0 projects without membership, got %d", len(projects))
+	}
+}
+
 // TestGetProjectAsMember verifies project members can read a single project.
 func TestGetProjectAsMember(t *testing.T) {
 	k8sClient := setupEnvtest(t)

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -187,6 +187,20 @@ func TestGetProjectAsMember(t *testing.T) {
 	}
 }
 
+func TestGetProjectAsViewerWithMembership(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "viewer-readable")
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	seedProjectMember(t, k8sClient, "viewer-readable", "test@example.com", mortisev1alpha1.ProjectRoleViewer)
+
+	w := doRequest(h, http.MethodGet, "/api/projects/viewer-readable", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for viewer getting project with membership, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestGetProjectNonMemberForbidden verifies non-members cannot read a project.
 func TestGetProjectNonMemberForbidden(t *testing.T) {
 	k8sClient := setupEnvtest(t)
@@ -197,6 +211,18 @@ func TestGetProjectNonMemberForbidden(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/projects/private", nil)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for non-member, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetProjectAsViewerWithoutMembershipForbidden(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "viewer-private")
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodGet, "/api/projects/viewer-private", nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for viewer without membership, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the remaining platform-viewer fast paths from project listing and platform activity aggregation
- route `GET /api/projects` through the same membership-aware readable-project filter already used by platform activity
- add viewer-specific regression coverage for one-membership, zero-membership, and filtered activity cases

## Original review finding
Issue #316 identified that PR #259 fixed the core authz engine bypass but left route-level visibility logic treating platform viewers like admins. `GET /api/projects` still returned every project for viewers, and `readableProjects()` still let viewers aggregate activity across projects where they had no `ProjectMember` membership.

## Root cause
The handlers had local role-based shortcuts that bypassed the corrected membership-aware authz model:
- `internal/api/projects.go` returned every project for `RoleViewer`
- `internal/api/activity.go` treated `RoleViewer` like `RoleAdmin` when building the cross-project activity set

Those shortcuts drifted from the post-#259 policy engine contract, where viewers are read-only but still project-scoped.

## Exact fix
- Dropped the viewer fast path from `readableProjects()`, leaving only admins with the platform-wide shortcut.
- Changed `ListProjects` to reuse `readableProjects()` instead of maintaining a separate viewer/member filtering path.
- Updated the list-project handler description and regenerated the published OpenAPI descriptions so they no longer imply broader visibility than the code allows.

## Adjacent misses fixed in this PR
- The project list endpoint was still duplicating its own visibility rules instead of reusing the readable-project helper. This PR consolidates those paths so future authz changes do not drift independently again.
- The generated OpenAPI descriptions for `GET /projects` were stale after the handler comment update; regenerated docs are included.

## Docs / contract updates
- Regenerated `docs/swagger.yaml`
- Regenerated `internal/api/openapi.yaml`

## Tests added / updated
- `TestListProjectsAsViewerWithMembership`
- `TestListProjectsAsViewerWithoutMembership`
- `TestListPlatformActivityAsViewerHonorsProjectMembership`

## Validation
- `KUBEBUILDER_ASSETS=/home/james/workspaces/mortise/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -run 'TestListProjectsAs(ViewerWithMembership|ViewerWithoutMembership|Member)|TestListPlatformActivity(AsViewerHonorsProjectMembership|HonorsProjectAccess)' -count=1`
- `KUBEBUILDER_ASSETS=/home/james/workspaces/mortise/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -count=1`
- `make test-charts`
- `make test`

Fixes #316
