### PR TITLE
[codex] fix #315 buildrun durability follow-up

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -316,6 +316,9 @@ domain" concept does not exist.
 | `GET /api/projects/{p}/apps/{a}/logs` | SSE multi-pod log stream |
 | `GET /api/projects/{p}/apps/{a}/logs/history` | historical log lines |
 | `GET /api/projects/{p}/apps/{a}/build-logs` | build log lines |
+| `GET /api/projects/{p}/apps/{a}/build-runs` | durable build execution history for an app |
+| `GET /api/projects/{p}/build-runs/{name}` | durable build execution detail |
+| `GET /api/projects/{p}/build-runs/{name}/logs` | durable build execution logs |
 | `GET /api/projects/{p}/apps/{a}/pods` | list pods |
 | `GET /api/projects/{p}/apps/{a}/metrics/current` | current pod metrics |
 | `GET /api/projects/{p}/apps/{a}/metrics` | metrics history |

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -101,6 +101,25 @@ definitions:
       value:
         type: string
     type: object
+  api.buildRunLogsResponse:
+    properties:
+      building:
+        type: boolean
+      commitSHA:
+        type: string
+      error:
+        type: string
+      lines:
+        items:
+          type: string
+        type: array
+      offset:
+        type: integer
+      status:
+        type: string
+      timestamp:
+        type: string
+    type: object
   api.changePasswordRequest:
     properties:
       current_password:
@@ -835,6 +854,21 @@ definitions:
     type: object
   v1.FieldsV1:
     type: object
+  v1.LocalObjectReference:
+    properties:
+      name:
+        description: |-
+          Name of the referent.
+          This field is effectively required, but due to backwards compatibility is
+          allowed to be empty. Instances of this type with an empty value here are
+          almost certainly wrong.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          +optional
+          +default=""
+          +kubebuilder:default=""
+          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+        type: string
+    type: object
   v1.ManagedFieldsEntry:
     properties:
       apiVersion:
@@ -1358,6 +1392,36 @@ definitions:
     - BuildModeAuto
     - BuildModeDockerfile
     - BuildModeRailpack
+  v1alpha1.BuildRun:
+    properties:
+      apiVersion:
+        description: |-
+          APIVersion defines the versioned schema of this representation of an object.
+          Servers should convert recognized schemas to the latest internal value, and
+          may reject unrecognized values.
+          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          +optional
+        type: string
+      kind:
+        description: |-
+          Kind is a string value representing the REST resource this object represents.
+          Servers may infer this from the endpoint the client submits requests to.
+          Cannot be updated.
+          In CamelCase.
+          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          +optional
+        type: string
+      metadata:
+        allOf:
+        - $ref: '#/definitions/v1.ObjectMeta'
+        description: +optional
+      spec:
+        $ref: '#/definitions/v1alpha1.BuildRunSpec'
+      status:
+        allOf:
+        - $ref: '#/definitions/v1alpha1.BuildRunStatus'
+        description: +optional
+    type: object
   v1alpha1.BuildRunPhase:
     enum:
     - Pending
@@ -1377,6 +1441,117 @@ definitions:
       phase:
         $ref: '#/definitions/v1alpha1.BuildRunPhase'
     type: object
