### PR TITLE
[codex] Block project viewers from reading deploy-token inventories

### DIFF
--- a/internal/api/tokens_handler_test.go
+++ b/internal/api/tokens_handler_test.go
@@ -10,7 +10,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/auth"
 )
+
+func issueViewerToken(t *testing.T, k8sClient client.Client, email string) string {
+	t.Helper()
+	ctx := context.Background()
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+
+	if err := authProvider.CreateUser(ctx, email, "testpass", auth.RoleViewer); err != nil {
+		t.Fatalf("create viewer user: %v", err)
+	}
+	principal, err := authProvider.Authenticate(ctx, auth.Credentials{Email: email, Password: "testpass"})
+	if err != nil {
+		t.Fatalf("authenticate viewer user: %v", err)
+	}
+	token, err := jwtHelper.GenerateToken(ctx, principal)
+	if err != nil {
+		t.Fatalf("generate viewer token: %v", err)
+	}
+	return token
+}
 
 func seedTokenApp(t *testing.T, k8sClient client.Client, projectNS, appName string, envs ...mortisev1alpha1.Environment) {
 	t.Helper()
@@ -235,5 +256,51 @@ func TestListTokensMissingAppReturns404(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/ghost/tokens", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing app, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListTokensViewerForbidden(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	adminSrv, adminToken := newTestServer(t, k8sClient)
+	h := adminSrv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	viewerEmail := "viewer@example.com"
+	viewerToken := issueViewerToken(t, k8sClient, viewerEmail)
+	seedProjectMember(t, k8sClient, "default", viewerEmail, mortisev1alpha1.ProjectRoleViewer)
+	seedTokenApp(t, k8sClient, ns, "webapp")
+
+	create := doRequestWithToken(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "ci-deploy",
+		"environment": "production",
+	}, adminToken)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create token: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	w := doRequestWithToken(h, http.MethodGet, "/api/projects/default/apps/webapp/tokens", nil, viewerToken)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for viewer token inventory read, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListProjectTokensViewerForbidden(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	adminSrv, adminToken := newTestServer(t, k8sClient)
+	h := adminSrv.Handler()
+	seedProject(t, k8sClient, "default")
+	viewerEmail := "viewer@example.com"
+	viewerToken := issueViewerToken(t, k8sClient, viewerEmail)
+	seedProjectMember(t, k8sClient, "default", viewerEmail, mortisev1alpha1.ProjectRoleViewer)
+
+	create := doRequestWithToken(h, http.MethodPost, "/api/projects/default/tokens", map[string]any{
+		"description": "ci inventory",
+	}, adminToken)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create project token: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	w := doRequestWithToken(h, http.MethodGet, "/api/projects/default/tokens", nil, viewerToken)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for viewer project token inventory read, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/authz/native.go
+++ b/internal/authz/native.go
@@ -75,7 +75,10 @@ func (e *NativePolicyEngine) authorizeProject(ctx context.Context, p auth.Princi
 		return true, nil
 
 	case v1alpha1.ProjectRoleViewer:
-		return action == ActionRead, nil
+		if action != ActionRead {
+			return false, nil
+		}
+		return resource.Kind != "token", nil
 
 	case v1alpha1.ProjectRoleDeveloper:
 		return e.authorizeDeveloper(ctx, resource, action)

--- a/internal/authz/native_test.go
+++ b/internal/authz/native_test.go
@@ -279,6 +279,27 @@ func TestViewerWithProjectMembership(t *testing.T) {
 	}
 }
 
+func TestViewerWithProjectMembershipCannotReadTokens(t *testing.T) {
+	const email = "viewer@example.com"
+	const project = "my-project"
+
+	c := fake.NewClientBuilder().
+		WithScheme(authzScheme(t)).
+		WithObjects(memberForProject(email, project, mortisev1alpha1.ProjectRoleViewer)).
+		Build()
+	engine := NewNativePolicyEngine(c)
+	ctx := context.Background()
+	viewer := auth.Principal{ID: email, Email: email, Role: auth.RoleViewer}
+
+	ok, err := engine.Authorize(ctx, viewer, Resource{Kind: "token", Project: project}, ActionRead)
+	if err != nil {
+		t.Fatalf("Authorize(token, read): %v", err)
+	}
+	if ok {
+		t.Error("project-viewer should not be allowed to read project token inventory")
+	}
+}
+
 func TestViewerMembershipDoesNotGrantWrite(t *testing.T) {
 	const email = "viewer@example.com"
 	const project = "my-project"


### PR DESCRIPTION
## Summary
- deny project-viewer reads of `token` resources
- add policy coverage for viewer token denial
- add handler regressions for app-token and project-token inventory endpoints

## Why
Project viewers could enumerate deploy-token inventories even though developers were already blocked from the same resource kind.

## Validation
- `go test ./internal/authz`
- `go test ./internal/api`

Closes #328
