### PR TITLE
[codex] BuildRun recovery and webhook latching

### DIFF
--- a/api/v1alpha1/buildrun_types.go
+++ b/api/v1alpha1/buildrun_types.go
@@ -98,6 +98,7 @@ type BuildRunSpec struct {
 // BuildRunStatus defines the observed state of BuildRun.
 type BuildRunStatus struct {
 	Phase          BuildRunPhase                `json:"phase,omitempty"`
+	Attempt        int32                        `json:"attempt,omitempty"`
 	JobRef         *corev1.LocalObjectReference `json:"jobRef,omitempty"`
 	LogRef         *corev1.LocalObjectReference `json:"logRef,omitempty"`
 	Image          string                       `json:"image,omitempty"`

--- a/charts/mortise-core/crds/mortise.mortise.dev_buildruns.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_buildruns.yaml
@@ -152,6 +152,9 @@ spec:
           status:
             description: BuildRunStatus defines the observed state of BuildRun.
             properties:
+              attempt:
+                format: int32
+                type: integer
               completedAt:
                 format: date-time
                 type: string

--- a/config/crd/bases/mortise.mortise.dev_buildruns.yaml
+++ b/config/crd/bases/mortise.mortise.dev_buildruns.yaml
@@ -152,6 +152,9 @@ spec:
           status:
             description: BuildRunStatus defines the observed state of BuildRun.
             properties:
+              attempt:
+                format: int32
+                type: integer
               completedAt:
                 format: date-time
                 type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1523,6 +1523,8 @@ definitions:
     type: object
   v1alpha1.BuildRunStatus:
     properties:
+      attempt:
+        type: integer
       completedAt:
         type: string
       conditions:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1523,6 +1523,8 @@ definitions:
     type: object
   v1alpha1.BuildRunStatus:
     properties:
+      attempt:
+        type: integer
       completedAt:
         type: string
       conditions:

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2337,11 +2337,14 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 	if webhookConditionInputHash(app) == inputHash {
 		return nil
 	}
+	if webhookConditionPermanentFailureInputHash(app) == inputHash {
+		return nil
+	}
 
 	// Build GitAPI and register.
 	api, err := r.newGitAPI(gp, token, webhookSecret)
 	if err != nil {
-		r.setWebhookCondition(ctx, app, metav1.ConditionFalse, webhookConditionReason(err), err.Error())
+		r.setWebhookFailureCondition(ctx, app, inputHash, err)
 		return fmt.Errorf("create git API: %w", err)
 	}
 
@@ -2374,7 +2377,7 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 		Secret: webhookSecret,
 		Events: []string{"push", "pull_request"},
 	}); err != nil {
-		r.setWebhookCondition(ctx, app, metav1.ConditionFalse, webhookConditionReason(err), err.Error())
+		r.setWebhookFailureCondition(ctx, app, inputHash, err)
 		return fmt.Errorf("register webhook: %w", err)
 	}
 
@@ -2407,10 +2410,38 @@ func webhookInputHashMessage(hash string) string {
 
 func webhookConditionInputHash(app *mortisev1alpha1.App) string {
 	cond := meta.FindStatusCondition(app.Status.Conditions, webhookConditionType)
-	if cond == nil || cond.Status != metav1.ConditionTrue || !strings.HasPrefix(cond.Message, webhookInputHashMessageKey) {
+	if cond == nil || cond.Status != metav1.ConditionTrue {
 		return ""
 	}
-	return strings.TrimPrefix(cond.Message, webhookInputHashMessageKey)
+	return webhookConditionInputHashValue(cond.Message)
+}
+
+func webhookConditionPermanentFailureInputHash(app *mortisev1alpha1.App) string {
+	cond := meta.FindStatusCondition(app.Status.Conditions, webhookConditionType)
+	if cond == nil || cond.Status != metav1.ConditionFalse || !isWebhookPermanentReason(cond.Reason) {
+		return ""
+	}
+	return webhookConditionInputHashValue(cond.Message)
+}
+
+func webhookConditionInputHashValue(message string) string {
+	if !strings.HasPrefix(message, webhookInputHashMessageKey) {
+		return ""
+	}
+	hash := strings.TrimPrefix(message, webhookInputHashMessageKey)
+	if idx := strings.IndexByte(hash, '\n'); idx >= 0 {
+		hash = hash[:idx]
+	}
+	return hash
+}
+
+func isWebhookPermanentReason(reason string) bool {
+	switch reason {
+	case "WebhookAuthFailed", "WebhookRepoNotFound", "WebhookConflict":
+		return true
+	default:
+		return false
+	}
 }
 
 func webhookConditionReason(err error) string {
@@ -2467,6 +2498,15 @@ func (r *AppReconciler) setWebhookCondition(ctx context.Context, app *mortisev1a
 			LastTransitionTime: transitionTime,
 		})
 	})