+  v1alpha1.BuildRunSpec:
+    properties:
+      appName:
+        type: string
+      branch:
+        type: string
+      buildArgs:
+        additionalProperties:
+          type: string
+        type: object
+      buildContext:
+        $ref: '#/definitions/v1alpha1.BuildContext'
+      buildMode:
+        type: string
+      createdBy:
+        type: string
+      dockerfile:
+        type: string
+      dockerfilePath:
+        type: string
+      environment:
+        type: string
+      inputHash:
+        type: string
+      noCache:
+        type: boolean
+      path:
+        type: string
+      providerRef:
+        type: string
+      pullImage:
+        type: string
+      pullTarget:
+        type: string
+      pushImage:
+        type: string
+      pushTarget:
+        type: string
+      repo:
+        type: string
+      requestID:
+        type: string
+      revision:
+        type: string
+      sourcePath:
+        type: string
+      targetRef:
+        $ref: '#/definitions/v1alpha1.BuildRunTargetRef'
+      tokenOwner:
+        type: string
+      tokenSecretRef:
+        $ref: '#/definitions/v1alpha1.SecretRef'
+      trigger:
+        $ref: '#/definitions/v1alpha1.BuildRunTrigger'
+    type: object
+  v1alpha1.BuildRunStatus:
+    properties:
+      completedAt:
+        type: string
+      conditions:
+        description: |-
+          +listType=map
+          +listMapKey=type
+          +optional
+        items:
+          $ref: '#/definitions/v1.Condition'
+        type: array
+      detectedPort:
+        type: integer
+      digest:
+        type: string
+      error:
+        type: string
+      failureMessage:
+        type: string
+      failureReason:
+        type: string
+      finishedAt:
+        type: string
+      image:
+        type: string
+      jobRef:
+        $ref: '#/definitions/v1.LocalObjectReference'
+      logRef:
+        $ref: '#/definitions/v1.LocalObjectReference'
+      phase:
+        $ref: '#/definitions/v1alpha1.BuildRunPhase'
+      startedAt:
+        type: string
+    type: object
+  v1alpha1.BuildRunTargetRef:
+    properties:
+      kind:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+    type: object
+  v1alpha1.BuildRunTrigger:
+    enum:
+    - auto
+    - manual
+    - preview
+    - webhook
+    type: string
+    x-enum-varnames:
+    - BuildRunTriggerAuto
+    - BuildRunTriggerManual
+    - BuildRunTriggerPreview
+    - BuildRunTriggerWebhook
   v1alpha1.ConcurrencyPolicy:
     enum:
     - Allow
@@ -1872,6 +2047,24 @@ definitions:
           Secret names an existing k8s Secret in the App's namespace. Mortise
           does not create or manage this Secret.
           +kubebuilder:validation:Required
+        type: string
+    type: object
+  v1alpha1.SecretRef:
+    properties:
+      key:
+        description: |-
+          Key within the secret.
+          +required
+        type: string
+      name:
+        description: |-
+          Name of the secret.
+          +required
+        type: string
+      namespace:
+        description: |-
+          Namespace of the secret.
+          +required
         type: string
     type: object
   v1alpha1.SourceType:
@@ -3228,6 +3421,42 @@ paths:
       summary: Get build logs for an app
       tags:
       - logs
+  /projects/{project}/apps/{app}/build-runs:
+    get:
+      description: Returns durable build executions for an app, newest first
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/v1alpha1.BuildRun'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: List BuildRuns for an app
+      tags:
+      - buildruns
   /projects/{project}/apps/{app}/connect:
     post:
       description: Start a reverse proxy listener on an auto-allocated local port
@@ -4536,6 +4765,74 @@ paths:
       summary: List bindings for a project environment
       tags:
       - bindings
+  /projects/{project}/build-runs/{name}:
+    get:
+      description: Returns a single durable build execution within a project
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: BuildRun name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1alpha1.BuildRun'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a BuildRun
+      tags:
+      - buildruns
+  /projects/{project}/build-runs/{name}/logs:
+    get:
+      description: Returns durable build logs for a specific BuildRun
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: BuildRun name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.buildRunLogsResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get BuildRun logs
+      tags:
+      - buildruns
   /projects/{project}/environments:
     get:
       description: Returns the project's ordered environment list with aggregated

--- a/internal/api/buildruns.go
+++ b/internal/api/buildruns.go
@@ -335,6 +335,18 @@ func (s *Server) readBuildRunLogSnapshot(ctx context.Context, namespace string, 
 }
 
 // handleListBuildRuns returns durable build executions for an app, newest first.
