### PR TITLE
[codex] Env redaction and secret guardrails

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -297,6 +297,8 @@ definitions:
     properties:
       name:
         type: string
+      redacted:
+        type: boolean
       source:
         type: string
       value:

--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -23,9 +23,10 @@ import (
 
 // envVarResponse is the JSON shape for a single env var.
 type envVarResponse struct {
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	Source string `json:"source,omitempty"`
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Source   string `json:"source,omitempty"`
+	Redacted bool   `json:"redacted,omitempty"`
 }
 
 // patchEnvRequest is the JSON body for PATCH .../env.
@@ -70,10 +71,15 @@ func (s *Server) GetEnv(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	plaintext, err := s.canAuthorize(r, authz.Resource{Kind: "app", Project: projectName, Environment: envName}, authz.ActionUpdate)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{"authorization check failed"})
+		return
+	}
 
 	resp := make([]envVarResponse, 0, len(envs))
 	for _, e := range envs {
-		resp = append(resp, envVarResponse{Name: e.Name, Value: e.Value, Source: e.Source})
+		resp = append(resp, envResponseVar(e, plaintext))
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -381,12 +387,27 @@ func (s *Server) GetSharedVars(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	plaintext, err := s.canAuthorize(r, authz.Resource{Kind: "app", Project: projectName}, authz.ActionUpdate)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{"authorization check failed"})
+		return
+	}
 
 	resp := make([]envVarResponse, 0, len(envs))
 	for _, e := range envs {
-		resp = append(resp, envVarResponse{Name: e.Name, Value: e.Value, Source: e.Source})
+		resp = append(resp, envResponseVar(e, plaintext))
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func envResponseVar(e envstore.Env, plaintext bool) envVarResponse {
+	resp := envVarResponse{Name: e.Name, Source: e.Source}
+	if plaintext {
+		resp.Value = e.Value
+		return resp
+	}
+	resp.Redacted = true
+	return resp
 }
 
 // PutSharedVars replaces all shared env vars for a project.

--- a/internal/api/env_handler_test.go
+++ b/internal/api/env_handler_test.go
@@ -8,8 +8,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/api"
+	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/envstore"
 )
