### PR TITLE
[codex] fix #317 preview token cache isolation

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -137,6 +137,9 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		return ctrl.Result{}, err
 	}
+	cacheKey := gitTokenCacheKey(&app)
+	r.gitTokenCache.Delete(cacheKey)
+	defer r.gitTokenCache.Delete(cacheKey)
 
 	// Finalizer flow — owner references can't cross namespaces, so the only
 	// way to clean up per-env-ns resources on App delete is via a finalizer

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -99,7 +99,8 @@ type AppReconciler struct {
 	Builds *BuildTrackerStore
 
 	// gitTokenCache holds the resolved git token for the current reconcile
-	// iteration so per-env builds don't re-resolve credentials. Keyed by app name.
+	// iteration so per-env builds don't re-resolve credentials. Keyed by the
+	// app's control-namespace/name pair.
 	gitTokenCache sync.Map
 
 	GitAPIFactory func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
@@ -433,9 +434,13 @@ func (r *AppReconciler) prepareGitSource(ctx context.Context, app *mortisev1alph
 	}
 
 	// Stash the token transiently for per-env builds during this reconcile.
-	r.gitTokenCache.Store(app.Namespace+"/"+app.Name, tokenResult.Token)
+	r.gitTokenCache.Store(gitTokenCacheKey(app), tokenResult.Token)
 
 	return ctrl.Result{}, true, nil
+}
+
+func gitTokenCacheKey(app *mortisev1alpha1.App) string {
+	return app.Namespace + "/" + app.Name
 }
 
 func (r *AppReconciler) syncOpenPreviews(ctx context.Context, app *mortisev1alpha1.App, project *mortisev1alpha1.Project) error {
@@ -451,7 +456,7 @@ func (r *AppReconciler) syncOpenPreviews(ctx context.Context, app *mortisev1alph
 		return nil
 	}
 
-	tokenVal, _ := r.gitTokenCache.Load(app.Name)
+	tokenVal, _ := r.gitTokenCache.Load(gitTokenCacheKey(app))
 	token, _ := tokenVal.(string)
 
 	var gp mortisev1alpha1.GitProvider
@@ -466,7 +471,7 @@ func (r *AppReconciler) syncOpenPreviews(ctx context.Context, app *mortisev1alph
 			return fmt.Errorf("resolve git token for preview sync: %w", err)
 		}
 		token = tokenResult.Token
-		r.gitTokenCache.Store(app.Name, token)
+		r.gitTokenCache.Store(gitTokenCacheKey(app), token)
 	}
 
 	api, err := r.newGitAPI(&gp, token, "")

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -229,6 +229,199 @@ func TestPreviewSyncStateIncludesBackfillInputs(t *testing.T) {
 	}
 }
 