+}
+
+func (r *AppReconciler) setWebhookFailureCondition(ctx context.Context, app *mortisev1alpha1.App, inputHash string, err error) error {
+	reason := webhookConditionReason(err)
+	message := err.Error()
+	if isWebhookPermanentReason(reason) {
+		message = webhookInputHashMessage(inputHash) + "\n" + message
+	}
+	return r.setWebhookCondition(ctx, app, metav1.ConditionFalse, reason, message)
 }
 
 // checkPodCrashLoopInEnv checks pods for CrashLoopBackOff within a single env

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -3445,6 +3445,103 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(cond.Reason).To(Equal("WebhookAuthFailed"))
 			Expect(cond.Message).To(ContainSubstring("missing webhook scope"))
 		})
+
+		It("latches permanent webhook failures by input hash", func() {
+			ctx := context.Background()
+
+			pc := &mortisev1alpha1.PlatformConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-permanent"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type: mortisev1alpha1.GitProviderTypeGitHub,
+					Host: "https://github.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			app := makeGitSourceApp("git-webhook-permanent", namespace, gp.Name)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+
+			api := &fakeWebhookAPI{
+				registerErr: &git.WebhookOperationError{
+					Provider:   "github",
+					Operation:  git.WebhookOperationRegister,
+					StatusCode: http.StatusForbidden,
+					Err:        fmt.Errorf("%w: missing webhook scope", git.ErrAuthFailed),
+				},
+			}
+			r := gitSourceReconciler(&fakeBuildClient{digest: "sha256:latch"}, &fakeGitClient{}, &fakeRegistryBackend{})
+			r.GitAPIFactory = func(_ *mortisev1alpha1.GitProvider, _, _ string) (git.GitAPI, error) {
+				return api, nil
+			}
+
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(HaveOccurred())
+			Expect(api.listCount).To(Equal(1))
+			Expect(api.registerCount).To(Equal(1))
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+			cond := meta.FindStatusCondition(app.Status.Conditions, webhookConditionType)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Message).To(HavePrefix(webhookInputHashMessageKey))
+
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(Succeed())
+			Expect(api.listCount).To(Equal(1))
+			Expect(api.registerCount).To(Equal(1))
+		})
+
+		It("retries transient webhook failures even when inputs are unchanged", func() {
+			ctx := context.Background()
+
+			pc := &mortisev1alpha1.PlatformConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-transient"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type: mortisev1alpha1.GitProviderTypeGitHub,
+					Host: "https://github.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			app := makeGitSourceApp("git-webhook-transient", namespace, gp.Name)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+
+			api := &fakeWebhookAPI{
+				registerErr: &git.WebhookOperationError{
+					Provider:   "github",
+					Operation:  git.WebhookOperationRegister,
+					StatusCode: http.StatusServiceUnavailable,
+					Err:        fmt.Errorf("temporary outage"),
+				},
+			}
+			r := gitSourceReconciler(&fakeBuildClient{digest: "sha256:latch"}, &fakeGitClient{}, &fakeRegistryBackend{})
+			r.GitAPIFactory = func(_ *mortisev1alpha1.GitProvider, _, _ string) (git.GitAPI, error) {
+				return api, nil
+			}
+
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(HaveOccurred())
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(HaveOccurred())
+			Expect(api.listCount).To(Equal(2))
+			Expect(api.registerCount).To(Equal(2))
+		})
 	})
 
 	Context("happy path", func() {

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -39,7 +39,11 @@ import (
 	"github.com/mortise-org/mortise/internal/registry"
 )
 
-const buildRunPollInterval = 15 * time.Second
+const (
+	buildRunPollInterval        = 15 * time.Second
+	buildRunTrackerLossGrace    = 5 * time.Second
+	maxBuildRunRecoveryAttempts = 2
+)
 
 // BuildRunReconciler reconciles durable BuildRun objects.
 type BuildRunReconciler struct {
@@ -80,7 +84,7 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		switch phase {
 		case buildPhaseRunning:
 			if br.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning {
-				now := metav1.Now()
+				now := metav1.NewTime(r.clock().Now())
 				br.Status.Phase = mortisev1alpha1.BuildRunPhaseRunning
 				if br.Status.StartedAt == nil {
 					br.Status.StartedAt = &now
@@ -98,7 +102,7 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 
-			now := metav1.Now()
+			now := metav1.NewTime(r.clock().Now())
 			br.Status.FinishedAt = &now
 			br.Status.CompletedAt = &now
 			br.Status.LogRef = logRef
@@ -126,34 +130,79 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
+	if br.Status.Phase == mortisev1alpha1.BuildRunPhaseRunning {
+		return r.handleLostBuildRunTracker(ctx, &br, key)
+	}
+
+	attempt := br.Status.Attempt
+	if attempt < 1 {
+		attempt = 1
+	}
+	return r.startBuildRunAttempt(ctx, &br, key, attempt, "")
+}
+
+func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName) (ctrl.Result, error) {
+	if br.Status.StartedAt == nil {
+		return ctrl.Result{RequeueAfter: buildRunTrackerLossGrace}, nil
+	}
+
+	elapsed := r.clock().Now().Sub(br.Status.StartedAt.Time)
+	if elapsed < buildRunTrackerLossGrace {
+		return ctrl.Result{RequeueAfter: buildRunTrackerLossGrace - elapsed}, nil
+	}
+
+	attempt := br.Status.Attempt
+	if attempt < 1 {
+		attempt = 1
+	}
+	if attempt < maxBuildRunRecoveryAttempts {
+		marker := fmt.Sprintf("[recovery] build tracker lost; restarting attempt %d", attempt+1)
+		if err := r.appendBuildRunLogMarker(ctx, br, marker); err != nil {
+			return ctrl.Result{}, err
+		}
+		return r.startBuildRunAttempt(ctx, br, key, attempt+1, marker)
+	}
+
+	message := fmt.Sprintf("build tracker lost after recovery attempt %d", attempt)
+	if err := r.appendBuildRunLogMarker(ctx, br, "[interrupted] "+message); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.failBuildRun(ctx, br, attempt, "BuildInterrupted", message); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.projectTerminalBuildRunStatus(ctx, br); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.Builds.delete(key)
+	return ctrl.Result{}, nil
+}
+
+func (r *BuildRunReconciler) startBuildRunAttempt(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName, attempt int32, marker string) (ctrl.Result, error) {
 	if r.BuildClient == nil || r.GitClient == nil || r.RegistryBackend == nil {
-		now := metav1.Now()
-		br.Status.Phase = mortisev1alpha1.BuildRunPhaseFailed
-		br.Status.FailureReason = "BuildInfraUnavailable"
-		br.Status.FailureMessage = "build infrastructure is not configured"
-		br.Status.FinishedAt = &now
-		setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseFailed, br.Generation, br.Status.FailureMessage, now)
-		return ctrl.Result{}, r.Status().Update(ctx, &br)
+		return ctrl.Result{}, r.failBuildRun(ctx, br, attempt, "BuildInfraUnavailable", "build infrastructure is not configured")
 	}
 
-	token, err := r.resolveBuildRunGitToken(ctx, &br)
+	token, err := r.resolveBuildRunGitToken(ctx, br)
 	if err != nil {
-		now := metav1.Now()
-		br.Status.Phase = mortisev1alpha1.BuildRunPhaseFailed
-		br.Status.FailureReason = "GitAuthFailed"
-		br.Status.FailureMessage = err.Error()
-		br.Status.FinishedAt = &now
-		setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseFailed, br.Generation, br.Status.FailureMessage, now)
-		return ctrl.Result{}, r.Status().Update(ctx, &br)
+		return ctrl.Result{}, r.failBuildRun(ctx, br, attempt, "GitAuthFailed", err.Error())
 	}
 
-	now := metav1.Now()
+	now := metav1.NewTime(r.clock().Now())
+	br.Status.Attempt = attempt
 	br.Status.Phase = mortisev1alpha1.BuildRunPhaseRunning
 	if br.Status.StartedAt == nil {
 		br.Status.StartedAt = &now
 	}
-	setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseRunning, br.Generation, "build is running", now)
-	if err := r.Status().Update(ctx, &br); err != nil {
+	br.Status.CompletedAt = nil
+	br.Status.FinishedAt = nil
+	br.Status.FailureReason = ""
+	br.Status.FailureMessage = ""
+	message := "build is running"
+	if attempt > 1 {
+		message = fmt.Sprintf("build recovered after tracker loss (attempt %d)", attempt)
+	}
+	setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseRunning, br.Generation, message, now)
+	if err := r.Status().Update(ctx, br); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -162,6 +211,9 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		revision: br.Spec.Revision,
 		phase:    buildPhaseRunning,
 		cancel:   cancel,
+	}
+	if marker != "" {
+		tracker.appendLog(marker)
 	}
 	r.Builds.set(key, tracker)
 
@@ -188,6 +240,18 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{RequeueAfter: buildRunPollInterval}, nil
 }
 
