### PR TITLE
[codex] fix #318 sse redeem revalidation

### DIFF
--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -155,8 +155,14 @@ curl -s "$BASE/api/projects/$PROJECT/apps/$APP/metrics/current?env=$ENV" \
 Stream logs (SSE):
 
 ```bash
-curl -N "$BASE/api/projects/$PROJECT/apps/$APP/logs?env=$ENV&follow=true&token=$TOKEN"
+SSE_TOKEN=$(curl -s -X POST "$BASE/api/auth/sse-token" \
+  -H "Authorization: Bearer $TOKEN" | jq -r .token)
+
+curl -N "$BASE/api/projects/$PROJECT/apps/$APP/logs?env=$ENV&follow=true&token=$SSE_TOKEN"
 ```
+
+`POST /api/auth/sse-token` returns a short-lived, single-use opaque token for one
+SSE connection. Do not pass full JWTs in SSE query params.
 
 ## 9) Optional: create deploy token for CI
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -604,6 +604,13 @@ definitions:
       password:
         type: string
     type: object
+  api.sseTokenResponse:
+    properties:
+      expiresIn:
+        type: integer
+      token:
+        type: string
+    type: object
   api.statusResponse:
     properties:
       setupRequired:
@@ -2340,8 +2347,8 @@ paths:
       - auth
   /auth/refresh:
     post:
-      description: Issues a new JWT from an existing token (valid or expired within
-        7 days)
+      description: Revalidates the current user against the auth provider and issues
+        a new JWT from an existing token (valid or expired within 7 days)
       produces:
       - application/json
       responses:
@@ -2398,6 +2405,31 @@ paths:
           schema:
             $ref: '#/definitions/api.errorResponse'
       summary: First-time setup
+      tags:
+      - auth
+  /auth/sse-token:
+    post:
+      description: Exchanges a bearer-authenticated session for a short-lived, single-use
+        opaque SSE token. Redeem revalidates the user against the auth provider before
+        opening the stream.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.sseTokenResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Issue short-lived SSE token
       tags:
       - auth
   /auth/status:

--- a/docs/systems-overview.md
+++ b/docs/systems-overview.md
@@ -102,7 +102,8 @@ The HTTP server is mounted by `internal/api/server.go`.
   - `/api/webhooks/{provider}`
 - Authenticated routes use JWT bearer auth middleware
 - Deploy endpoint supports JWT **or** deploy token (`mrt_*`)
-- SSE routes support JWT query-token fallback (`?token=`) for EventSource clients
+- Browser SSE routes use short-lived, single-use opaque tokens minted by `POST /api/auth/sse-token`
+- JWT refresh revalidates current user state before minting the replacement token
 
 See `docs/api-endpoints.md` and `docs/openapi.yaml` for the full surface.
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -84,8 +84,7 @@ func (s *Server) Status(w http.ResponseWriter, r *http.Request) {
 // @Failure 501 {object} errorResponse
 // @Router /auth/setup [post]
 //
-// Setup creates the first admin user and the `default` Project. Returns 409 if
-// any user already exists.
+// Setup creates the first admin user. Returns 409 if any user already exists.
 func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 	var req setupRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -18,6 +18,21 @@ type refreshPrincipalProvider interface {
 	CurrentPrincipal(ctx context.Context, email string, tokenGen int64) (auth.Principal, error)
 }
 
+var errCurrentPrincipalUnavailable = errors.New("current principal unavailable for this auth provider")
+
+func (s *Server) revalidatePrincipal(ctx context.Context, email string, tokenGen int64) (auth.Principal, error) {
+	if native, ok := s.auth.(*auth.NativeAuthProvider); ok && s.clientset != nil && s.restConfig != nil {
+		return native.CurrentPrincipalLive(ctx, s.clientset, email, tokenGen)
+	}
+
+	refresher, ok := s.auth.(refreshPrincipalProvider)
+	if !ok {
+		return auth.Principal{}, errCurrentPrincipalUnavailable
+	}
+
+	return refresher.CurrentPrincipal(ctx, email, tokenGen)
+}
+
 type setupRequest struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
@@ -135,7 +150,7 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Refresh JWT token
-// @Description Issues a new JWT from an existing token (valid or expired within 7 days)
+// @Description Revalidates the current user against the auth provider and issues a new JWT from an existing token (valid or expired within 7 days)
 // @Tags auth
 // @Produce json
 // @Security BearerAuth
@@ -144,8 +159,9 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} errorResponse
 // @Router /auth/refresh [post]
 //
