### PR TITLE
[codex] Roll back partial stack creates on failure

### DIFF
--- a/internal/api/stacks.go
+++ b/internal/api/stacks.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -163,6 +164,7 @@ func (s *Server) CreateStack(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := s.client.Create(r.Context(), app); err != nil {
+			s.rollbackStackApps(r.Context(), ns, created)
 			writeError(w, r, err)
 			return
 		}
@@ -199,6 +201,24 @@ func (s *Server) CreateStack(w http.ResponseWriter, r *http.Request) {
 	s.recordActivity(r, project, "create", "stack", stackName, fmt.Sprintf("Created stack %s with %d apps", stackName, len(created)), "")
 
 	writeJSON(w, http.StatusCreated, createStackResponse{Apps: created})
+}
+
+func (s *Server) rollbackStackApps(ctx context.Context, namespace string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	log := logf.FromContext(ctx)
+	for _, name := range names {
+		app := &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		if err := s.client.Delete(ctx, app); err != nil {
+			log.Error(err, "rollback stack app", "app", name, "namespace", namespace)
+		}
+	}
 }
 
 // filterDependsOn removes references to services not in the keep set.

--- a/internal/api/stacks_handler_test.go
+++ b/internal/api/stacks_handler_test.go
@@ -2,12 +2,17 @@ package api_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/api"
 )
 
@@ -191,5 +196,37 @@ func TestCreateStackFilterExcludesAll(t *testing.T) {
 		if !strings.Contains(resp["error"], want) {
 			t.Errorf("expected error %q to mention %q", resp["error"], want)
 		}
+	}
+}
+
+func TestCreateStackRollsBackCreatedAppsOnConflict(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	existing := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-collide", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), existing); err != nil {
+		t.Fatalf("create existing app: %v", err)
+	}
+
+	body := map[string]any{
+		"compose": "services:\n  bravo:\n    image: nginx:1.25\n  collide:\n    image: nginx:1.25\n",
+		"name":    "stack",
+	}
+	w := doRequest(h, http.MethodPost, "/api/projects/default/stacks", body)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when one app already exists, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created mortisev1alpha1.App
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "stack-bravo", Namespace: ns}, &created)
+	if err == nil {
+		t.Fatalf("expected stack-bravo to be rolled back after failure")
 	}
 }


### PR DESCRIPTION
## Summary
- roll back already-created apps if a later create in the same stack request fails
- add a regression that exercises the name-collision case

## Why
`POST /api/projects/{project}/stacks` could return `409` after already creating earlier apps from the same request, leaving leaked partial stack state.

## Validation
- `go test ./internal/api`

Closes #337