+func (r *BuildRunReconciler) failBuildRun(ctx context.Context, br *mortisev1alpha1.BuildRun, attempt int32, reason, message string) error {
+	now := metav1.NewTime(r.clock().Now())
+	br.Status.Attempt = attempt
+	br.Status.Phase = mortisev1alpha1.BuildRunPhaseFailed
+	br.Status.FailureReason = reason
+	br.Status.FailureMessage = message
+	br.Status.CompletedAt = &now
+	br.Status.FinishedAt = &now
+	setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseFailed, br.Generation, message, now)
+	return r.Status().Update(ctx, br)
+}
+
 func (r *BuildRunReconciler) resolveBuildRunGitToken(ctx context.Context, br *mortisev1alpha1.BuildRun) (string, error) {
 	if br.Spec.TokenSecretRef == nil {
 		return "", fmt.Errorf("token secret ref is required")
@@ -206,7 +270,10 @@ func (r *BuildRunReconciler) resolveBuildRunGitToken(ctx context.Context, br *mo
 
 func (r *BuildRunReconciler) persistBuildRunLog(ctx context.Context, br *mortisev1alpha1.BuildRun, tracker *buildTracker) (*corev1.LocalObjectReference, error) {
 	phase, _, _, _, errMsg, _ := tracker.snapshot()
-	lines := tracker.snapshotLogs()
+	lines, err := r.mergedBuildRunLogLines(ctx, br, tracker.snapshotLogs())
+	if err != nil {
+		return nil, err
+	}
 	joined := strings.Join(lines, "\n")
 	for len(joined) > maxBuildLogConfigMapBytes && len(lines) > 0 {
 		lines = lines[1:]
@@ -266,6 +333,58 @@ func (r *BuildRunReconciler) persistBuildRunLog(ctx context.Context, br *mortise
 	}
 
 	return &corev1.LocalObjectReference{Name: runLog.Name}, nil
+}
+
+func (r *BuildRunReconciler) mergedBuildRunLogLines(ctx context.Context, br *mortisev1alpha1.BuildRun, current []string) ([]string, error) {
+	key := types.NamespacedName{Name: buildRunLogConfigMapName(br.Name), Namespace: br.Namespace}
+	var existing corev1.ConfigMap
+	if err := r.Get(ctx, key, &existing); err != nil {
+		if errors.IsNotFound(err) {
+			return current, nil
+		}
+		return nil, err
+	}
+	merged := []string{}
+	if existing.Data["lines"] != "" {
+		merged = append(merged, strings.Split(existing.Data["lines"], "\n")...)
+	}
+	if len(merged) > 0 && len(current) > 0 && merged[len(merged)-1] == current[0] {
+		current = current[1:]
+	}
+	merged = append(merged, current...)
+	return merged, nil
+}
+
+func (r *BuildRunReconciler) appendBuildRunLogMarker(ctx context.Context, br *mortisev1alpha1.BuildRun, marker string) error {
+	if marker == "" {
+		return nil
+	}
+	lines, err := r.mergedBuildRunLogLines(ctx, br, []string{marker})
+	if err != nil {
+		return err
+	}
+	joined := strings.Join(lines, "\n")
+	for len(joined) > maxBuildLogConfigMapBytes && len(lines) > 0 {
+		lines = lines[1:]
+		joined = strings.Join(lines, "\n")
+	}
+	runLog := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      buildRunLogConfigMapName(br.Name),
+			Namespace: br.Namespace,
+			Labels:    map[string]string{"app.kubernetes.io/managed-by": "mortise"},
+			Annotations: map[string]string{
+				buildLogAnnotationTimestamp: r.clock().Now().UTC().Format(time.RFC3339Nano),
+				buildLogAnnotationCommit:    br.Spec.Revision,
+				buildLogAnnotationStatus:    string(br.Status.Phase),
+			},
+		},
+		Data: map[string]string{"lines": joined},
+	}
+	if err := controllerutil.SetControllerReference(br, runLog, r.Scheme); err != nil {
+		return err
+	}
+	return upsertConfigMap(ctx, r.Client, runLog)
 }
 
 func (r *BuildRunReconciler) projectTerminalBuildRunStatus(ctx context.Context, br *mortisev1alpha1.BuildRun) error {

--- a/internal/controller/buildrun_controller_recovery_test.go
+++ b/internal/controller/buildrun_controller_recovery_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clocktesting "k8s.io/utils/clock/testing"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/build"
+)
+
+type countingGatedBuildClient struct {
+	release <-chan struct{}
+	mu      sync.Mutex
+	submits int
+}
+
+func (c *countingGatedBuildClient) Submit(ctx context.Context, _ build.BuildRequest) (<-chan build.BuildEvent, error) {
+	c.mu.Lock()
+	c.submits++
+	c.mu.Unlock()
+
+	ch := make(chan build.BuildEvent, 1)
+	go func() {
+		defer close(ch)
+		select {
+		case <-c.release:
+			ch <- build.BuildEvent{Type: build.EventSuccess, Digest: "sha256:deadbeef"}
+		case <-ctx.Done():
+			ch <- build.BuildEvent{Type: build.EventFailure, Error: ctx.Err().Error()}
+		}
+	}()
+	return ch, nil
+}
+
+func (c *countingGatedBuildClient) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.submits
+}
+
+func TestBuildRunRestartsOnceAfterTrackerLoss(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	release := make(chan struct{})
+	defer close(release)
+
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-1", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment:    "production",
+			Repo:           "https://example.com/repo.git",
+			Branch:         "main",
+			Revision:       "abc123",
+			DockerfilePath: "Dockerfile",
+			PushTarget:     "registry.example.com/demo:abc123",
+			PullTarget:     "registry.example.com/demo:abc123",
+			TokenSecretRef: &mortisev1alpha1.SecretRef{Name: "git-token", Namespace: "mortise-system", Key: "token"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-token", Namespace: "mortise-system"},
+		Data:       map[string][]byte{"token": []byte("tok")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run, secret).Build()
+	clock := clocktesting.NewFakeClock(time.Unix(1_700_000_000, 0))
+	buildClient := &countingGatedBuildClient{release: release}
+	r := &BuildRunReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		Clock:           clock,
+		BuildClient:     buildClient,
+		GitClient:       &fakeGitClient{},
+		RegistryBackend: &fakeRegistryBackend{},
+		Builds:          &BuildTrackerStore{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if err := waitForBuildSubmits(buildClient, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	r.Builds.delete(types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+	clock.Step(buildRunTrackerLossGrace + time.Second)
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("recovery reconcile: %v", err)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning {
+		t.Fatalf("expected running after recovery, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Attempt != 2 {
+		t.Fatalf("expected attempt 2 after recovery, got %d", updated.Status.Attempt)
+	}
+	if err := waitForBuildSubmits(buildClient, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	var logCM corev1.ConfigMap
+	if err := c.Get(context.Background(), types.NamespacedName{Name: buildRunLogConfigMapName(run.Name), Namespace: run.Namespace}, &logCM); err != nil {
+		t.Fatalf("get buildrun log configmap: %v", err)
+	}
+	if !strings.Contains(logCM.Data["lines"], "restarting attempt 2") {
+		t.Fatalf("expected recovery marker in persisted logs, got %q", logCM.Data["lines"])
+	}
+}
+
+func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-2", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment: "production",
+			Repo:        "https://example.com/repo.git",
+			Revision:    "abc123",
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   2,
+			StartedAt: &started,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Second))
+	r := &BuildRunReconciler{
+		Client: c,
+		Scheme: scheme,
+		Clock:  clock,
+		Builds: &BuildTrackerStore{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile interrupted buildrun: %v", err)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseFailed {
+		t.Fatalf("expected failed buildrun, got %q", updated.Status.Phase)
+	}
+	if updated.Status.FailureReason != "BuildInterrupted" {
+		t.Fatalf("expected BuildInterrupted failure reason, got %q", updated.Status.FailureReason)
+	}
+	if !strings.Contains(updated.Status.FailureMessage, "tracker lost") {
+		t.Fatalf("expected interruption message, got %q", updated.Status.FailureMessage)
+	}
+}
+
+func waitForBuildSubmits(client *countingGatedBuildClient, want int) error {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if client.count() == want {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("expected %d build submits, got %d", want, client.count())
+}


### PR DESCRIPTION
## What changed
- add BuildRun tracker-loss recovery with attempt tracking, restart-once behavior, terminal failure after a second loss, and log markers that persist across recovery
- merge persisted BuildRun log lines across retries so recovery/failure markers survive tracker restarts
- latch successful webhook registration by input hash and also latch permanent webhook failures by the same hash while still retrying transient failures
- add focused controller coverage for BuildRun recovery and webhook latching behavior

Closes #295.

## Why
- BuildRun reconcile should recover deterministically when the in-memory tracker disappears instead of silently stalling or losing context
- webhook registration failures caused by permanent repo/auth conflicts should stop repeating on every reconcile until inputs change, while transient outages should still retry

## Impact
- BuildRun status now records the current attempt and produces clearer interrupted/recovery logs
- Apps avoid repeated permanent webhook registration calls for unchanged inputs, reducing noisy failures without changing manual build behavior

## Checks
- go test ./internal/controller -run 'TestBuildRun(RestartsOnceAfterTrackerLoss|FailsAfterSecondTrackerLoss)$'
- KUBEBUILDER_ASSETS=/home/james/workspaces/mortise/bin/k8s/1.35.0-linux-amd64 go test ./internal/controller -run TestControllers -args -ginkgo.focus='webhook registration'