-// Refresh issues a new JWT from a valid or recently-expired token. The token
-// may be expired for up to 7 days and still be eligible for refresh.
+// Refresh revalidates the current user against the auth provider and issues a
+// new JWT from a valid or recently-expired token. The token may be expired for
+// up to 7 days and still be eligible for refresh.
 func (s *Server) Refresh(w http.ResponseWriter, r *http.Request) {
 	header := r.Header.Get("Authorization")
 	if header == "" || !strings.HasPrefix(header, "Bearer ") {
@@ -164,26 +180,22 @@ func (s *Server) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if native, ok := s.auth.(*auth.NativeAuthProvider); ok && s.clientset != nil && s.restConfig != nil {
-		principal, err = native.CurrentPrincipalLive(r.Context(), s.clientset, principal.Email, tokenGen)
-	} else {
-		refresher, ok := s.auth.(refreshPrincipalProvider)
-		if !ok {
-			writeJSON(w, http.StatusUnauthorized, errorResponse{"token refresh unavailable for this auth provider"})
-			return
-		}
-		principal, err = refresher.CurrentPrincipal(r.Context(), principal.Email, tokenGen)
-	}
+	principal, err = s.revalidatePrincipal(r.Context(), principal.Email, tokenGen)
 	if err != nil {
 		switch {
+		case errors.Is(err, errCurrentPrincipalUnavailable):
+			writeJSON(w, http.StatusUnauthorized, errorResponse{"token refresh unavailable for this auth provider"})
+			return
 		case errors.Is(err, auth.ErrPasswordChangeInvalidated):
 			writeJSON(w, http.StatusUnauthorized, errorResponse{"session invalidated by password change"})
+			return
 		case errors.Is(err, auth.ErrUserNotFound):
 			writeJSON(w, http.StatusUnauthorized, errorResponse{"user no longer exists"})
+			return
 		default:
 			writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+			return
 		}
-		return
 	}
 
 	newToken, err := s.jwt.GenerateToken(r.Context(), principal)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -86,7 +86,9 @@ func maxBytesMiddleware(maxBytes int64) func(http.Handler) http.Handler {
 }
 
 // sseAuthMiddleware handles authentication for SSE endpoints. It accepts only
-// a short-lived, single-use SSE token in the ?token= query parameter.
+// a short-lived, single-use SSE token in the ?token= query parameter and
+// revalidates the user against the auth provider before attaching principal
+// context.
 func (s *Server) sseAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// If Authorization header is already set, let jwtAuthMiddleware handle it.
@@ -102,8 +104,13 @@ func (s *Server) sseAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		if strings.HasPrefix(tok, sseTokenPrefix) {
-			principal, ok := s.sseTokens.Redeem(tok)
+			redeemed, ok := s.sseTokens.Redeem(tok)
 			if !ok {
+				writeJSON(w, http.StatusUnauthorized, errorResponse{"invalid or expired SSE token"})
+				return
+			}
+			principal, err := s.revalidatePrincipal(r.Context(), redeemed.email, redeemed.passwordGen)
+			if err != nil {
 				writeJSON(w, http.StatusUnauthorized, errorResponse{"invalid or expired SSE token"})
 				return
 			}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -604,6 +604,13 @@ definitions:
       password:
         type: string
     type: object
+  api.sseTokenResponse:
+    properties:
+      expiresIn:
+        type: integer
+      token:
+        type: string
+    type: object
   api.statusResponse:
     properties:
       setupRequired:
@@ -2340,8 +2347,8 @@ paths:
       - auth
   /auth/refresh:
     post:
-      description: Issues a new JWT from an existing token (valid or expired within
-        7 days)
+      description: Revalidates the current user against the auth provider and issues
+        a new JWT from an existing token (valid or expired within 7 days)
       produces:
       - application/json
       responses:
@@ -2398,6 +2405,31 @@ paths:
           schema:
             $ref: '#/definitions/api.errorResponse'
       summary: First-time setup
+      tags:
+      - auth
+  /auth/sse-token:
+    post:
+      description: Exchanges a bearer-authenticated session for a short-lived, single-use
+        opaque SSE token. Redeem revalidates the user against the auth provider before
+        opening the stream.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.sseTokenResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+      security:
+      - BearerAuth: []
+      summary: Issue short-lived SSE token
       tags:
       - auth
   /auth/status:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,6 +127,7 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, resource auth
 // URL scheme:
 //
 //	/api/auth/{status|setup|login|refresh}                          unauthenticated
+//	/api/auth/sse-token                                             authenticated — exchanges Bearer auth for short-lived SSE token
 //	/api/webhooks/{provider}                                       unauthenticated — HMAC-verified
 //	/api/auth/git/{provider}/device                                authenticated — device flow initiation
 //	/api/auth/git/{provider}/device/poll                           authenticated — device flow polling
@@ -182,7 +183,6 @@ func (s *Server) Handler() http.Handler {
 			r.Use(s.jwtAuthMiddleware)
 
 			r.Post("/auth/sse-token", s.IssueSSEToken)
-			r.Post("/auth/refresh", s.RefreshToken)
 
 			// Device flow: provider-parameterized routes for per-user git auth.
 			r.Post("/auth/git/{provider}/device", s.deviceFlow.RequestCode)
@@ -314,9 +314,10 @@ func (s *Server) Handler() http.Handler {
 			r.Post("/projects/{project}/apps/{app}/deploy", s.Deploy)
 		})
 
-		// SSE endpoints: authenticated via short-lived SSE token (?token=msse_...)
-		// or Authorization bearer token. sseAuthMiddleware handles SSE-token
-		// query auth, then jwtAuthMiddleware handles bearer-token auth.
+		// SSE endpoints: authenticated via short-lived SSE token
+		// (?token=msse_...) or Authorization bearer token. sseAuthMiddleware
+		// revalidates redeemed SSE tokens, then jwtAuthMiddleware handles bearer
+		// header auth for non-browser clients.
 		r.Group(func(r chi.Router) {
 			r.Use(s.sseAuthMiddleware)
 			r.Use(s.jwtAuthMiddleware)

--- a/internal/api/sse_tokens.go
+++ b/internal/api/sse_tokens.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -132,7 +133,25 @@ func (s *Server) IssueSSEToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.sseTokens.Issue(*p)
+	revalidated, err := s.revalidatePrincipal(r.Context(), p.Email, p.PasswordGen)
+	if err != nil {
+		switch {
+		case errors.Is(err, errCurrentPrincipalUnavailable):
+			writeJSON(w, http.StatusUnauthorized, errorResponse{"SSE token unavailable for this auth provider"})
+			return
+		case errors.Is(err, auth.ErrPasswordChangeInvalidated):
+			writeJSON(w, http.StatusUnauthorized, errorResponse{"session invalidated by password change"})
+			return
+		case errors.Is(err, auth.ErrUserNotFound):
+			writeJSON(w, http.StatusUnauthorized, errorResponse{"user no longer exists"})
+			return
+		default:
+			writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+			return
+		}
+	}
+
+	token, err := s.sseTokens.Issue(revalidated)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to generate SSE token"})
 		return

--- a/internal/api/sse_tokens.go
+++ b/internal/api/sse_tokens.go
@@ -1,11 +1,9 @@
 package api
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,12 +18,13 @@ const (
 	cleanupEvery   = 60 * time.Second
 )
 
-type refreshTokenProvider interface {
-	RefreshPrincipal(ctx context.Context, email string, tokenGen int64) (auth.Principal, error)
+type sseTokenPrincipal struct {
+	email       string
+	passwordGen int64
 }
 
 type sseTokenEntry struct {
-	principal auth.Principal
+	principal sseTokenPrincipal
 	expiresAt time.Time
 }
 
@@ -56,7 +55,10 @@ func (s *sseTokenStore) Issue(p auth.Principal) (string, error) {
 
 	s.mu.Lock()
 	s.tokens[token] = sseTokenEntry{
-		principal: p,
+		principal: sseTokenPrincipal{
+			email:       p.Email,
+			passwordGen: p.PasswordGen,
+		},
 		expiresAt: s.clock.Now().Add(sseTokenTTL),
 	}
 	s.mu.Unlock()
@@ -65,18 +67,18 @@ func (s *sseTokenStore) Issue(p auth.Principal) (string, error) {
 }
 
 // Redeem validates and consumes an SSE token (single-use).
-func (s *sseTokenStore) Redeem(token string) (auth.Principal, bool) {
+func (s *sseTokenStore) Redeem(token string) (sseTokenPrincipal, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	entry, ok := s.tokens[token]
 	if !ok {
-		return auth.Principal{}, false
+		return sseTokenPrincipal{}, false
 	}
 	delete(s.tokens, token)
 
 	if s.clock.Now().After(entry.expiresAt) {
-		return auth.Principal{}, false
+		return sseTokenPrincipal{}, false
 	}
 	return entry.principal, true
 }
@@ -110,6 +112,16 @@ func (s *sseTokenStore) Stop() {
 	}
 }
 
+// @Summary Issue short-lived SSE token
+// @Description Exchanges a bearer-authenticated session for a short-lived, single-use opaque SSE token. Redeem revalidates the user against the auth provider before opening the stream.
+// @Tags auth
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} sseTokenResponse
+// @Failure 401 {object} errorResponse
+// @Failure 500 {object} errorResponse
+// @Router /auth/sse-token [post]
+//
 // IssueSSEToken handles POST /api/auth/sse-token. It returns a short-lived,
 // single-use opaque token that the client can pass as ?token= on SSE endpoints
 // instead of the full JWT.
@@ -135,42 +147,4 @@ func (s *Server) IssueSSEToken(w http.ResponseWriter, r *http.Request) {
 type sseTokenResponse struct {
 	Token     string `json:"token"`
 	ExpiresIn int    `json:"expiresIn"`
-}
-
-// RefreshToken handles POST /api/auth/refresh. It returns a new JWT if the
-// current token is valid (the caller is already authenticated via middleware).
-// Re-validates user state from the auth provider before issuing a new token
-// to ensure the user has not been revoked or disabled since initial auth.
-func (s *Server) RefreshToken(w http.ResponseWriter, r *http.Request) {
-	p := PrincipalFromContext(r.Context())
-	if p == nil {
-		writeJSON(w, http.StatusUnauthorized, errorResponse{"authentication required"})
-		return
-	}
-
-	if header := r.Header.Get("Authorization"); header == "" || !strings.HasPrefix(header, "Bearer ") {
-		writeJSON(w, http.StatusUnauthorized, errorResponse{"authentication required"})
-		return
-	}
-
-	refresher, ok := s.auth.(refreshTokenProvider)
-	if !ok {
-		writeJSON(w, http.StatusUnauthorized, errorResponse{"token refresh unavailable for this auth provider"})
-		return
-	}
-
-	current, err := refresher.RefreshPrincipal(r.Context(), p.Email, p.PasswordGen)
-	if err != nil {
-		writeJSON(w, http.StatusUnauthorized, errorResponse{"user session is no longer valid"})
-		return
-	}
-	p = &current
-
-	token, err := s.jwt.GenerateToken(r.Context(), *p)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{"failed to generate token"})
-		return
-	}
-
-	writeJSON(w, http.StatusOK, authResponse{Token: token, User: *p})
 }

--- a/internal/api/sse_tokens_test.go
+++ b/internal/api/sse_tokens_test.go
@@ -79,6 +79,78 @@ func TestSSETokenRedeemAndSingleUse(t *testing.T) {
 	}
 }
 
+func TestSSETokenRedeemRejectsRevokedUserAfterIssue(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+	seedProject(t, k8sClient, "default")
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	if err := authProvider.CreateUser(ctx, "revoked@example.com", "pass1234", auth.RoleAdmin); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	principal, _ := authProvider.Authenticate(ctx, auth.Credentials{Email: "revoked@example.com", Password: "pass1234"})
+	token, _ := jwtHelper.GenerateToken(ctx, principal)
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/sse-token", nil, token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	sseToken := resp["token"].(string)
+
+	if err := authProvider.RevokeUser(ctx, "revoked@example.com"); err != nil {
+		t.Fatalf("revoke user: %v", err)
+	}
+
+	path := "/api/projects/default/apps/missing/logs?env=production&token=" + url.QueryEscape(sseToken)
+	redeem := doRequestWithToken(h, http.MethodGet, path, nil, "")
+	if redeem.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for revoked user redeem, got %d: %s", redeem.Code, redeem.Body.String())
+	}
+}
+
+func TestSSETokenRedeemRejectsPasswordChangeAfterIssue(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+	seedProject(t, k8sClient, "default")
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	if err := authProvider.CreateUser(ctx, "password@example.com", "pass1234", auth.RoleAdmin); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	principal, _ := authProvider.Authenticate(ctx, auth.Credentials{Email: "password@example.com", Password: "pass1234"})
+	token, _ := jwtHelper.GenerateToken(ctx, principal)
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/sse-token", nil, token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	sseToken := resp["token"].(string)
+
+	if err := authProvider.UpdatePassword(ctx, "password@example.com", "newpass1234"); err != nil {
+		t.Fatalf("update password: %v", err)
+	}
+
+	path := "/api/projects/default/apps/missing/logs?env=production&token=" + url.QueryEscape(sseToken)
+	redeem := doRequestWithToken(h, http.MethodGet, path, nil, "")
+	if redeem.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 after password change, got %d: %s", redeem.Code, redeem.Body.String())
+	}
+}
+
 func TestIssueSSETokenRejectsRevokedUser(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	ctx := context.Background()
@@ -175,7 +247,52 @@ func TestRefreshTokenRejectsRevokedUser(t *testing.T) {
 	}
 }
 
-func TestRefreshTokenRejectsProviderWithoutRefreshPrincipal(t *testing.T) {
+func TestSSETokenRedeemRejectsProviderWithoutCurrentPrincipal(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+	seedProject(t, k8sClient, "default")
+
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	principal := auth.Principal{
+		ID:          "user@example.com",
+		Email:       "user@example.com",
+		Role:        auth.RoleAdmin,
+		PasswordGen: 0,
+	}
+	token, err := jwtHelper.GenerateToken(ctx, principal)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	srv := api.NewServer(
+		k8sClient,
+		fake.NewClientset(),
+		nil,
+		nil,
+		staticAuthProvider{principal: principal},
+		jwtHelper,
+		nil,
+		authz.NewNativePolicyEngine(k8sClient),
+	)
+	h := srv.Handler()
+
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/sse-token", nil, token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	sseToken := resp["token"].(string)
+
+	path := "/api/projects/default/apps/missing/logs?env=production&token=" + url.QueryEscape(sseToken)
+	redeem := doRequestWithToken(h, http.MethodGet, path, nil, "")
+	if redeem.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when provider cannot revalidate SSE redeem, got %d: %s", redeem.Code, redeem.Body.String())
+	}
+}
+
+func TestRefreshTokenRejectsProviderWithoutCurrentPrincipal(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	ctx := context.Background()
 	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})

--- a/internal/api/sse_tokens_test.go
+++ b/internal/api/sse_tokens_test.go
@@ -17,6 +17,39 @@ import (
 	"github.com/mortise-org/mortise/internal/authz"
 )
 
+type stagedCurrentPrincipalProvider struct {
+	principal auth.Principal
+	calls     int
+}
+
+func (s *stagedCurrentPrincipalProvider) Authenticate(context.Context, auth.Credentials) (auth.Principal, error) {
+	return auth.Principal{}, nil
+}
+
+func (s *stagedCurrentPrincipalProvider) Principal(context.Context, auth.SessionToken) (auth.Principal, error) {
+	return s.principal, nil
+}
+
+func (s *stagedCurrentPrincipalProvider) ListUsers(context.Context) ([]auth.User, error) {
+	return nil, nil
+}
+
+func (s *stagedCurrentPrincipalProvider) InviteUser(context.Context, string, auth.Role) (auth.InviteLink, error) {
+	return auth.InviteLink{}, nil
+}
+
+func (s *stagedCurrentPrincipalProvider) RevokeUser(context.Context, string) error {
+	return nil
+}
+
+func (s *stagedCurrentPrincipalProvider) CurrentPrincipal(context.Context, string, int64) (auth.Principal, error) {
+	s.calls++
+	if s.calls == 1 {
+		return s.principal, nil
+	}
+	return auth.Principal{}, auth.ErrUserNotFound
+}
+
 func TestIssueSSEToken(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv, token := newTestServer(t, k8sClient)
@@ -176,6 +209,41 @@ func TestIssueSSETokenRejectsRevokedUser(t *testing.T) {
 	}
 }
 
+func TestIssueSSETokenRejectsProviderWithoutCurrentPrincipal(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	principal := auth.Principal{
+		ID:          "user@example.com",
+		Email:       "user@example.com",
+		Role:        auth.RoleAdmin,
+		PasswordGen: 0,
+	}
+	token, err := jwtHelper.GenerateToken(ctx, principal)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	srv := api.NewServer(
+		k8sClient,
+		fake.NewClientset(),
+		nil,
+		nil,
+		staticAuthProvider{principal: principal},
+		jwtHelper,
+		nil,
+		authz.NewNativePolicyEngine(k8sClient),
+	)
+	h := srv.Handler()
+
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/sse-token", nil, token)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when provider cannot revalidate SSE issue, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestRefreshToken(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	ctx := context.Background()
@@ -265,12 +333,14 @@ func TestSSETokenRedeemRejectsProviderWithoutCurrentPrincipal(t *testing.T) {
 		t.Fatalf("generate token: %v", err)
 	}
 
+	authProvider := &stagedCurrentPrincipalProvider{principal: principal}
+
 	srv := api.NewServer(
 		k8sClient,
 		fake.NewClientset(),
 		nil,
 		nil,
-		staticAuthProvider{principal: principal},
+		authProvider,
 		jwtHelper,
 		nil,
 		authz.NewNativePolicyEngine(k8sClient),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -36,6 +36,31 @@ const BASE = '/api';
 
 const REFRESH_WINDOW_MS = 4 * 60 * 60 * 1000; // refresh when <4h remaining
 
+export type AuthUser = {
+	email: string;
+	role: 'admin' | 'member' | 'viewer';
+};
+
+export function normalizeAuthUser(value: unknown): AuthUser | null {
+	if (!value || typeof value !== 'object') return null;
+	const record = value as Record<string, unknown>;
+	const email =
+		typeof record.email === 'string'
+			? record.email
+			: typeof record.Email === 'string'
+				? record.Email
+				: null;
+	const role =
+		typeof record.role === 'string'
+			? record.role
+			: typeof record.Role === 'string'
+				? record.Role
+				: null;
+	if (!email) return null;
+	if (role !== 'admin' && role !== 'member' && role !== 'viewer') return null;
+	return { email, role };
+}
+
 function tokenExpiresAt(): number | null {
 	const token = localStorage.getItem('mortise_token');
 	if (!token) return null;
@@ -71,9 +96,15 @@ function forceReauth(message = 'Unauthorized'): never {
 }
 
 async function maybeRefreshToken(): Promise<boolean> {
-	const exp = tokenExpiresAt();
-	if (!exp) return false;
-	if (exp - Date.now() > REFRESH_WINDOW_MS) return false;
+	return refreshSession();
+}
+
+async function refreshSession(force = false): Promise<boolean> {
+	if (!force) {
+		const exp = tokenExpiresAt();
+		if (!exp) return false;
+		if (exp - Date.now() > REFRESH_WINDOW_MS) return false;
+	}
 	if (refreshPromise) return refreshPromise;
 
 	refreshPromise = (async () => {
@@ -94,9 +125,10 @@ async function maybeRefreshToken(): Promise<boolean> {
 				const data = await res.json();
 				if (data.token) {
 					localStorage.setItem('mortise_token', data.token);
-					if (data.user) {
-						localStorage.setItem('mortise_user', JSON.stringify(data.user));
-						window.dispatchEvent(new CustomEvent('mortise:user-updated', { detail: data.user }));
+					const user = normalizeAuthUser(data.user);
+					if (user) {
+						localStorage.setItem('mortise_user', JSON.stringify(user));
+						window.dispatchEvent(new CustomEvent('mortise:user-updated', { detail: user }));
 					}
 					return true;
 				}
@@ -386,6 +418,7 @@ export const api = {
 	},
 
 	fetchSSEToken,
+	refreshSession,
 
 	getBuildLogs: (project: string, app: string) =>
 		request<BuildLogsResponse>(`/projects/${enc(project)}/apps/${enc(app)}/build-logs`),

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { api } from './api';
+import { api, normalizeAuthUser, type AuthUser } from './api';
 import type { App, AppSpec, PreviewSummary, Project, ProjectEnvironment, ProjectMember } from './types';
 
 export type ProjectRole = 'owner' | 'developer' | 'viewer';
@@ -13,7 +13,7 @@ interface StagedChange {
 class MortiseStore {
 	// Auth
 	token = $state<string | null>(null);
-	user = $state<{ email: string; role: 'admin' | 'member' } | null>(null);
+	user = $state<AuthUser | null>(null);
 	githubConnected = $state<boolean | null>(null);
 
 	get isAdmin(): boolean { return this.user?.role === 'admin'; }
@@ -75,21 +75,14 @@ class MortiseStore {
 			}
 			const savedUser = localStorage.getItem('mortise_user');
 			if (savedUser) {
-				try { this.user = JSON.parse(savedUser); } catch { /* ignore */ }
+				try { this.user = normalizeAuthUser(JSON.parse(savedUser)); } catch { /* ignore */ }
 			}
-			// JWT decode fallback when token exists but no persisted user.
-			// The server still enforces authorization on every request.
 			if (!this.user && this.token) {
-				try {
-					const payload = JSON.parse(atob(this.token.split('.')[1]));
-					if (payload.email) {
-						this.user = { email: payload.email, role: payload.role ?? 'member' };
-					}
-				} catch { /* ignore */ }
+				void api.refreshSession(true);
 			}
 
 			window.addEventListener('mortise:user-updated', (event: Event) => {
-				const detail = (event as CustomEvent<{ email: string; role: 'admin' | 'member' }>).detail;
+				const detail = normalizeAuthUser((event as CustomEvent<unknown>).detail);
 				if (detail) {
 					this.user = detail;
 				}
@@ -97,7 +90,7 @@ class MortiseStore {
 		}
 	}
 
-	login(token: string, user: { email: string; role: 'admin' | 'member' }) {
+	login(token: string, user: AuthUser) {
 		this.token = token;
 		this.user = user;
 		if (browser) {

--- a/ui/src/routes/login/+page.svelte
+++ b/ui/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { normalizeAuthUser } from '$lib/api';
 	import { store } from '$lib/store.svelte';
 
 	let email = $state('');
@@ -31,8 +32,12 @@
 				const data = await res.json().catch(() => ({}));
 				throw new Error(data.error || 'Invalid credentials');
 			}
-			const data = await res.json() as { token: string; user: { Email: string; Role: string } };
-			store.login(data.token, { email: data.user.Email, role: (data.user.Role as 'admin' | 'member') ?? 'member' });
+			const data = await res.json() as { token: string; user: unknown };
+			const user = normalizeAuthUser(data.user);
+			if (!user) {
+				throw new Error('Login response missing user details');
+			}
+			store.login(data.token, user);
 			await goto('/');
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Login failed';

--- a/ui/src/routes/setup/+page.svelte
+++ b/ui/src/routes/setup/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { normalizeAuthUser } from '$lib/api';
 	import { store } from '$lib/store.svelte';
 
 	let email = $state('');
@@ -24,8 +25,12 @@
 				const data = await res.json().catch(() => ({}));
 				throw new Error(data.error || 'Setup failed');
 			}
-			const data = await res.json() as { token: string; user: { Email: string; Role: string } };
-			store.login(data.token, { email: data.user.Email, role: (data.user.Role as 'admin' | 'member') });
+			const data = await res.json() as { token: string; user: unknown };
+			const user = normalizeAuthUser(data.user);
+			if (!user) {
+				throw new Error('Setup response missing user details');
+			}
+			store.login(data.token, user);
 			await goto('/setup/wizard');
 		} catch(e) {
 			error = e instanceof Error ? e.message : 'Setup failed';

--- a/ui/tests/e2e/auth.spec.ts
+++ b/ui/tests/e2e/auth.spec.ts
@@ -87,6 +87,22 @@ test.describe('login page', () => {
 		await expect(page.getByTitle('Settings')).toBeVisible({ timeout: 5_000 });
 	});
 
+	test('reload without persisted user rehydrates user state from the server', async ({ page }) => {
+		await loginViaUI(page);
+		await expect(page.getByTitle('Settings')).toBeVisible({ timeout: 5_000 });
+
+		await page.evaluate(() => {
+			localStorage.removeItem('mortise_user');
+		});
+		await page.reload();
+
+		await expect(page.getByTitle('Settings')).toBeVisible({ timeout: 10_000 });
+
+		const savedUser = await page.evaluate(() => localStorage.getItem('mortise_user'));
+		expect(savedUser).toContain('"email"');
+		expect(savedUser).toContain('"role":"admin"');
+	});
+
 	test('invalid credentials show error message', async ({ page }) => {
 		await page.goto('/login');
 


### PR DESCRIPTION
Fixes #318

## Summary
This restores revocation and password-change semantics for SSE stream connects, removes the remaining client-side decoded-role trust fallback, and brings the auth/SSE docs and generated API contracts back in sync with the current flow.

## Root cause
PR #272 introduced `POST /api/auth/sse-token` so browser `EventSource` clients no longer had to place full JWTs in query params. The issued `msse_` token cached a fully trusted `auth.Principal`, and redeem attached that cached principal directly to request context without asking the auth provider to revalidate current user state.

That weakened the previous connect-time behavior: a user could mint an SSE token, get revoked or have `password_gen` bumped, and still open a fresh logs/events stream before the short SSE TTL expired.

The same landing also left two adjacent gaps:
- the UI still reconstructed a trusted platform role from decoded JWT claims when persisted user data was missing
- docs/generated contracts still described older auth/SSE behavior incompletely

## What changed
### Backend auth/SSE
- stop storing a full trusted principal in the SSE token store
- store only minimal redeem data: `{email, passwordGen}`
- add a shared server-side revalidation path that resolves the current principal from the auth provider
- revalidate redeemed SSE tokens before attaching principal context
- preserve short TTL and single-use redeem behavior
- remove the duplicate protected `/api/auth/refresh` route so the route surface matches the intended unauthenticated refresh endpoint
- update refresh docs/comments to explicitly describe provider revalidation

### UI auth state
- remove the decoded-JWT role fallback from the store
- normalize auth user payloads from API responses instead of trusting ad hoc shapes
- when `mortise_user` is missing but a token remains, force a server refresh to rehydrate canonical user state
- add an auth E2E covering reload without persisted user data

### Docs/contracts
- document the `POST /api/auth/sse-token` exchange in the quickstart
- document that browser SSE now uses opaque single-use tokens rather than full JWT query params
- regenerate `docs/swagger.yaml` and `internal/api/openapi.yaml` so `/auth/sse-token` and refresh behavior match code

## User/developer impact
- revoked users can no longer open new SSE streams with a pre-issued `msse_` token
- password resets invalidate pre-issued SSE tokens as expected
- browser clients continue using opaque SSE tokens; no change needed to the current UI SSE callers
- reloads with a token but missing persisted user state now rehydrate from the server instead of inferring role from decoded JWT claims

## Validation
Focused validation:
- `KUBEBUILDER_ASSETS=/tmp/mortise-issue-318-sse-revalidation/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -run 'Test(IssueSSEToken|SSETokenRedeem|Refresh)'`\n- `cd ui && npm install`\n- `cd ui && npm run check`\n\nBroader validation:\n- `make generate-api`\n- `KUBEBUILDER_ASSETS=/tmp/mortise-issue-318-sse-revalidation/bin/k8s/1.35.0-linux-amd64 go test ./internal/api ./internal/auth`\n- `KUBEBUILDER_ASSETS=/tmp/mortise-issue-318-sse-revalidation/bin/k8s/1.35.0-linux-amd64 go test $(go list ./... | grep -v /e2e)`\n\n## Review notes\nThe important trust-boundary change is that SSE token redeem is no longer a cache hit for authorization state. Redeem now only proves possession of a short-lived opaque token and then asks the auth provider for current truth before the stream is admitted.