### PR TITLE
[codex] Sync docs and OpenAPI

### DIFF
--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -36,9 +36,11 @@ curl -s "$BASE/api/auth/status" | jq
 If `setupRequired` is `true`, run setup:
 
 ```bash
-curl -s -X POST "$BASE/api/auth/setup" \
+TOKEN=$(curl -s -X POST "$BASE/api/auth/setup" \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" | jq
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" | jq -r .token)
+
+echo "$TOKEN" | cut -c1-24
 ```
 
 If setup already exists, login:


### PR DESCRIPTION
## What changed
Updated the API quickstart setup example to capture the returned token directly and show a short preview of it.

## Why
The setup endpoint returns a token that users need for subsequent API calls, so the quickstart should reflect the actual response flow.

## Impact
This is a docs-only change. It makes the setup step easier to follow and reduces ambiguity for first-time API users.

## Checks
- `git diff --check -- docs/api-quickstart.md docs/swagger.yaml internal/api/openapi.yaml`
- `cmp -s docs/swagger.yaml internal/api/openapi.yaml`
- `make generate-api`
- `go test ./internal/api -run TestOpenAPISpecIncludesBuildRunRoutes -count=1` *(fails in this environment: missing `/usr/local/kubebuilder/bin/etcd` for envtest)*