+//
+// @Summary List BuildRuns for an app
+// @Description Returns durable build executions for an app, newest first
+// @Tags buildruns
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param app path string true "App name"
+// @Success 200 {array} v1alpha1.BuildRun
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project}/apps/{app}/build-runs [get]
 func (s *Server) handleListBuildRuns(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {
@@ -357,6 +369,18 @@ func (s *Server) handleListBuildRuns(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleGetBuildRun returns a single durable build execution within a project.
+//
+// @Summary Get a BuildRun
+// @Description Returns a single durable build execution within a project
+// @Tags buildruns
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param name path string true "BuildRun name"
+// @Success 200 {object} v1alpha1.BuildRun
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project}/build-runs/{name} [get]
 func (s *Server) handleGetBuildRun(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {
@@ -387,6 +411,18 @@ func (s *Server) handleGetBuildRun(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleBuildRunLogs returns build logs for a specific BuildRun.
+//
+// @Summary Get BuildRun logs
+// @Description Returns durable build logs for a specific BuildRun
+// @Tags buildruns
+// @Produce json
+// @Security BearerAuth
+// @Param project path string true "Project name"
+// @Param name path string true "BuildRun name"
+// @Success 200 {object} buildRunLogsResponse
+// @Failure 403 {object} errorResponse
+// @Failure 404 {object} errorResponse
+// @Router /projects/{project}/build-runs/{name}/logs [get]
 func (s *Server) handleBuildRunLogs(w http.ResponseWriter, r *http.Request) {
 	ns, projectName, ok := s.resolveProject(w, r)
 	if !ok {

--- a/internal/api/buildruns_test.go
+++ b/internal/api/buildruns_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -309,6 +311,14 @@ func TestOpenAPISpecIncludesBuildRunRoutes(t *testing.T) {
 		if !strings.Contains(spec, route) {
 			t.Fatalf("expected openapi spec to include %q", route)
 		}
+	}
+
+	docsSpec, err := os.ReadFile(filepath.Join("..", "..", "docs", "swagger.yaml"))
+	if err != nil {
+		t.Fatalf("read docs swagger: %v", err)
+	}
+	if string(docsSpec) != spec {
+		t.Fatal("expected embedded openapi spec to match docs/swagger.yaml")
 	}
 }
 

--- a/internal/api/buildruns_test.go
+++ b/internal/api/buildruns_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,6 +287,28 @@ func TestBuildLogsUsesCurrentBuildRunTrackerAndPersistedRunLogs(t *testing.T) {
 	}
 	if len(terminalResp.Lines) != 2 || terminalResp.Lines[0] != "final 1" {
 		t.Fatalf("unexpected terminal build-logs lines: %+v", terminalResp.Lines)
+	}
+}
+
+func TestOpenAPISpecIncludesBuildRunRoutes(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodGet, "/api/openapi.yaml", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("openapi: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	spec := w.Body.String()
+	for _, route := range []string{
+		"/projects/{project}/apps/{app}/build-runs:",
+		"/projects/{project}/build-runs/{name}:",
+		"/projects/{project}/build-runs/{name}/logs:",
+	} {
+		if !strings.Contains(spec, route) {
+			t.Fatalf("expected openapi spec to include %q", route)
+		}
 	}
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -101,6 +101,25 @@ definitions:
       value:
         type: string
     type: object
+  api.buildRunLogsResponse:
+    properties:
+      building:
+        type: boolean
+      commitSHA:
+        type: string
+      error:
+        type: string
+      lines:
+        items:
+          type: string
+        type: array
+      offset:
+        type: integer
+      status:
+        type: string
+      timestamp:
+        type: string
+    type: object
   api.changePasswordRequest:
     properties:
       current_password:
@@ -835,6 +854,21 @@ definitions:
     type: object
   v1.FieldsV1:
     type: object
+  v1.LocalObjectReference:
+    properties:
+      name:
+        description: |-
+          Name of the referent.
+          This field is effectively required, but due to backwards compatibility is
+          allowed to be empty. Instances of this type with an empty value here are
+          almost certainly wrong.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          +optional
+          +default=""
+          +kubebuilder:default=""
+          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+        type: string
+    type: object
   v1.ManagedFieldsEntry:
     properties:
       apiVersion:
@@ -1358,6 +1392,36 @@ definitions:
     - BuildModeAuto
     - BuildModeDockerfile
     - BuildModeRailpack
+  v1alpha1.BuildRun:
+    properties:
+      apiVersion:
+        description: |-
+          APIVersion defines the versioned schema of this representation of an object.
+          Servers should convert recognized schemas to the latest internal value, and
+          may reject unrecognized values.
+          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          +optional
+        type: string
+      kind:
+        description: |-
+          Kind is a string value representing the REST resource this object represents.
+          Servers may infer this from the endpoint the client submits requests to.
+          Cannot be updated.
+          In CamelCase.
+          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          +optional
+        type: string
+      metadata:
+        allOf:
+        - $ref: '#/definitions/v1.ObjectMeta'
+        description: +optional
+      spec:
+        $ref: '#/definitions/v1alpha1.BuildRunSpec'
+      status:
+        allOf:
+        - $ref: '#/definitions/v1alpha1.BuildRunStatus'
+        description: +optional
+    type: object
   v1alpha1.BuildRunPhase:
     enum:
     - Pending
@@ -1377,6 +1441,117 @@ definitions:
       phase:
         $ref: '#/definitions/v1alpha1.BuildRunPhase'
     type: object
+  v1alpha1.BuildRunSpec:
+    properties:
+      appName:
+        type: string
+      branch:
+        type: string
+      buildArgs:
+        additionalProperties:
+          type: string
+        type: object
+      buildContext:
+        $ref: '#/definitions/v1alpha1.BuildContext'
+      buildMode:
+        type: string
+      createdBy:
+        type: string
+      dockerfile:
+        type: string
+      dockerfilePath:
+        type: string
+      environment:
+        type: string
+      inputHash:
+        type: string
+      noCache:
+        type: boolean
+      path:
+        type: string
+      providerRef:
+        type: string
+      pullImage:
+        type: string
+      pullTarget:
+        type: string
+      pushImage:
+        type: string
+      pushTarget:
+        type: string
+      repo:
+        type: string
+      requestID:
+        type: string
+      revision:
+        type: string
+      sourcePath:
+        type: string
+      targetRef:
+        $ref: '#/definitions/v1alpha1.BuildRunTargetRef'
+      tokenOwner:
+        type: string
+      tokenSecretRef:
+        $ref: '#/definitions/v1alpha1.SecretRef'
+      trigger:
+        $ref: '#/definitions/v1alpha1.BuildRunTrigger'
+    type: object
+  v1alpha1.BuildRunStatus:
+    properties:
+      completedAt:
+        type: string
+      conditions:
+        description: |-
+          +listType=map
+          +listMapKey=type
+          +optional
+        items:
+          $ref: '#/definitions/v1.Condition'
+        type: array
+      detectedPort:
+        type: integer
+      digest:
+        type: string
+      error:
+        type: string
+      failureMessage:
+        type: string
+      failureReason:
+        type: string
+      finishedAt:
+        type: string
+      image:
+        type: string
+      jobRef:
+        $ref: '#/definitions/v1.LocalObjectReference'
+      logRef:
+        $ref: '#/definitions/v1.LocalObjectReference'
+      phase:
+        $ref: '#/definitions/v1alpha1.BuildRunPhase'
+      startedAt:
+        type: string
+    type: object
+  v1alpha1.BuildRunTargetRef:
+    properties:
+      kind:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+    type: object
+  v1alpha1.BuildRunTrigger:
+    enum:
+    - auto
+    - manual
+    - preview
+    - webhook
+    type: string
+    x-enum-varnames:
+    - BuildRunTriggerAuto
+    - BuildRunTriggerManual
+    - BuildRunTriggerPreview
+    - BuildRunTriggerWebhook
   v1alpha1.ConcurrencyPolicy:
     enum:
     - Allow
@@ -1872,6 +2047,24 @@ definitions:
           Secret names an existing k8s Secret in the App's namespace. Mortise
           does not create or manage this Secret.
           +kubebuilder:validation:Required
+        type: string
+    type: object
+  v1alpha1.SecretRef:
+    properties:
+      key:
+        description: |-
+          Key within the secret.
+          +required
+        type: string
+      name:
+        description: |-
+          Name of the secret.
+          +required
+        type: string
+      namespace:
+        description: |-
+          Namespace of the secret.
+          +required
         type: string
     type: object
   v1alpha1.SourceType:
@@ -3228,6 +3421,42 @@ paths:
       summary: Get build logs for an app
       tags:
       - logs
+  /projects/{project}/apps/{app}/build-runs:
+    get:
+      description: Returns durable build executions for an app, newest first
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: App name
+        in: path
+        name: app
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/v1alpha1.BuildRun'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: List BuildRuns for an app
+      tags:
+      - buildruns
   /projects/{project}/apps/{app}/connect:
     post:
       description: Start a reverse proxy listener on an auto-allocated local port
@@ -4536,6 +4765,74 @@ paths:
       summary: List bindings for a project environment
       tags:
       - bindings
+  /projects/{project}/build-runs/{name}:
+    get:
+      description: Returns a single durable build execution within a project
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: BuildRun name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1alpha1.BuildRun'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a BuildRun
+      tags:
+      - buildruns
+  /projects/{project}/build-runs/{name}/logs:
+    get:
+      description: Returns durable build logs for a specific BuildRun
+      parameters:
+      - description: Project name
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: BuildRun name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.buildRunLogsResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get BuildRun logs
+      tags:
+      - buildruns
   /projects/{project}/environments:
     get:
       description: Returns the project's ordered environment list with aggregated

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -44,6 +45,7 @@ const buildRunPollInterval = 15 * time.Second
 type BuildRunReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
+	Clock           clock.Clock
 	BuildClient     build.BuildClient
 	GitClient       git.GitClient
 	RegistryBackend registry.RegistryBackend
@@ -217,7 +219,7 @@ func (r *BuildRunReconciler) persistBuildRunLog(ctx context.Context, br *mortise
 	}
 
 	annotations := map[string]string{
-		buildLogAnnotationTimestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		buildLogAnnotationTimestamp: r.clock().Now().UTC().Format(time.RFC3339Nano),
 		buildLogAnnotationCommit:    br.Spec.Revision,
 		buildLogAnnotationStatus:    status,
 	}
@@ -325,6 +327,13 @@ func parseImageRef(full string) registry.ImageRef {
 		ref.Path = ref.Path[:idx]
 	}
 	return ref
+}
+
+func (r *BuildRunReconciler) clock() clock.Clock {
+	if r.Clock != nil {
+		return r.Clock
+	}
+	return clock.RealClock{}
 }
 
 func (r *BuildRunReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/buildrun_support.go
+++ b/internal/controller/buildrun_support.go
@@ -24,18 +24,20 @@ const (
 	buildRunEnvironmentLabel            = "mortise.dev/buildrun-environment"
 	rebuildRequestedAtAnnotation        = "mortise.dev/rebuild-requested-at"
 	rebuildNoCacheRequestedAtAnnotation = "mortise.dev/rebuild-no-cache-requested-at"
+	maxK8sNameLength                    = 63
 )
 
 func buildRunName(kind, targetName, environment, revision, inputHash, requestID string) string {
 	base := fmt.Sprintf("%s-%s-%s-%s", strings.ToLower(kind), targetName, environment, shortTag(revision))
+	suffix := shortHash(inputHash)
 	if requestID != "" {
-		return sanitizeK8sName(base + "-" + shortHash(requestID))
+		suffix = shortHash(requestID)
 	}
-	return sanitizeK8sName(base + "-" + shortHash(inputHash))
+	return sanitizeK8sNameWithSuffix(base, suffix, "buildrun")
 }
 
 func buildRunLogConfigMapName(runName string) string {
-	return sanitizeK8sName("buildrun-" + runName)
+	return sanitizeK8sNameWithSuffix("buildrun-"+runName, shortHash(runName), "buildrun")
 }
 
 func shortHash(v string) string {
@@ -44,18 +46,49 @@ func shortHash(v string) string {
 }
 
 func sanitizeK8sName(v string) string {
-	v = strings.ToLower(v)
-	repl := strings.NewReplacer("/", "-", "_", "-", ".", "-", ":", "-", "@", "-")
-	v = repl.Replace(v)
-	v = strings.Trim(v, "-")
-	if len(v) > 63 {
-		v = v[:63]
+	v = sanitizeK8sNamePart(v)
+	if len(v) > maxK8sNameLength {
+		v = v[:maxK8sNameLength]
 	}
 	v = strings.Trim(v, "-")
 	if v == "" {
 		return "buildrun"
 	}
 	return v
+}
+
+func sanitizeK8sNameWithSuffix(prefix, suffix, fallback string) string {
+	suffix = sanitizeK8sNamePart(suffix)
+	if suffix == "" {
+		return sanitizeK8sName(prefix)
+	}
+
+	prefix = sanitizeK8sNamePart(prefix)
+	maxPrefixLen := maxK8sNameLength - len(suffix) - 1
+	if maxPrefixLen <= 0 {
+		return suffix[:maxK8sNameLength]
+	}
+
+	if len(prefix) > maxPrefixLen {
+		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+	}
+	if prefix == "" {
+		prefix = sanitizeK8sNamePart(fallback)
+		if len(prefix) > maxPrefixLen {
+			prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+		}
+	}
+	if prefix == "" {
+		return suffix
+	}
+	return prefix + "-" + suffix
+}
+
+func sanitizeK8sNamePart(v string) string {
+	v = strings.ToLower(v)
+	repl := strings.NewReplacer("/", "-", "_", "-", ".", "-", ":", "-", "@", "-")
+	v = repl.Replace(v)
+	return strings.Trim(v, "-")
 }
 
 func buildRunInputHash(spec mortisev1alpha1.BuildRunSpec) string {

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -2,12 +2,15 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clocktesting "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -80,6 +83,52 @@ func TestParseImageRefSplitsRegistryPathAndTag(t *testing.T) {
 	}
 	if ref.Tag != "sha-prod" {
 		t.Fatalf("tag = %q", ref.Tag)
+	}
+}
+
+func TestBuildRunNamePreservesUniquenessSuffixForLongNames(t *testing.T) {
+	targetName := strings.Repeat("demo-app-", 8)
+	first := buildRunName("app", targetName, "production", "abcdef1234567890", "input-one", "request-one")
+	second := buildRunName("app", targetName, "production", "abcdef1234567890", "input-two", "request-two")
+
+	if len(first) > maxK8sNameLength {
+		t.Fatalf("first buildrun name too long: %d", len(first))
+	}
+	if len(second) > maxK8sNameLength {
+		t.Fatalf("second buildrun name too long: %d", len(second))
+	}
+	if first == second {
+		t.Fatalf("expected distinct buildrun names, got %q", first)
+	}
+	if !strings.HasSuffix(first, "-"+shortHash("request-one")) {
+		t.Fatalf("expected first buildrun name to preserve request suffix, got %q", first)
+	}
+	if !strings.HasSuffix(second, "-"+shortHash("request-two")) {
+		t.Fatalf("expected second buildrun name to preserve request suffix, got %q", second)
+	}
+}
+
+func TestBuildRunLogConfigMapNamePreservesUniquenessForLongRunNames(t *testing.T) {
+	runOne := buildRunName("app", strings.Repeat("service-", 8), "production", "abcdef1234567890", "input-one", "request-one")
+	runTwo := buildRunName("app", strings.Repeat("service-", 8), "production", "abcdef1234567890", "input-two", "request-two")
+
+	logOne := buildRunLogConfigMapName(runOne)
+	logTwo := buildRunLogConfigMapName(runTwo)
+
+	if len(logOne) > maxK8sNameLength {
+		t.Fatalf("first buildrun log configmap name too long: %d", len(logOne))
+	}
+	if len(logTwo) > maxK8sNameLength {
+		t.Fatalf("second buildrun log configmap name too long: %d", len(logTwo))
+	}
+	if logOne == logTwo {
+		t.Fatalf("expected distinct log configmap names, got %q", logOne)
+	}
+	if !strings.HasSuffix(logOne, "-"+shortHash(runOne)) {
+		t.Fatalf("expected first configmap name to preserve run hash suffix, got %q", logOne)
+	}
+	if !strings.HasSuffix(logTwo, "-"+shortHash(runTwo)) {
+		t.Fatalf("expected second configmap name to preserve run hash suffix, got %q", logTwo)
 	}
 }
 
@@ -557,7 +606,8 @@ func TestPersistBuildRunLogKeepsLegacyAppConfigMap(t *testing.T) {
 		},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
-	r := &BuildRunReconciler{Client: c, Scheme: scheme}
+	fakeClock := clocktesting.NewFakeClock(time.Date(2026, 5, 10, 18, 45, 0, 123456789, time.UTC))
+	r := &BuildRunReconciler{Client: c, Scheme: scheme, Clock: fakeClock}
 
 	run := &mortisev1alpha1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -589,6 +639,9 @@ func TestPersistBuildRunLogKeepsLegacyAppConfigMap(t *testing.T) {
 	}
 	if durable.OwnerReferences[0].Kind != "BuildRun" {
 		t.Fatalf("expected durable log owner BuildRun, got %+v", durable.OwnerReferences)
+	}
+	if got := durable.Annotations[buildLogAnnotationTimestamp]; got != fakeClock.Now().UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("expected durable log timestamp %q, got %q", fakeClock.Now().UTC().Format(time.RFC3339Nano), got)
 	}
 
 	var legacy corev1.ConfigMap


### PR DESCRIPTION
## Summary
- reserve BuildRun suffix space so long app/environment names only trim the readable prefix
- make durable BuildRun log ConfigMap names collision-free and cover the new naming behavior with focused tests
- replace the touched BuildRun controller `time.Now()` usage with the injected clock and publish the BuildRun API routes in SPEC/OpenAPI/Swagger

## Root Cause
PR #296 appended the uniqueness suffix and then truncated the entire Kubernetes name at 63 characters. For long names, that removed the suffix entirely, so distinct rebuild requests collapsed onto the same durable `BuildRun` identity. The persisted BuildRun log ConfigMap name then prepended `buildrun-` to an already-max-length run name and truncated again, creating another collision surface. The BuildRun API handlers were mounted in the server but lacked Swagger annotations, so the published contract omitted them. The touched log persistence path also stamped timestamps with real wall clock time instead of the reconciler's injected clock.

## What Changed
- added a suffix-preserving name helper that sanitizes first, reserves suffix space, and truncates only the readable prefix
- updated `buildRunName()` to keep the request/input hash suffix intact for long names
- updated `buildRunLogConfigMapName()` to keep a collision-proof suffix derived from the run name
- switched `persistBuildRunLog()` to `r.clock().Now()`
- added BuildRun route annotations plus a regression test that asserts the served OpenAPI spec includes the BuildRun endpoints
- regenerated `docs/swagger.yaml` and `internal/api/openapi.yaml`
- documented the published BuildRun routes in `SPEC.md`

## Validation
- `go test ./internal/controller -run 'TestBuildRunNamePreservesUniquenessSuffixForLongNames|TestBuildRunLogConfigMapNamePreservesUniquenessForLongRunNames|TestPersistBuildRunLogKeepsLegacyAppConfigMap'`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'TestBuildRunEndpointsListDetailAndLogs|TestBuildLogsUsesCurrentBuildRunTrackerAndPersistedRunLogs|TestOpenAPISpecIncludesBuildRunRoutes'`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/controller`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/api`