+func TestSyncOpenPreviewsReusesPrepareGitSourceTokenCacheKey(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	provider := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-preview-cache"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+	app := makeGitSourceApp("web", "pj-alpha", provider.Name)
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName(provider.Name, "test@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("token-alpha")},
+	}
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, Domain: "pr-{number}.example.com"},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(provider, app, tokenSecret).
+		Build()
+
+	usedTokens := make([]string, 0, 1)
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		BuildClient:     &fakeBuildClient{},
+		GitClient:       &fakeGitClient{},
+		RegistryBackend: &fakeRegistryBackend{},
+		GitAPIFactory: func(_ *mortisev1alpha1.GitProvider, token, _ string) (git.GitAPI, error) {
+			usedTokens = append(usedTokens, token)
+			return &fakeWebhookAPI{}, nil
+		},
+	}
+
+	if _, proceed, err := r.prepareGitSource(ctx, app); err != nil {
+		t.Fatalf("prepareGitSource: %v", err)
+	} else if !proceed {
+		t.Fatal("prepareGitSource did not proceed")
+	}
+
+	cacheKey := gitTokenCacheKey(app)
+	cachedToken, ok := r.gitTokenCache.Load(cacheKey)
+	if !ok {
+		t.Fatalf("expected cached token under key %q", cacheKey)
+	}
+	if got := cachedToken.(string); got != "token-alpha" {
+		t.Fatalf("cached token = %q, want %q", got, "token-alpha")
+	}
+	if _, ok := r.gitTokenCache.Load(app.Name); ok {
+		t.Fatalf("unexpected bare app-name cache entry %q after prepare", app.Name)
+	}
+
+	if err := c.Delete(ctx, tokenSecret); err != nil {
+		t.Fatalf("delete token secret: %v", err)
+	}
+
+	if err := r.syncOpenPreviews(ctx, app, project); err != nil {
+		t.Fatalf("syncOpenPreviews: %v", err)
+	}
+
+	if len(usedTokens) != 1 {
+		t.Fatalf("GitAPIFactory called %d times, want 1", len(usedTokens))
+	}
+	if usedTokens[0] != "token-alpha" {
+		t.Fatalf("preview sync used token %q, want %q", usedTokens[0], "token-alpha")
+	}
+	if _, ok := r.gitTokenCache.Load(app.Name); ok {
+		t.Fatalf("unexpected bare app-name cache entry %q after preview sync", app.Name)
+	}
+}
+
+func TestSyncOpenPreviewsIsolatesGitTokenCacheKeysByNamespace(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	provider := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-preview-isolation"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+	appA := makeGitSourceApp("web", "pj-a", provider.Name)
+	appA.Annotations["mortise.dev/created-by"] = "alpha@example.com"
+	appB := makeGitSourceApp("web", "pj-b", provider.Name)
+	appB.Annotations["mortise.dev/created-by"] = "bravo@example.com"
+
+	secretA := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName(provider.Name, "alpha@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("token-alpha")},
+	}
+	secretB := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName(provider.Name, "bravo@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("token-bravo")},
+	}
+	projectA := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, Domain: "pr-{number}.alpha.example.com"},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+	projectB := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "bravo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, Domain: "pr-{number}.bravo.example.com"},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(provider, appA, appB, secretA, secretB).
+		Build()
+
+	usedTokens := make([]string, 0, 2)
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		BuildClient:     &fakeBuildClient{},
+		GitClient:       &fakeGitClient{},
+		RegistryBackend: &fakeRegistryBackend{},
+		GitAPIFactory: func(_ *mortisev1alpha1.GitProvider, token, _ string) (git.GitAPI, error) {
+			usedTokens = append(usedTokens, token)
+			return &fakeWebhookAPI{}, nil
+		},
+	}
+
+	if _, proceed, err := r.prepareGitSource(ctx, appA); err != nil {
+		t.Fatalf("prepareGitSource appA: %v", err)
+	} else if !proceed {
+		t.Fatal("prepareGitSource appA did not proceed")
+	}
+	if _, proceed, err := r.prepareGitSource(ctx, appB); err != nil {
+		t.Fatalf("prepareGitSource appB: %v", err)
+	} else if !proceed {
+		t.Fatal("prepareGitSource appB did not proceed")
+	}
+
+	if err := c.Delete(ctx, secretB); err != nil {
+		t.Fatalf("delete appB token secret: %v", err)
+	}
+
+	if err := r.syncOpenPreviews(ctx, appA, projectA); err != nil {
+		t.Fatalf("syncOpenPreviews appA: %v", err)
+	}
+	if err := r.syncOpenPreviews(ctx, appB, projectB); err != nil {
+		t.Fatalf("syncOpenPreviews appB: %v", err)
+	}
+
+	if len(usedTokens) != 2 {
+		t.Fatalf("GitAPIFactory called %d times, want 2", len(usedTokens))
+	}
+	if usedTokens[0] != "token-alpha" {
+		t.Fatalf("appA preview sync used token %q, want %q", usedTokens[0], "token-alpha")
+	}
+	if usedTokens[1] != "token-bravo" {
+		t.Fatalf("appB preview sync used token %q, want %q", usedTokens[1], "token-bravo")
+	}
+	if _, ok := r.gitTokenCache.Load(appA.Name); ok {
+		t.Fatalf("unexpected bare app-name cache entry %q after isolated preview sync", appA.Name)
+	}
+}
+
 var _ = Describe("App Controller", func() {
 	const namespace = "pj-default-project"
 	const envNsProduction = "pj-default-project-production"

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -422,6 +422,93 @@ func TestSyncOpenPreviewsIsolatesGitTokenCacheKeysByNamespace(t *testing.T) {
 	}
 }
 
+func TestReconcileClearsStaleGitTokenCacheBetweenReconciles(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch scheme: %v", err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add networking scheme: %v", err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add storage scheme: %v", err)
+	}
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	provider := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-preview-stale-cache"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, Domain: "pr-{number}.example.com"},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}},
+		},
+	}
+	app := makeGitSourceApp("web", "pj-alpha", provider.Name)
+	app.Spec.Source.Image = testImageNginx
+	app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{{
+		Name:           "production",
+		LastBuiltSHA:   "main",
+		LastBuiltImage: "registry.example.com/mortise/web:main-production",
+	}}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName(provider.Name, "test@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fresh-token")},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app).
+		WithObjects(provider, project, app, tokenSecret).
+		Build()
+
+	usedTokens := make([]string, 0, 1)
+	r := &AppReconciler{
+		Client: c,
+		Scheme: scheme,
+		GitAPIFactory: func(_ *mortisev1alpha1.GitProvider, token, _ string) (git.GitAPI, error) {
+			usedTokens = append(usedTokens, token)
+			return &fakeWebhookAPI{}, nil
+		},
+	}
+	cacheKey := gitTokenCacheKey(app)
+	r.gitTokenCache.Store(cacheKey, "stale-token")
+
+	if _, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if len(usedTokens) != 1 {
+		t.Fatalf("GitAPIFactory called %d times, want 1", len(usedTokens))
+	}
+	if usedTokens[0] != "fresh-token" {
+		t.Fatalf("preview sync used token %q, want %q", usedTokens[0], "fresh-token")
+	}
+	if _, ok := r.gitTokenCache.Load(cacheKey); ok {
+		t.Fatalf("expected reconcile to clear cache entry %q", cacheKey)
+	}
+}
+
 var _ = Describe("App Controller", func() {
 	const namespace = "pj-default-project"
 	const envNsProduction = "pj-default-project-production"


### PR DESCRIPTION
## Summary

This fixes issue #317 by making git-token cache access use one namespace-qualified key everywhere preview sync touches it.

## Root cause

`prepareGitSource()` already cached the resolved token under `app.Namespace + "/" + app.Name`, but `syncOpenPreviews()` loaded and stored under bare `app.Name`.

That created two problems:
- preview sync could miss the token already resolved earlier in the same reconcile and do unnecessary fallback resolution work
- same-named apps in different control namespaces could share a bare cache key and reuse the wrong repo token during preview reconciliation

## What changed

- added a single `gitTokenCacheKey()` helper in `internal/controller/app_controller.go`
- switched `prepareGitSource()` to store with that helper
- switched `syncOpenPreviews()` to load and store with that same helper
- added regression tests covering:
  - prepare + preview sync sharing the same cache entry
  - same-named apps in different namespaces keeping distinct cached tokens

## Validation

Passed locally:
- `go test ./internal/controller -run 'TestSyncOpenPreviews(ReusesPrepareGitSourceTokenCacheKey|IsolatesGitTokenCacheKeysByNamespace)$'`
- `go test ./internal/previewsync`
- `go test ./internal/controller -run "$(rg -o '^func (Test[^ (]+)' internal/controller/*_test.go | cut -d' ' -f2 | grep -v '^TestControllers$' | paste -sd'|' -)"`

Local environment limitation:
- `go test ./internal/controller` still hits the envtest suite bootstrap and fails before specs run because this machine does not have the required envtest binaries (`../../bin/k8s` missing and `/usr/local/kubebuilder/bin/etcd` missing).

## Impact

Preview backfill now reuses the same in-reconcile git token cache entry as the build path and same-named apps in different projects cannot collide through bare app-name cache access.
