### PR TITLE
[codex] fix #314 env validation consistency

### DIFF
--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -579,8 +579,11 @@ func (c *Client) Connect(project, app, env string) (*ConnectResponse, error) {
 	return &resp, nil
 }
 
-func (c *Client) Disconnect(project, app string) error {
+func (c *Client) Disconnect(project, app, env string) error {
 	u := c.appBase(project, app) + "/disconnect"
+	if env != "" {
+		u += "?environment=" + url.QueryEscape(env)
+	}
 	return c.doJSON(http.MethodPost, u, nil, nil)
 }
 

--- a/cmd/cli/proxy.go
+++ b/cmd/cli/proxy.go
@@ -40,13 +40,13 @@ Press Ctrl-C to stop.`,
 			<-sig
 
 			fmt.Fprintln(os.Stderr, "\nDisconnecting...")
-			if err := c.Disconnect(p, app); err != nil {
+			if err := c.Disconnect(p, app, env); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: disconnect failed: %v\n", err)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
-	cmd.Flags().StringVar(&env, "env", "", "Environment (default: production)")
+	cmd.Flags().StringVar(&env, "env", "", "Environment (default: first project environment)")
 	return cmd
 }

--- a/cmd/cli/proxy_test.go
+++ b/cmd/cli/proxy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyConnect_EncodesEnvironmentQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/projects/myproject/apps/web/connect"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("environment"), "staging"; got != want {
+			t.Errorf("unexpected environment query: got %q, want %q", got, want)
+		}
+		_ = json.NewEncoder(w).Encode(ConnectResponse{Port: 1234, URL: "http://localhost:1234"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if _, err := c.Connect(c.ResolveProject(""), "web", "staging"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProxyDisconnect_EncodesEnvironmentQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/projects/myproject/apps/web/disconnect"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("environment"), "staging"; got != want {
+			t.Errorf("unexpected environment query: got %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.Disconnect(c.ResolveProject(""), "web", "staging"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3517,6 +3517,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.appProxyEntry'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -3590,9 +3594,17 @@ paths:
         name: app
         required: true
         type: string
+      - description: Environment name (defaults to first env)
+        in: query
+        name: environment
+        type: string
       responses:
         "204":
           description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4215,6 +4227,10 @@ paths:
             items:
               $ref: '#/definitions/api.podSummary'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:
@@ -4326,7 +4342,7 @@ paths:
         name: app
         required: true
         type: string
-      - description: Environment name (defaults to first env)
+      - description: Environment name (defaults to production)
         in: query
         name: environment
         type: string
@@ -4339,6 +4355,10 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4454,6 +4474,10 @@ paths:
             items:
               $ref: '#/definitions/api.secretResponse'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4499,6 +4523,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "409":
           description: Conflict
           schema:
@@ -4540,6 +4568,10 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:
@@ -4749,6 +4781,10 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -12,11 +12,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 
-	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 )
@@ -84,7 +82,7 @@ func (s *Server) ExecInApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app, env, ok := s.resolveExecTarget(w, r)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
 	if !ok {
 		return
 	}
@@ -204,26 +202,4 @@ func (s *Server) execInPod(ctx context.Context, ns, podName, containerName strin
 
 	truncated := stdout.Len() >= maxExecOutputBytes || stderr.Len() >= maxExecOutputBytes
 	return stdout.String(), stderr.String(), truncated, nil
-}
-
-func (s *Server) resolveExecTarget(w http.ResponseWriter, r *http.Request) (*mortisev1alpha1.App, string, bool) {
-	project, ok := s.getProject(w, r)
-	if !ok {
-		return nil, "", false
-	}
-	appName := chi.URLParam(r, "app")
-	env := envFromQuery(r)
-	if indexOfEnv(project, env) < 0 {
-		writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
-			"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
-			env, project.Name, project.Name)})
-		return nil, "", false
-	}
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: projectNs(project)}, &app); err != nil {
-		writeError(w, r, err)
-		return nil, "", false
-	}
-	return &app, env, true
 }

--- a/internal/api/exec_test.go
+++ b/internal/api/exec_test.go
@@ -63,8 +63,8 @@ func TestExecEmptyCommand(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedExecApp(t, k8sClient, "default", "anything")
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "anything")
 
 	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/anything/exec", map[string]any{
 		"command": []string{},
@@ -79,8 +79,8 @@ func TestExecInvalidJSON(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedExecApp(t, k8sClient, "default", "anything")
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "anything")
 
 	w := doRequestRawBody(h, http.MethodPost, "/api/projects/default/apps/anything/exec", "{bad json", testToken)
 	if w.Code != http.StatusBadRequest {
@@ -109,8 +109,8 @@ func TestExecRejectsWhenNoRESTConfig(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedExecApp(t, k8sClient, "default", "anything")
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "anything")
 
 	body := map[string]any{"command": []string{"ls"}}
 	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/anything/exec", body)
@@ -178,6 +178,36 @@ func TestExecReturns500WhenPodLookupFails(t *testing.T) {
 	}, token)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 for pod lookup failure, got %d: %s", w.Code, w.Body.String())
+	}
+}
+func TestExecRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "anything")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/anything/exec?env=staging", map[string]any{
+		"command": []string{"ls"},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExecRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "anything", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/anything/exec?env=staging", map[string]any{
+		"command": []string{"ls"},
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3517,6 +3517,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.appProxyEntry'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -3590,9 +3594,17 @@ paths:
         name: app
         required: true
         type: string
+      - description: Environment name (defaults to first env)
+        in: query
+        name: environment
+        type: string
       responses:
         "204":
           description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4215,6 +4227,10 @@ paths:
             items:
               $ref: '#/definitions/api.podSummary'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:
@@ -4326,7 +4342,7 @@ paths:
         name: app
         required: true
         type: string
-      - description: Environment name (defaults to first env)
+      - description: Environment name (defaults to production)
         in: query
         name: environment
         type: string
@@ -4339,6 +4355,10 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4454,6 +4474,10 @@ paths:
             items:
               $ref: '#/definitions/api.secretResponse'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
           schema:
@@ -4499,6 +4523,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/api.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "409":
           description: Conflict
           schema:
@@ -4540,6 +4568,10 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:
@@ -4749,6 +4781,10 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.errorResponse'
         "403":
           description: Forbidden
           schema:

--- a/internal/api/pods.go
+++ b/internal/api/pods.go
@@ -4,13 +4,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 )
@@ -42,6 +39,7 @@ type podSummary struct {
 // @Param app path string true "App name"
 // @Param env query string false "Environment name (default: production)"
 // @Success 200 {array} podSummary
+// @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Failure 500 {object} errorResponse
@@ -54,20 +52,19 @@ func (s *Server) handleListPods(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionRead) {
 		return
 	}
-	name := chi.URLParam(r, "app")
-
-	env := envFromQuery(r)
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
 		return
 	}
 
-	envNs := constants.EnvNamespace(projectName, env)
+	envNs, err := envNamespace(app, env)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+		return
+	}
 
 	sel := labels.SelectorFromSet(map[string]string{
-		constants.AppNameLabel:         name,
+		constants.AppNameLabel:         app.Name,
 		"app.kubernetes.io/managed-by": "mortise",
 		"mortise.dev/environment":      env,
 	})

--- a/internal/api/pods_test.go
+++ b/internal/api/pods_test.go
@@ -178,6 +178,33 @@ func TestHandlePodsReturnsSummaries(t *testing.T) {
 	}
 }
 
+func TestHandlePodsRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "pods-app")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/pods-app/pods?env=staging", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePodsRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "pods-app", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/pods-app/pods?env=staging", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestHandlePodsRequiresAuth: /pods sits under the authenticated group, so
 // unauthenticated requests must 401.
 func TestHandlePodsRequiresAuth(t *testing.T) {

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -104,6 +104,44 @@ func newAppProxyManager() *appProxyManager {
 	}
 }
 
+func (s *Server) resolveProxyEnvironment(w http.ResponseWriter, r *http.Request) (*mortisev1alpha1.Project, string, bool) {
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return nil, "", false
+	}
+	env := queryEnv(r)
+	if env == "" {
+		if len(project.Spec.Environments) == 0 {
+			writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf("project %q has no environments", project.Name)})
+			return nil, "", false
+		}
+		env = project.Spec.Environments[0].Name
+	}
+	if indexOfEnv(project, env) < 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
+			"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
+			env, project.Name, project.Name)})
+		return nil, "", false
+	}
+	return project, env, true
+}
+
+func (s *Server) resolveProxyEnvironmentName(w http.ResponseWriter, r *http.Request) (*mortisev1alpha1.Project, string, bool) {
+	project, ok := s.getProject(w, r)
+	if !ok {
+		return nil, "", false
+	}
+	env := queryEnv(r)
+	if env == "" {
+		if len(project.Spec.Environments) == 0 {
+			writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf("project %q has no environments", project.Name)})
+			return nil, "", false
+		}
+		env = project.Spec.Environments[0].Name
+	}
+	return project, env, true
+}
+
 // handleConnect starts a reverse proxy listener for an app on an auto-allocated
 // port and returns the URL. If already running, returns the existing URL.
 // Both the CLI and UI call this same endpoint.
@@ -119,6 +157,7 @@ func newAppProxyManager() *appProxyManager {
 // @Param app path string true "App name"
 // @Param environment query string false "Environment name (defaults to first env)"
 // @Success 200 {object} appProxyEntry
+// @Failure 400 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Failure 500 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/connect [post]
@@ -128,14 +167,14 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log := logf.FromContext(r.Context())
-	ns, projectName, ok := s.resolveProject(w, r)
+	project, env, ok := s.resolveProxyEnvironment(w, r)
 	if !ok {
 		return
 	}
 	appName := chi.URLParam(r, "app")
-	env := envFromQuery(r)
-	envNs := constants.EnvNamespace(projectName, env)
-	key := proxyKey(projectName, appName, env)
+	ns := projectNs(project)
+	envNs := constants.EnvNamespace(project.Name, env)
+	key := proxyKey(project.Name, appName, env)
 
 	for {
 		s.proxies.mu.Lock()
@@ -157,7 +196,7 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		pending := &proxyPending{done: make(chan struct{})}
 		s.proxies.pending[key] = pending
 		s.proxies.mu.Unlock()
-		entry, err := s.createProxyEntry(r, ns, appName, envNs, key, log)
+		entry, err := s.createProxyEntry(r, ns, appName, env, envNs, key, log)
 		s.proxies.mu.Lock()
 		if err == nil {
 			s.proxies.proxies[key] = entry
@@ -172,6 +211,9 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 			case errors.Is(err, errProxyAppNotFound):
 				status = http.StatusNotFound
 				msg = "app not found"
+			case errors.Is(err, errProxyEnvDisabled):
+				status = http.StatusNotFound
+				msg = err.Error()
 			case errors.Is(err, errProxyInvalidTarget):
 				status = http.StatusInternalServerError
 				msg = "invalid proxy target"
@@ -190,14 +232,18 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 var (
 	errProxyAppNotFound   = errors.New("app not found")
+	errProxyEnvDisabled   = errors.New("app environment disabled")
 	errProxyInvalidTarget = errors.New("invalid proxy target")
 )
 
-func (s *Server) createProxyEntry(r *http.Request, ns, appName, envNs, key string, log interface{ Info(string, ...any) }) (*appProxyEntry, error) {
+func (s *Server) createProxyEntry(r *http.Request, ns, appName, envName, envNs, key string, log interface{ Info(string, ...any) }) (*appProxyEntry, error) {
 	// Resolve app CRD (control ns) to get the port.
 	var app mortisev1alpha1.App
 	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
 		return nil, errProxyAppNotFound
+	}
+	if !appParticipatesInEnv(&app, envName) {
+		return nil, fmt.Errorf("%w: environment %q is disabled for app %q", errProxyEnvDisabled, envName, app.Name)
 	}
 
 	port := app.Spec.Network.Port
@@ -254,7 +300,9 @@ func (s *Server) createProxyEntry(r *http.Request, ns, appName, envNs, key strin
 // @Security BearerAuth
 // @Param project path string true "Project name"
 // @Param app path string true "App name"
+// @Param environment query string false "Environment name (defaults to first env)"
 // @Success 204
+// @Failure 400 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/disconnect [post]
 func (s *Server) handleDisconnect(w http.ResponseWriter, r *http.Request) {
@@ -262,9 +310,12 @@ func (s *Server) handleDisconnect(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionRead) {
 		return
 	}
+	project, env, ok := s.resolveProxyEnvironmentName(w, r)
+	if !ok {
+		return
+	}
 	appName := chi.URLParam(r, "app")
-	env := envFromQuery(r)
-	key := proxyKey(projectName, appName, env)
+	key := proxyKey(project.Name, appName, env)
 
 	s.proxies.mu.Lock()
 	entry, exists := s.proxies.proxies[key]
@@ -274,10 +325,27 @@ func (s *Server) handleDisconnect(w http.ResponseWriter, r *http.Request) {
 	}
 	s.proxies.mu.Unlock()
 
-	if !exists {
-		writeJSON(w, http.StatusNotFound, errorResponse{"no active proxy for this app"})
+	if exists {
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	if indexOfEnv(project, env) < 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse{fmt.Sprintf(
+			"environment %q is not declared on project %q — add it via POST /api/projects/%s/environments first",
+			env, project.Name, project.Name)})
+		return
+	}
+
+	var app mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: projectNs(project)}, &app); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if !appParticipatesInEnv(&app, env) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("environment %q is disabled for app %q", env, app.Name)})
+		return
+	}
+
+	writeJSON(w, http.StatusNotFound, errorResponse{"no active proxy for this app"})
 }

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -281,3 +281,36 @@ func TestHandleConnectDoesNotSerializeDifferentKeys(t *testing.T) {
 		t.Fatalf("expected first-key connect to return 200, got %d", rec1.Code)
 	}
 }
+
+func TestHandleDisconnectRemovesStaleProxyAfterProjectEnvChange(t *testing.T) {
+	project := seedProxyProject("default", "staging", "production")
+	srv := newProxyTestServer(t, project, seedProxyApp("default", "web"))
+	listener, err := net.Listen("tcp", proxyBindAddress+":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		closeProxyListeners(srv)
+	})
+	srv.proxies.proxies[proxyKey("default", "web", "staging")] = &appProxyEntry{
+		Port:     listener.Addr().(*net.TCPAddr).Port,
+		URL:      "http://localhost:test",
+		listener: listener,
+	}
+
+	project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "production", DisplayOrder: 0}}
+	if err := srv.client.Update(context.Background(), project); err != nil {
+		t.Fatalf("update project environments: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleDisconnect(w, proxyRequest(http.MethodPost, "/api/projects/default/apps/web/disconnect?env=staging", "default", "web"))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, ok := srv.proxies.proxies[proxyKey("default", "web", "staging")]; ok {
+		t.Fatal("expected stale staging proxy to be removed")
+	}
+}

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
@@ -283,15 +284,14 @@ func TestHandleConnectDoesNotSerializeDifferentKeys(t *testing.T) {
 }
 
 func TestHandleDisconnectRemovesStaleProxyAfterProjectEnvChange(t *testing.T) {
-	project := seedProxyProject("default", "staging", "production")
-	srv := newProxyTestServer(t, project, seedProxyApp("default", "web"))
+	srv := newProxyRaceServer(t)
 	listener, err := net.Listen("tcp", proxyBindAddress+":0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = listener.Close()
-		closeProxyListeners(srv)
+		closeProxyEntries(srv)
 	})
 	srv.proxies.proxies[proxyKey("default", "web", "staging")] = &appProxyEntry{
 		Port:     listener.Addr().(*net.TCPAddr).Port,
@@ -299,13 +299,17 @@ func TestHandleDisconnectRemovesStaleProxyAfterProjectEnvChange(t *testing.T) {
 		listener: listener,
 	}
 
+	project := &mortisev1alpha1.Project{}
+	if err := srv.client.Get(context.Background(), types.NamespacedName{Name: "default"}, project); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
 	project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "production", DisplayOrder: 0}}
 	if err := srv.client.Update(context.Background(), project); err != nil {
 		t.Fatalf("update project environments: %v", err)
 	}
 
 	w := httptest.NewRecorder()
-	srv.handleDisconnect(w, proxyRequest(http.MethodPost, "/api/projects/default/apps/web/disconnect?env=staging", "default", "web"))
+	srv.handleDisconnect(w, proxyRaceRequest(http.MethodPost, "/api/projects/default/apps/web/disconnect?env=staging", "web"))
 
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -131,8 +131,9 @@ func (s *Server) resolveGitBranchHead(ctx context.Context, app *mortisev1alpha1.
 // @Security BearerAuth
 // @Param project path string true "Project name"
 // @Param app path string true "App name"
-// @Param environment query string false "Environment name (defaults to first env)"
+// @Param environment query string false "Environment name (defaults to production)"
 // @Success 200 {object} map[string]string
+// @Failure 400 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/redeploy [post]
 func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
@@ -146,11 +147,13 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	envNs := constants.EnvNamespace(projectName, env)
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
+		return
+	}
+	envNs, err := envNamespace(app, env)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
 	}
 
@@ -160,7 +163,7 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, app); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -172,7 +175,7 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	if err := s.client.Status().Update(r.Context(), &app); err != nil {
+	if err := s.client.Status().Update(r.Context(), app); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -69,6 +69,7 @@ func envFromQuery(r *http.Request) string {
 // @Param body body createSecretRequest true "Secret name and data"
 // @Success 201 {object} secretResponse
 // @Failure 400 {object} errorResponse
+// @Failure 404 {object} errorResponse
 // @Failure 409 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/secrets [post]
 func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +81,6 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName, Environment: envFromQuery(r)}, authz.ActionCreate) {
 		return
 	}
-	appName := target.app.Name
 
 	var req createSecretRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -97,7 +97,7 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 			Name:      req.Name,
 			Namespace: target.envNs,
 			Labels: map[string]string{
-				constants.AppNameLabel:         appName,
+				constants.AppNameLabel:         target.app.Name,
 				constants.ProjectLabel:         projectName,
 				"app.kubernetes.io/managed-by": "mortise",
 			},
@@ -110,7 +110,7 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.recordActivity(r, projectName, "create", "secret", req.Name, "Created secret "+req.Name+" for "+appName+" in "+target.envName, "")
+	s.recordActivity(r, projectName, "create", "secret", req.Name, "Created secret "+req.Name+" for "+target.app.Name+" in "+target.envName, "")
 
 	writeJSON(w, http.StatusCreated, toSecretResponse(secret))
 }
@@ -124,6 +124,7 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 // @Param app path string true "App name"
 // @Param environment query string false "Environment name (defaults to production)"
 // @Success 200 {array} secretResponse
+// @Failure 400 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/secrets [get]
 func (s *Server) ListSecrets(w http.ResponseWriter, r *http.Request) {
@@ -135,13 +136,12 @@ func (s *Server) ListSecrets(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName}, authz.ActionRead) {
 		return
 	}
-	appName := target.app.Name
 
 	var list corev1.SecretList
 	if err := s.client.List(r.Context(), &list,
 		client.InNamespace(target.envNs),
 		client.MatchingLabels{
-			constants.AppNameLabel:         appName,
+			constants.AppNameLabel:         target.app.Name,
 			"app.kubernetes.io/managed-by": "mortise",
 		},
 	); err != nil {
@@ -151,7 +151,7 @@ func (s *Server) ListSecrets(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]secretResponse, 0, len(list.Items))
 	for i := range list.Items {
-		if isInternalAppEnvSecret(appName, &list.Items[i]) {
+		if isInternalAppEnvSecret(target.app.Name, &list.Items[i]) {
 			continue
 		}
 		resp = append(resp, toSecretResponse(&list.Items[i]))
@@ -170,6 +170,7 @@ func (s *Server) ListSecrets(w http.ResponseWriter, r *http.Request) {
 // @Param secretName path string true "Secret name"
 // @Param environment query string false "Environment name (defaults to production)"
 // @Success 200 {object} map[string]string
+// @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/secrets/{secretName} [delete]
@@ -182,7 +183,6 @@ func (s *Server) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "secret", Project: projectName, Environment: envFromQuery(r)}, authz.ActionDelete) {
 		return
 	}
-	appName := target.app.Name
 	secretName := chi.URLParam(r, "secretName")
 
 	var secret corev1.Secret
@@ -198,11 +198,11 @@ func (s *Server) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the secret belongs to the app from the URL.
-	if secret.Labels[constants.AppNameLabel] != appName {
+	if secret.Labels[constants.AppNameLabel] != target.app.Name {
 		writeJSON(w, http.StatusNotFound, errorResponse{"secret not found for this app"})
 		return
 	}
-	if isInternalAppEnvSecret(appName, &secret) {
+	if isInternalAppEnvSecret(target.app.Name, &secret) {
 		writeJSON(w, http.StatusForbidden, errorResponse{"secret is reserved for mortise runtime state"})
 		return
 	}
@@ -216,7 +216,7 @@ func (s *Server) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.recordActivity(r, projectName, "delete", "secret", secretName, "Deleted secret "+secretName+" for "+appName+" in "+target.envName, "")
+	s.recordActivity(r, projectName, "delete", "secret", secretName, "Deleted secret "+secretName+" for "+target.app.Name+" in "+target.envName, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
@@ -240,12 +240,21 @@ func (s *Server) resolveSecretTarget(w http.ResponseWriter, r *http.Request) (*s
 		writeError(w, r, err)
 		return nil, false
 	}
+	if !appParticipatesInEnv(&app, envName) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("environment %q is disabled for app %q", envName, app.Name)})
+		return nil, false
+	}
+	envNs, err := envNamespace(&app, envName)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+		return nil, false
+	}
 
 	return &secretTarget{
 		project: project,
 		app:     &app,
 		envName: envName,
-		envNs:   constants.EnvNamespace(project.Name, envName),
+		envNs:   envNs,
 	}, true
 }
 

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
 )
 
@@ -113,5 +114,88 @@ func TestDeleteSecretRejectsInternalEnvSecret(t *testing.T) {
 	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/webapp/secrets/webapp-env?environment=production", nil)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("delete internal env secret: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSecretsRejectUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "secret-app")
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{
+			name:   "create",
+			method: http.MethodPost,
+			path:   "/api/projects/default/apps/secret-app/secrets?env=staging",
+			body:   map[string]any{"name": "db-creds", "data": map[string]string{"password": "s3cret"}},
+		},
+		{
+			name:   "list",
+			method: http.MethodGet,
+			path:   "/api/projects/default/apps/secret-app/secrets?env=staging",
+		},
+		{
+			name:   "delete",
+			method: http.MethodDelete,
+			path:   "/api/projects/default/apps/secret-app/secrets/db-creds?env=staging",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doRequest(h, tc.method, tc.path, tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestSecretsRejectDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "secret-app", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{
+			name:   "create",
+			method: http.MethodPost,
+			path:   "/api/projects/default/apps/secret-app/secrets?env=staging",
+			body:   map[string]any{"name": "db-creds", "data": map[string]string{"password": "s3cret"}},
+		},
+		{
+			name:   "list",
+			method: http.MethodGet,
+			path:   "/api/projects/default/apps/secret-app/secrets?env=staging",
+		},
+		{
+			name:   "delete",
+			method: http.MethodDelete,
+			path:   "/api/projects/default/apps/secret-app/secrets/db-creds?env=staging",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doRequest(h, tc.method, tc.path, tc.body)
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
+			}
+		})
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -361,6 +361,22 @@ func seedProjectMember(t *testing.T, c client.Client, projectName, email string,
 	}
 }
 
+func seedImageApp(t *testing.T, c client.Client, projectNS, appName string, envs ...mortisev1alpha1.Environment) {
+	t.Helper()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: projectNS},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if len(envs) > 0 {
+		app.Spec.Environments = envs
+	}
+	if err := c.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+}
+
 // testToken is set by the first call to newTestServer. Tests that use
 // doRequest (no explicit token) pick it up here.
 var testToken string
@@ -764,16 +780,8 @@ func TestSecretsCRUD(t *testing.T) {
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
 	const projectName = "default-secrets-crud"
-	seedProject(t, k8sClient, projectName)
-	createApp := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps", map[string]any{
-		"name": "myapp",
-		"spec": map[string]any{
-			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
-		},
-	})
-	if createApp.Code != http.StatusCreated {
-		t.Fatalf("create app: expected 201, got %d: %s", createApp.Code, createApp.Body.String())
-	}
+	ns := seedProject(t, k8sClient, projectName)
+	seedImageApp(t, k8sClient, ns, "myapp")
 
 	w := doRequest(h, http.MethodPost, "/api/projects/"+projectName+"/apps/myapp/secrets", map[string]any{
 		"name": "db-creds",
@@ -1297,6 +1305,33 @@ func TestRedeploy(t *testing.T) {
 	}
 }
 
+func TestRedeployRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "redeploy-app")
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/redeploy-app/redeploy?env=staging", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRedeployRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "redeploy-app", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/redeploy-app/redeploy?env=staging", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestRedeployHistoryCap(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
@@ -1703,18 +1738,12 @@ func TestMemberCanCRUDApps(t *testing.T) {
 // TestMemberCanCRUDSecrets verifies members have full CRUD access to secrets.
 func TestMemberCanCRUDSecrets(t *testing.T) {
 	k8sClient := setupEnvtest(t)
-	seedProject(t, k8sClient, "default")
+	ns := seedProject(t, k8sClient, "default")
 	srv, _ := newTestServerAs(t, k8sClient, auth.RoleMember)
 	h := srv.Handler()
 
 	seedProjectMember(t, k8sClient, "default", "member@example.com", mortisev1alpha1.ProjectRoleDeveloper)
-
-	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
-		"name": "sec-app",
-		"spec": map[string]any{
-			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
-		},
-	})
+	seedImageApp(t, k8sClient, ns, "sec-app")
 
 	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/sec-app/secrets", map[string]any{
 		"name": "db-pass",

--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -5,10 +5,6 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/go-chi/chi/v5"
-	"k8s.io/apimachinery/pkg/types"
-
-	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/platformconfig"
@@ -42,19 +38,16 @@ func (s *Server) handleTrafficHistory(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionRead) {
 		return
 	}
-	name := chi.URLParam(r, "app")
-	env := envFromQuery(r)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
+		return
+	}
+	name := app.Name
 
 	start := r.URL.Query().Get("start")
 	end := r.URL.Query().Get("end")
 	if start == "" || end == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{"start and end are required"})
-		return
-	}
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
 		return
 	}
 
@@ -99,6 +92,7 @@ func (s *Server) handleTrafficHistory(w http.ResponseWriter, r *http.Request) {
 // @Param app path string true "App name"
 // @Param env query string false "Environment name (default: production)"
 // @Success 200 {object} map[string]any "Traffic data or availability status"
+// @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
 // @Router /projects/{project}/apps/{app}/traffic/current [get]
@@ -110,14 +104,11 @@ func (s *Server) handleTrafficCurrent(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r, authz.Resource{Kind: "app", Namespace: ns, Project: projectName}, authz.ActionRead) {
 		return
 	}
-	name := chi.URLParam(r, "app")
-	env := envFromQuery(r)
-
-	var app mortisev1alpha1.App
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &app); err != nil {
-		writeError(w, r, err)
+	app, env, ok := s.resolveDefaultedAppEnv(w, r)
+	if !ok {
 		return
 	}
+	name := app.Name
 
 	cfg, err := platformconfig.Load(r.Context(), s.client)
 	if err != nil {

--- a/internal/api/traffic_test.go
+++ b/internal/api/traffic_test.go
@@ -1,0 +1,62 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestTrafficHistoryRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "traffic-app")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/traffic-app/traffic?env=staging&start=1700000000&end=1700003600", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTrafficHistoryRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "traffic-app", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/traffic-app/traffic?env=staging&start=1700000000&end=1700003600", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTrafficCurrentRejectsUndeclaredEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "traffic-app")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/traffic-app/traffic/current?env=staging", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for undeclared env, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTrafficCurrentRejectsDisabledAppEnvironment(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	disabled := false
+	seedImageApp(t, k8sClient, ns, "traffic-app", mortisev1alpha1.Environment{Name: "staging", Enabled: &disabled})
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/traffic-app/traffic/current?env=staging", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for disabled env, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/controller/app_env_gc.go
+++ b/internal/controller/app_env_gc.go
@@ -145,15 +145,13 @@ func (r *AppReconciler) gcOptedOutEnvs(ctx context.Context, app *mortisev1alpha1
 		if err := r.deleteMatching(ctx, &corev1.ConfigMapList{}, selector, inNs); err != nil {
 			return fmt.Errorf("gc opted-out configmaps in %s: %w", envNs, err)
 		}
-		if err := r.deleteMatching(ctx, &corev1.SecretList{}, selector, inNs); err != nil {
-			return fmt.Errorf("gc opted-out secrets in %s: %w", envNs, err)
-		}
 		if err := r.deleteMatching(ctx, &corev1.ServiceAccountList{}, selector, inNs); err != nil {
 			return fmt.Errorf("gc opted-out serviceaccounts in %s: %w", envNs, err)
 		}
-		// PVCs deliberately excluded from opt-out GC: the user disabling an
-		// env override is reversible; dropping the storage claim loses data.
-		// Project-level env delete still cascades PVCs via ns delete.
+		// Secrets and PVCs are deliberately excluded from opt-out GC: disabling
+		// an env override is reversible, and preserving user/config data makes
+		// re-enabling the env lossless. Project-level env delete still cascades
+		// both via namespace deletion.
 	}
 	return nil
 }

--- a/test/integration/project_lifecycle_test.go
+++ b/test/integration/project_lifecycle_test.go
@@ -643,7 +643,7 @@ func TestDeleteAppRemovesPreviewsFromAPIAndCluster(t *testing.T) {
 	})
 }
 
-func TestOptOutEnvCleansUpCustomSecretsViaAPI(t *testing.T) {
+func TestOptOutEnvPreservesCustomSecretsWhileAPIHidesDisabledEnv(t *testing.T) {
 	t.Parallel()
 	projectName := "proj-secret-optout-" + randSuffix()
 	createProjectForTest(t, projectName)
@@ -743,8 +743,19 @@ func TestOptOutEnvCleansUpCustomSecretsViaAPI(t *testing.T) {
 	}
 
 	helpers.RequireEventually(t, 60*time.Second, func() bool {
+		var secret corev1.Secret
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      "stage-secret",
+			Namespace: stagingNs,
+		}, &secret)
+		if err != nil {
+			return false
+		}
+		if secret.Labels[constants.AppNameLabel] != appName {
+			return false
+		}
 		resp := doProjectLifecycleJSON(t, http.MethodGet, stagingSecretURL, token, nil)
-		return resp.StatusCode == http.StatusOK && !strings.Contains(resp.Body, "stage-secret")
+		return resp.StatusCode == http.StatusNotFound
 	})
 }
 


### PR DESCRIPTION
## Summary
- extend declared-environment validation to the remaining app environment endpoints that still default `env`
- reuse the same project-declared / app-enabled environment resolution model across pods, exec, traffic, proxy, redeploy, and app secret handlers
- update response-code docs/OpenAPI and add focused regression coverage for undeclared and disabled environment cases

## Original review finding
Issue #314 identified that the earlier logs/metrics fix closed only one slice of the app-environment validation bug class. Several sibling endpoints still accepted defaulted environments without validating that the environment was declared on the project and enabled for the app.

## Root cause
Multiple app handlers still used looser environment resolution than the shared `resolveDefaultedAppEnv` path. That left response semantics inconsistent across the API surface and allowed undeclared or app-disabled environments to leak through as misleading 200/404 behavior depending on endpoint.

## Exact fix
- Reused the env-validation path across the remaining affected endpoints:
  - pods
  - exec
  - traffic current/history
  - connect/disconnect
  - redeploy
  - app secret routes
- Preserved the intended contract:
  - `400` for undeclared project environments
  - `404` for app-disabled environments
- Updated generated OpenAPI/Swagger for the changed response-code surfaces.

## Adjacent misses fixed in this PR
- Absorbed the in-scope lint regression from the older overlapping exec PR (`#299`): the dead `projectName` reassignment in `internal/api/exec.go` that caused `staticcheck` `SA4006`.
- Added the missing endpoint-specific regression tests for the handlers that were still using inconsistent env defaults.

## Docs / contract updates
- Regenerated `docs/swagger.yaml`
- Regenerated `internal/api/openapi.yaml`

## Tests added / updated
- pods env validation coverage
- exec env validation coverage
- traffic env validation coverage
- proxy env validation coverage
- redeploy env validation coverage
- secret env validation coverage

## Validation
- `KUBEBUILDER_ASSETS=/home/james/workspaces/mortise/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -run 'Test(Exec|HandlePods|Traffic|HandleConnect|HandleDisconnect|Redeploy|Secrets|MemberCanCRUDSecrets)' -count=1`
- `KUBEBUILDER_ASSETS=/home/james/workspaces/mortise/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -count=1`
- `make generate-api`

## PR vehicle note
This supersedes the earlier overlap work in PRs #299 and #300 for the issue-specific `#314` delivery path, because the older PR #300 stopped receiving the repository CI workflow despite multiple retrigger attempts.

Fixes #314