@@ -373,6 +377,109 @@ func TestPatchEnvRejectsManagedVarUnset(t *testing.T) {
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 when unsetting user var, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetEnvAndSharedVarsRedactionForDeveloperAndViewer(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	ns := seedProject(t, k8sClient, "default", "production", "staging")
+	seedImageApp(t, k8sClient, ns, "webapp", mortisev1alpha1.Environment{Name: "production"}, mortisev1alpha1.Environment{Name: "staging"})
+
+	newServerForUser := func(t *testing.T, email string, role auth.Role) (*api.Server, string) {
+		t.Helper()
+		authProvider := auth.NewNativeAuthProvider(k8sClient)
+		jwtHelper := auth.NewJWTHelper(k8sClient)
+		if err := authProvider.CreateUser(ctx, email, "testpass", role); err != nil {
+			t.Fatalf("create user %s: %v", email, err)
+		}
+		principal, err := authProvider.Authenticate(ctx, auth.Credentials{Email: email, Password: "testpass"})
+		if err != nil {
+			t.Fatalf("authenticate %s: %v", email, err)
+		}
+		token, err := jwtHelper.GenerateToken(ctx, principal)
+		if err != nil {
+			t.Fatalf("token for %s: %v", email, err)
+		}
+		return api.NewServer(k8sClient, nil, nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient)), token
+	}
+
+	var project mortisev1alpha1.Project
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "default"}, &project); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{
+		{Name: "production", Restricted: true},
+		{Name: "staging"},
+	}
+	if err := k8sClient.Update(ctx, &project); err != nil {
+		t.Fatalf("update project restrictions: %v", err)
+	}
+
+	store := &envstore.Store{Client: k8sClient}
+	if err := store.Set(ctx, constants.EnvNamespace("default", "production"), "webapp", []envstore.Env{{Name: "DB_URL", Value: "postgres://prod", Source: "user"}}, nil); err != nil {
+		t.Fatalf("seed prod env: %v", err)
+	}
+	if err := store.Set(ctx, constants.EnvNamespace("default", "staging"), "webapp", []envstore.Env{{Name: "DB_URL", Value: "postgres://staging", Source: "user"}}, nil); err != nil {
+		t.Fatalf("seed staging env: %v", err)
+	}
+	if err := store.SetSharedSource(ctx, constants.ControlNamespace("default"), []envstore.Env{{Name: "SHARED_KEY", Value: "shared-value", Source: "shared"}}, nil); err != nil {
+		t.Fatalf("seed shared vars: %v", err)
+	}
+
+	adminSrv, adminToken := newServerForUser(t, "admin@example.com", auth.RoleAdmin)
+	developerSrv, developerToken := newServerForUser(t, "developer@example.com", auth.RoleMember)
+	viewerSrv, viewerToken := newServerForUser(t, "viewer@example.com", auth.RoleMember)
+	seedProjectMember(t, k8sClient, "default", "developer@example.com", mortisev1alpha1.ProjectRoleDeveloper)
+	seedProjectMember(t, k8sClient, "default", "viewer@example.com", mortisev1alpha1.ProjectRoleViewer)
+
+	type envVar struct {
+		Name     string `json:"name"`
+		Value    string `json:"value"`
+		Source   string `json:"source"`
+		Redacted bool   `json:"redacted"`
+	}
+	readVars := func(t *testing.T, h http.Handler, token, path string) []envVar {
+		t.Helper()
+		w := doRequestWithToken(h, http.MethodGet, path, nil, token)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: expected 200, got %d: %s", path, w.Code, w.Body.String())
+		}
+		var got []envVar
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		return got
+	}
+
+	adminProd := readVars(t, adminSrv.Handler(), adminToken, "/api/projects/default/apps/webapp/env?environment=production")
+	if len(adminProd) != 1 || adminProd[0].Value != "postgres://prod" || adminProd[0].Redacted {
+		t.Fatalf("admin should see plaintext production env, got %+v", adminProd)
+	}
+
+	developerStaging := readVars(t, developerSrv.Handler(), developerToken, "/api/projects/default/apps/webapp/env?environment=staging")
+	if len(developerStaging) != 1 || developerStaging[0].Value != "postgres://staging" || developerStaging[0].Redacted {
+		t.Fatalf("developer should see plaintext staging env, got %+v", developerStaging)
+	}
+
+	developerProd := readVars(t, developerSrv.Handler(), developerToken, "/api/projects/default/apps/webapp/env?environment=production")
+	if len(developerProd) != 1 || developerProd[0].Value != "" || !developerProd[0].Redacted || developerProd[0].Source != "user" {
+		t.Fatalf("developer should receive redacted production env metadata, got %+v", developerProd)
+	}
+
+	developerShared := readVars(t, developerSrv.Handler(), developerToken, "/api/projects/default/shared-vars")
+	if len(developerShared) != 1 || developerShared[0].Value != "shared-value" || developerShared[0].Redacted {
+		t.Fatalf("developer should see plaintext shared vars, got %+v", developerShared)
+	}
+
+	viewerStaging := readVars(t, viewerSrv.Handler(), viewerToken, "/api/projects/default/apps/webapp/env?environment=staging")
+	if len(viewerStaging) != 1 || viewerStaging[0].Value != "" || !viewerStaging[0].Redacted {
+		t.Fatalf("viewer should receive redacted app env metadata, got %+v", viewerStaging)
+	}
+
+	viewerShared := readVars(t, viewerSrv.Handler(), viewerToken, "/api/projects/default/shared-vars")
+	if len(viewerShared) != 1 || viewerShared[0].Value != "" || !viewerShared[0].Redacted {
+		t.Fatalf("viewer should receive redacted shared var metadata, got %+v", viewerShared)
 	}
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -297,6 +297,8 @@ definitions:
     properties:
       name:
         type: string
+      redacted:
+        type: boolean
       source:
         type: string
       value:

--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -15,6 +15,7 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/envstore"
 )
 
 // createSecretRequest is the JSON body for upserting a secret.
@@ -89,6 +90,10 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 	if msg := validateDNSLabel("name", req.Name, 253); msg != "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{msg})
+		return
+	}
+	if req.Name == envstore.AppEnvSecretName(target.app.Name) {
+		writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("secret name %q is reserved for mortise runtime state", req.Name)})
 		return
 	}
 

--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -92,7 +92,7 @@ func (s *Server) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse{msg})
 		return
 	}
-	if req.Name == envstore.AppEnvSecretName(target.app.Name) {
+	if isReservedRuntimeSecretName(target.app.Name, req.Name) {
 		writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("secret name %q is reserved for mortise runtime state", req.Name)})
 		return
 	}
@@ -156,7 +156,7 @@ func (s *Server) ListSecrets(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]secretResponse, 0, len(list.Items))
 	for i := range list.Items {
-		if isInternalAppEnvSecret(target.app.Name, &list.Items[i]) {
+		if isReservedRuntimeSecret(target.app.Name, &list.Items[i]) {
 			continue
 		}
 		resp = append(resp, toSecretResponse(&list.Items[i]))
@@ -207,7 +207,7 @@ func (s *Server) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, errorResponse{"secret not found for this app"})
 		return
 	}
-	if isInternalAppEnvSecret(target.app.Name, &secret) {
+	if isReservedRuntimeSecret(target.app.Name, &secret) {
 		writeJSON(w, http.StatusForbidden, errorResponse{"secret is reserved for mortise runtime state"})
 		return
 	}
@@ -265,6 +265,14 @@ func (s *Server) resolveSecretTarget(w http.ResponseWriter, r *http.Request) (*s
 
 func isInternalAppEnvSecret(appName string, secret *corev1.Secret) bool {
 	return secret.Name == appName+"-env"
+}
+
+func isReservedRuntimeSecret(appName string, secret *corev1.Secret) bool {
+	return isReservedRuntimeSecretName(appName, secret.Name)
+}
+
+func isReservedRuntimeSecretName(appName, secretName string) bool {
+	return secretName == envstore.AppEnvSecretName(appName) || secretName == pullSecretName(appName)
 }
 
 func toSecretResponse(s *corev1.Secret) secretResponse {

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -13,6 +13,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/envstore"
 )
 
 func TestCreateSecretLabelsProject(t *testing.T) {
@@ -114,6 +115,22 @@ func TestDeleteSecretRejectsInternalEnvSecret(t *testing.T) {
 	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/webapp/secrets/webapp-env?environment=production", nil)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("delete internal env secret: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateSecretRejectsReservedRuntimeSecretName(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+	seedAppForEnv(t, h)
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
+		"name": envstore.AppEnvSecretName("webapp"),
+		"data": map[string]string{"TOP": "secret"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("create reserved secret: expected 409, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -122,11 +122,11 @@ func TestCreateSecretRejectsReservedRuntimeSecretName(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedAppForEnv(t, h)
+	ns := seedProject(t, k8sClient, "reserved-secret-create")
+	seedImageApp(t, k8sClient, ns, "reserved-app")
 
-	for _, name := range []string{envstore.AppEnvSecretName("webapp"), "webapp-pull-secret"} {
-		w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
+	for _, name := range []string{envstore.AppEnvSecretName("reserved-app"), "reserved-app-pull-secret"} {
+		w := doRequest(h, http.MethodPost, "/api/projects/reserved-secret-create/apps/reserved-app/secrets?environment=production", map[string]any{
 			"name": name,
 			"data": map[string]string{"TOP": "secret"},
 		})
@@ -140,10 +140,10 @@ func TestListSecretsHidesReservedRuntimeSecrets(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedAppForEnv(t, h)
+	ns := seedProject(t, k8sClient, "reserved-secret-list")
+	seedImageApp(t, k8sClient, ns, "reserved-app")
 
-	create := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
+	create := doRequest(h, http.MethodPost, "/api/projects/reserved-secret-list/apps/reserved-app/secrets?environment=production", map[string]any{
 		"name": "user-secret",
 		"data": map[string]string{"TOP": "secret"},
 	})
@@ -151,7 +151,7 @@ func TestListSecretsHidesReservedRuntimeSecrets(t *testing.T) {
 		t.Fatalf("create user secret: expected 201, got %d: %s", create.Code, create.Body.String())
 	}
 
-	setPull := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/pull-credentials", map[string]any{
+	setPull := doRequest(h, http.MethodPost, "/api/projects/reserved-secret-list/apps/reserved-app/pull-credentials", map[string]any{
 		"registry": "ghcr.io",
 		"username": "octo",
 		"password": "secret",
@@ -160,7 +160,7 @@ func TestListSecretsHidesReservedRuntimeSecrets(t *testing.T) {
 		t.Fatalf("set pull credentials: expected 200, got %d: %s", setPull.Code, setPull.Body.String())
 	}
 
-	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/webapp/secrets?environment=production", nil)
+	w := doRequest(h, http.MethodGet, "/api/projects/reserved-secret-list/apps/reserved-app/secrets?environment=production", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("list secrets: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -178,10 +178,10 @@ func TestDeleteSecretRejectsReservedPullSecret(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
-	seedProject(t, k8sClient, "default")
-	seedAppForEnv(t, h)
+	ns := seedProject(t, k8sClient, "reserved-secret-delete")
+	seedImageApp(t, k8sClient, ns, "reserved-app")
 
-	setPull := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/pull-credentials", map[string]any{
+	setPull := doRequest(h, http.MethodPost, "/api/projects/reserved-secret-delete/apps/reserved-app/pull-credentials", map[string]any{
 		"registry": "ghcr.io",
 		"username": "octo",
 		"password": "secret",
@@ -190,7 +190,7 @@ func TestDeleteSecretRejectsReservedPullSecret(t *testing.T) {
 		t.Fatalf("set pull credentials: expected 200, got %d: %s", setPull.Code, setPull.Body.String())
 	}
 
-	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/webapp/secrets/webapp-pull-secret?environment=production", nil)
+	w := doRequest(h, http.MethodDelete, "/api/projects/reserved-secret-delete/apps/reserved-app/secrets/reserved-app-pull-secret?environment=production", nil)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("delete reserved pull secret: expected 403, got %d: %s", w.Code, w.Body.String())
 	}

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -125,12 +125,74 @@ func TestCreateSecretRejectsReservedRuntimeSecretName(t *testing.T) {
 	seedProject(t, k8sClient, "default")
 	seedAppForEnv(t, h)
 
-	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
-		"name": envstore.AppEnvSecretName("webapp"),
+	for _, name := range []string{envstore.AppEnvSecretName("webapp"), "webapp-pull-secret"} {
+		w := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
+			"name": name,
+			"data": map[string]string{"TOP": "secret"},
+		})
+		if w.Code != http.StatusConflict {
+			t.Fatalf("create reserved secret %q: expected 409, got %d: %s", name, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestListSecretsHidesReservedRuntimeSecrets(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+	seedAppForEnv(t, h)
+
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/secrets?environment=production", map[string]any{
+		"name": "user-secret",
 		"data": map[string]string{"TOP": "secret"},
 	})
-	if w.Code != http.StatusConflict {
-		t.Fatalf("create reserved secret: expected 409, got %d: %s", w.Code, w.Body.String())
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create user secret: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	setPull := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/pull-credentials", map[string]any{
+		"registry": "ghcr.io",
+		"username": "octo",
+		"password": "secret",
+	})
+	if setPull.Code != http.StatusOK {
+		t.Fatalf("set pull credentials: expected 200, got %d: %s", setPull.Code, setPull.Body.String())
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/webapp/secrets?environment=production", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list secrets: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode secrets response: %v", err)
+	}
+	if len(resp) != 1 || resp[0]["name"] != "user-secret" {
+		t.Fatalf("expected only user-secret in response, got %+v", resp)
+	}
+}
+
+func TestDeleteSecretRejectsReservedPullSecret(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+	seedAppForEnv(t, h)
+
+	setPull := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/pull-credentials", map[string]any{
+		"registry": "ghcr.io",
+		"username": "octo",
+		"password": "secret",
+	})
+	if setPull.Code != http.StatusOK {
+		t.Fatalf("set pull credentials: expected 200, got %d: %s", setPull.Code, setPull.Body.String())
+	}
+
+	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/webapp/secrets/webapp-pull-secret?environment=production", nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("delete reserved pull secret: expected 403, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -122,6 +122,14 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, resource auth
 	return true
 }
 
+func (s *Server) canAuthorize(r *http.Request, resource authz.Resource, action authz.Action) (bool, error) {
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		return false, nil
+	}
+	return s.authz.Authorize(r.Context(), *p, resource, action)
+}
+
 // Handler returns the root HTTP handler with all routes mounted.
 //
 // URL scheme:

--- a/internal/api/tokens_handler_test.go
+++ b/internal/api/tokens_handler_test.go
@@ -152,6 +152,47 @@ func TestCreateTokenAllowsDeclaredEnvWithoutAppOverride(t *testing.T) {
 	}
 }
 
+func TestDeployTokenCanDeployToDeclaredEnvWithoutExplicitAppOverride(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default", "staging", "production")
+	seedTokenApp(t, k8sClient, ns, "webapp")
+
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
+		"name":        "ci-staging",
+		"environment": "staging",
+	})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create token: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+	var created struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(create.Body).Decode(&created); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if created.Token == "" {
+		t.Fatal("expected raw deploy token")
+	}
+
+	deploy := doRequestWithToken(h, http.MethodPost, "/api/projects/default/apps/webapp/deploy", map[string]any{
+		"environment": "staging",
+		"image":       "nginx:1.27.0",
+	}, created.Token)
+	if deploy.Code != http.StatusOK {
+		t.Fatalf("deploy with token: expected 200, got %d: %s", deploy.Code, deploy.Body.String())
+	}
+
+	var app mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "webapp", Namespace: ns}, &app); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if len(app.Spec.Environments) != 1 || app.Spec.Environments[0].Name != "staging" || app.Spec.Environments[0].Image != "nginx:1.27.0" {
+		t.Fatalf("expected staging override to be created by deploy token, got %+v", app.Spec.Environments)
+	}
+}
+
 func TestDeleteTokenNotFound(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)

--- a/internal/api/tokens_handler_test.go
+++ b/internal/api/tokens_handler_test.go
@@ -157,10 +157,10 @@ func TestDeployTokenCanDeployToDeclaredEnvWithoutExplicitAppOverride(t *testing.
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
 	ns := seedProject(t, k8sClient, "default", "staging", "production")
-	seedTokenApp(t, k8sClient, ns, "webapp")
+	seedTokenApp(t, k8sClient, ns, "env-deploy-target")
 
-	create := doRequest(h, http.MethodPost, "/api/projects/default/apps/webapp/tokens", map[string]any{
-		"name":        "ci-staging",
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps/env-deploy-target/tokens", map[string]any{
+		"name":        "ci-staging-deploy",
 		"environment": "staging",
 	})
 	if create.Code != http.StatusCreated {
@@ -176,7 +176,7 @@ func TestDeployTokenCanDeployToDeclaredEnvWithoutExplicitAppOverride(t *testing.
 		t.Fatal("expected raw deploy token")
 	}
 
-	deploy := doRequestWithToken(h, http.MethodPost, "/api/projects/default/apps/webapp/deploy", map[string]any{
+	deploy := doRequestWithToken(h, http.MethodPost, "/api/projects/default/apps/env-deploy-target/deploy", map[string]any{
 		"environment": "staging",
 		"image":       "nginx:1.27.0",
 	}, created.Token)
@@ -185,7 +185,7 @@ func TestDeployTokenCanDeployToDeclaredEnvWithoutExplicitAppOverride(t *testing.
 	}
 
 	var app mortisev1alpha1.App
-	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "webapp", Namespace: ns}, &app); err != nil {
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "env-deploy-target", Namespace: ns}, &app); err != nil {
 		t.Fatalf("get app: %v", err)
 	}
 	if len(app.Spec.Environments) != 1 || app.Spec.Environments[0].Name != "staging" || app.Spec.Environments[0].Image != "nginx:1.27.0" {


### PR DESCRIPTION
## What changed
- Redacted env and shared-var values unless the caller is authorized for update access.
- Blocked creation of app runtime-reserved secret names.
- Added focused API coverage for env redaction and deploy-token behavior.

Closes #313.
Closes #332.
Closes #333.

## Why
- Prevents secret values from being exposed to read-only users.
- Protects Mortise-managed runtime secret names from user collision.
- Verifies deploy tokens can still target declared environments without explicit app overrides.

## Impact
- Developers and admins still see plaintext where authorized; viewers and restricted callers receive metadata-only responses.
- Secret creation now returns `409 Conflict` for reserved runtime secret names.
- Deploy-token coverage is stronger without changing unrelated API surfaces.

## Checks
- `KUBEBUILDER_ASSETS=/tmp/mortise-upstream-main-api-sweep-20260511/bin/k8s/1.35.0-linux-amd64 go test ./internal/api -run 'TestGetEnvAndSharedVarsRedactionForDeveloperAndViewer|TestCreateSecretRejectsReservedRuntimeSecretName|TestCreateTokenMissingAppReturns404|TestDeployTokenCanDeployToDeclaredEnvWithoutExplicitAppOverride'`
