### PR TITLE
[codex] Activity backfill and log stream errors

### DIFF
--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -30,6 +30,9 @@ type logLine struct {
 	Ts     string `json:"ts,omitempty"`
 	Line   string `json:"line"`
 	Stream string `json:"stream"`
+	Kind   string `json:"kind,omitempty"`
+	Code   string `json:"code,omitempty"`
+	Fatal  bool   `json:"fatal,omitempty"`
 }
 
 // parseLogLine splits a kubelet log line of the form
@@ -325,7 +328,14 @@ func (s *Server) streamPodLogs(ctx context.Context, w *sseWriter, ns, podName st
 	stream, err := s.clientset.CoreV1().Pods(ns).GetLogs(podName, opts).Stream(ctx)
 	if err != nil {
 		if ctx.Err() == nil {
-			w.writeEvent(logLine{Pod: podName, Line: fmt.Sprintf("error opening log stream: %v", err), Stream: "stderr"})
+			w.writeEvent(logLine{
+				Pod:    podName,
+				Line:   fmt.Sprintf("error opening log stream: %v", err),
+				Stream: "stderr",
+				Kind:   "error",
+				Code:   "stream_open_failed",
+				Fatal:  true,
+			})
 		}
 		return
 	}

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -331,9 +331,9 @@ func TestLogsStreamOpenFailureUsesStructuredErrorPayload(t *testing.T) {
 	srv, _ := newLogsServer(t, k8sClient, cs)
 	h := srv.Handler()
 	ns := seedProject(t, k8sClient, "default")
-	seedAppAndPod(t, k8sClient, ns, "stream-app", "production", "stream-app-pod-1")
+	seedAppAndPod(t, k8sClient, ns, "stream-fail-app", "production", "stream-fail-pod-1")
 
-	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/stream-app/logs?env=production", nil)
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/stream-fail-app/logs?env=production", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -10,7 +11,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,7 +30,7 @@ import (
 // newLogsServer returns a Server wired with the supplied fake clientset and a
 // bearer token, so tests can both seed pod objects and inspect which
 // PodLogOptions the handler forwarded to GetLogs.
-func newLogsServer(t *testing.T, k8sClient client.Client, cs *fake.Clientset) (*api.Server, string) {
+func newLogsServer(t *testing.T, k8sClient client.Client, cs kubernetes.Interface) (*api.Server, string) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -49,6 +55,42 @@ func newLogsServer(t *testing.T, k8sClient client.Client, cs *fake.Clientset) (*
 
 	srv := api.NewServer(k8sClient, cs, nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
 	return srv, token
+}
+
+type streamOpenFailingClientset struct {
+	kubernetes.Interface
+}
+
+func (c *streamOpenFailingClientset) CoreV1() corev1typed.CoreV1Interface {
+	return &streamOpenFailingCoreV1{CoreV1Interface: c.Interface.CoreV1()}
+}
+
+type streamOpenFailingCoreV1 struct {
+	corev1typed.CoreV1Interface
+}
+
+func (c *streamOpenFailingCoreV1) Pods(namespace string) corev1typed.PodInterface {
+	return &streamOpenFailingPods{
+		PodInterface: c.CoreV1Interface.Pods(namespace),
+		namespace:    namespace,
+	}
+}
+
+type streamOpenFailingPods struct {
+	corev1typed.PodInterface
+	namespace string
+}
+
+func (p *streamOpenFailingPods) GetLogs(name string, _ *corev1.PodLogOptions) *restclient.Request {
+	fakeClient := &fakerest.RESTClient{
+		Client: fakerest.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("boom")
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		GroupVersion:         corev1.SchemeGroupVersion,
+		VersionedAPIPath:     fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", p.namespace, name),
+	}
+	return fakeClient.Request()
 }
 
 // lastPodLogOptions returns the PodLogOptions passed to the most recent
@@ -280,6 +322,35 @@ func TestLogsSSEHeadersWithPod(t *testing.T) {
 	}
 	if _, ok := ev["stream"]; !ok {
 		t.Errorf("expected stream field in SSE event, got %v", ev)
+	}
+}
+
+func TestLogsStreamOpenFailureUsesStructuredErrorPayload(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	cs := &streamOpenFailingClientset{Interface: fake.NewClientset()}
+	srv, _ := newLogsServer(t, k8sClient, cs)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+	seedAppAndPod(t, k8sClient, ns, "stream-app", "production", "stream-app-pod-1")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/stream-app/logs?env=production", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected text/event-stream, got %s", ct)
+	}
+
+	line := strings.TrimPrefix(w.Body.String(), "data: ")
+	if idx := strings.Index(line, "\n"); idx > 0 {
+		line = line[:idx]
+	}
+	var ev map[string]any
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		t.Fatalf("decode structured error event: %v", err)
+	}
+	if ev["kind"] != "error" || ev["code"] != "stream_open_failed" || ev["fatal"] != true {
+		t.Fatalf("expected structured stream-open failure payload, got %+v", ev)
 	}
 }
 

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	stderrors "errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/activity"
 	"github.com/mortise-org/mortise/internal/constants"
 )
 
@@ -73,6 +75,8 @@ const ProjectEnvsRevAnnotation = "mortise.dev/project-envs-rev"
 // bumps when the Project spec changes so preview backfill can rerun on the
 // next App reconcile.
 const ProjectPreviewRevAnnotation = "mortise.dev/project-preview-rev"
+
+const projectCreateActivityRecordedAnnotation = "mortise.dev/project-create-activity-recorded"
 
 // ProjectNamespace returns the control namespace for a Project. Kept for
 // callers outside this package that used to rely on `project-{name}`.
@@ -193,6 +197,9 @@ func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Auto-create an owner ProjectMember for the project creator.
 	if err := r.ensureOwnerMember(ctx, &project, controlNs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensure owner member: %w", err)
+	}
+	if err := r.ensureProjectCreateActivity(ctx, &project); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensure project create activity: %w", err)
 	}
 
 	// Ensure one namespace per declared env.
@@ -632,6 +639,77 @@ func (r *ProjectReconciler) ensureOwnerMember(ctx context.Context, project *mort
 		return fmt.Errorf("create owner ProjectMember: %w", err)
 	}
 	return nil
+}
+
+func (r *ProjectReconciler) ensureProjectCreateActivity(ctx context.Context, project *mortisev1alpha1.Project) error {
+	if project.Annotations[projectCreateActivityRecordedAnnotation] == "true" {
+		return nil
+	}
+
+	store := activity.NewConfigMapStore(r.Client)
+	events, err := store.List(ctx, project.Name, activity.Cap)
+	if err != nil {
+		return fmt.Errorf("list project activity: %w", err)
+	}
+	if !hasProjectCreateActivity(events, project.Name) {
+		ts := time.Now().UTC()
+		if !project.CreationTimestamp.IsZero() {
+			ts = project.CreationTimestamp.UTC()
+		}
+		if err := store.Append(ctx, activity.Event{
+			Timestamp:    ts,
+			Actor:        firstNonEmpty(project.Annotations["mortise.dev/created-by"], "system"),
+			Action:       "create",
+			ResourceKind: "project",
+			ResourceName: project.Name,
+			Project:      project.Name,
+			Message:      "Created project " + project.Name,
+		}); err != nil {
+			return fmt.Errorf("append project activity: %w", err)
+		}
+	}
+
+	return r.markProjectCreateActivityRecorded(ctx, project.Name)
+}
+
+func hasProjectCreateActivity(events []activity.Event, projectName string) bool {
+	for _, event := range events {
+		if event.Project == projectName &&
+			event.Action == "create" &&
+			event.ResourceKind == "project" &&
+			event.ResourceName == projectName {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ProjectReconciler) markProjectCreateActivityRecorded(ctx context.Context, name string) error {
+	const maxConflictRetries = 5
+	for attempt := 0; attempt < maxConflictRetries; attempt++ {
+		var fresh mortisev1alpha1.Project
+		if err := r.Get(ctx, types.NamespacedName{Name: name}, &fresh); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if fresh.Annotations == nil {
+			fresh.Annotations = map[string]string{}
+		}
+		if fresh.Annotations[projectCreateActivityRecordedAnnotation] == "true" {
+			return nil
+		}
+		fresh.Annotations[projectCreateActivityRecordedAnnotation] = "true"
+		if err := r.Update(ctx, &fresh); err != nil {
+			if errors.IsConflict(err) && attempt < maxConflictRetries-1 {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("could not record project activity annotation for Project %q after retries", name)
 }
 
 // SetupWithManager wires the controller. Watches Apps (to keep appCount fresh)

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"time"
@@ -646,30 +647,104 @@ func (r *ProjectReconciler) ensureProjectCreateActivity(ctx context.Context, pro
 		return nil
 	}
 
-	store := activity.NewConfigMapStore(r.Client)
-	events, err := store.List(ctx, project.Name, activity.Cap)
-	if err != nil {
-		return fmt.Errorf("list project activity: %w", err)
+	if err := r.appendProjectCreateActivityIfMissing(ctx, projectCreateActivityEvent(project)); err != nil {
+		return fmt.Errorf("append project activity: %w", err)
 	}
-	if !hasProjectCreateActivity(events, project.Name) {
-		ts := time.Now().UTC()
-		if !project.CreationTimestamp.IsZero() {
-			ts = project.CreationTimestamp.UTC()
+	return r.markProjectCreateActivityRecorded(ctx, project.Name)
+}
+
+func projectCreateActivityEvent(project *mortisev1alpha1.Project) activity.Event {
+	ts := time.Now().UTC()
+	if !project.CreationTimestamp.IsZero() {
+		ts = project.CreationTimestamp.UTC()
+	}
+	return activity.Event{
+		Timestamp:    ts,
+		Actor:        firstNonEmpty(project.Annotations["mortise.dev/created-by"], "system"),
+		Action:       "create",
+		ResourceKind: "project",
+		ResourceName: project.Name,
+		Project:      project.Name,
+		Message:      "Created project " + project.Name,
+	}
+}
+
+// appendProjectCreateActivityIfMissing keeps the project-create backfill
+// exactly-once across concurrent reconciles by re-reading the latest ConfigMap
+// state before every create/update attempt and bailing out once the semantic
+// create event is already present.
+func (r *ProjectReconciler) appendProjectCreateActivityIfMissing(ctx context.Context, event activity.Event) error {
+	const (
+		maxConflictRetries = 5
+		activityEventsKey  = "events"
+	)
+
+	ns := constants.ControlNamespace(event.Project)
+	name := "activity-" + event.Project
+
+	for attempt := 0; attempt < maxConflictRetries; attempt++ {
+		var cm corev1.ConfigMap
+		err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &cm)
+		if errors.IsNotFound(err) {
+			data, err := json.Marshal([]activity.Event{event})
+			if err != nil {
+				return fmt.Errorf("marshal initial activity events: %w", err)
+			}
+			createErr := r.Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "mortise",
+						"mortise.dev/kind":             "activity",
+					},
+				},
+				Data: map[string]string{activityEventsKey: string(data)},
+			})
+			if createErr == nil {
+				return nil
+			}
+			if errors.IsAlreadyExists(createErr) || errors.IsConflict(createErr) {
+				continue
+			}
+			return createErr
 		}
-		if err := store.Append(ctx, activity.Event{
-			Timestamp:    ts,
-			Actor:        firstNonEmpty(project.Annotations["mortise.dev/created-by"], "system"),
-			Action:       "create",
-			ResourceKind: "project",
-			ResourceName: project.Name,
-			Project:      project.Name,
-			Message:      "Created project " + project.Name,
-		}); err != nil {
-			return fmt.Errorf("append project activity: %w", err)
+		if err != nil {
+			return err
 		}
+
+		var events []activity.Event
+		if raw := cm.Data[activityEventsKey]; raw != "" {
+			if err := json.Unmarshal([]byte(raw), &events); err != nil {
+				return fmt.Errorf("unmarshal project activity: %w", err)
+			}
+		}
+		if hasProjectCreateActivity(events, event.Project) {
+			return nil
+		}
+
+		events = append(events, event)
+		if len(events) > activity.Cap {
+			events = events[len(events)-activity.Cap:]
+		}
+		data, err := json.Marshal(events)
+		if err != nil {
+			return fmt.Errorf("marshal project activity: %w", err)
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[activityEventsKey] = string(data)
+		if err := r.Update(ctx, &cm); err != nil {
+			if errors.IsConflict(err) {
+				continue
+			}
+			return err
+		}
+		return nil
 	}
 
-	return r.markProjectCreateActivityRecorded(ctx, project.Name)
+	return fmt.Errorf("could not ensure create activity for Project %q after retries", event.Project)
 }
 
 func hasProjectCreateActivity(events []activity.Event, projectName string) bool {

--- a/internal/controller/project_controller_test.go
+++ b/internal/controller/project_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"encoding/hex"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -103,6 +104,9 @@ var _ = Describe("Project Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: ProjectNamespace(projectName)},
+			})).To(Succeed())
 
 			store := activity.NewConfigMapStore(k8sClient)
 			Expect(store.Append(ctx, activity.Event{
@@ -116,10 +120,10 @@ var _ = Describe("Project Controller", func() {
 			})).To(Succeed())
 
 			r := &ProjectReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(r.ensureProjectCreateActivity(ctx, project)).To(Succeed())
+			var stale mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, &stale)).To(Succeed())
+			Expect(r.ensureProjectCreateActivity(ctx, &stale)).To(Succeed())
 
 			events, err := store.List(ctx, projectName, activity.Cap)
 			Expect(err).NotTo(HaveOccurred())
@@ -133,6 +137,78 @@ var _ = Describe("Project Controller", func() {
 
 			var updated mortisev1alpha1.Project
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, &updated)).To(Succeed())
+			Expect(updated.Annotations[projectCreateActivityRecordedAnnotation]).To(Equal("true"))
+		})
+
+		It("dedupes concurrent stale backfill attempts", func() {
+			const concurrentProjectName = "activity-backfill-concurrent"
+			DeferCleanup(func() {
+				proj := &mortisev1alpha1.Project{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: concurrentProjectName}, proj); err == nil {
+					proj.Finalizers = nil
+					_ = k8sClient.Update(ctx, proj)
+					_ = k8sClient.Delete(ctx, proj)
+				}
+				_ = k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ProjectNamespace(concurrentProjectName)}})
+			})
+
+			project := &mortisev1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        concurrentProjectName,
+					Annotations: map[string]string{"mortise.dev/created-by": "owner@example.com"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: ProjectNamespace(concurrentProjectName)},
+			})).To(Succeed())
+
+			var staleA, staleB mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: concurrentProjectName}, &staleA)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: concurrentProjectName}, &staleB)).To(Succeed())
+
+			r := &ProjectReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			start := make(chan struct{})
+			errCh := make(chan error, 2)
+
+			run := func(stale *mortisev1alpha1.Project) {
+				defer GinkgoRecover()
+				<-start
+				errCh <- r.ensureProjectCreateActivity(ctx, stale)
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				run(&staleA)
+			}()
+			go func() {
+				defer wg.Done()
+				run(&staleB)
+			}()
+
+			close(start)
+			wg.Wait()
+			close(errCh)
+			for err := range errCh {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			store := activity.NewConfigMapStore(k8sClient)
+			events, err := store.List(ctx, concurrentProjectName, activity.Cap)
+			Expect(err).NotTo(HaveOccurred())
+
+			createEvents := 0
+			for _, event := range events {
+				if event.Action == "create" && event.ResourceKind == "project" && event.ResourceName == concurrentProjectName {
+					createEvents++
+				}
+			}
+			Expect(createEvents).To(Equal(1))
+
+			var updated mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: concurrentProjectName}, &updated)).To(Succeed())
 			Expect(updated.Annotations[projectCreateActivityRecordedAnnotation]).To(Equal("true"))
 		})
 	})

--- a/internal/controller/project_controller_test.go
+++ b/internal/controller/project_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/activity"
 )
 
 var _ = Describe("Project Controller", func() {
@@ -78,6 +79,61 @@ var _ = Describe("Project Controller", func() {
 			Expect(updated.Status.Phase).To(Equal(mortisev1alpha1.ProjectPhaseReady))
 			Expect(updated.Status.Namespace).To(Equal(nsName))
 			Expect(updated.Finalizers).To(ContainElement(projectFinalizer))
+		})
+	})
+
+	Context("project create activity backfill", func() {
+		const projectName = "activity-backfill"
+
+		AfterEach(func() {
+			proj := &mortisev1alpha1.Project{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, proj); err == nil {
+				proj.Finalizers = nil
+				_ = k8sClient.Update(ctx, proj)
+				_ = k8sClient.Delete(ctx, proj)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ProjectNamespace(projectName)}})
+		})
+
+		It("records exactly one create event after the control namespace exists", func() {
+			project := &mortisev1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        projectName,
+					Annotations: map[string]string{"mortise.dev/created-by": "owner@example.com"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+			store := activity.NewConfigMapStore(k8sClient)
+			Expect(store.Append(ctx, activity.Event{
+				Timestamp:    metav1.Now().Time,
+				Actor:        "owner@example.com",
+				Action:       "create",
+				ResourceKind: "project",
+				ResourceName: projectName,
+				Project:      projectName,
+				Message:      "Created project " + projectName,
+			})).To(Succeed())
+
+			r := &ProjectReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			events, err := store.List(ctx, projectName, activity.Cap)
+			Expect(err).NotTo(HaveOccurred())
+			createEvents := 0
+			for _, event := range events {
+				if event.Action == "create" && event.ResourceKind == "project" && event.ResourceName == projectName {
+					createEvents++
+				}
+			}
+			Expect(createEvents).To(Equal(1))
+
+			var updated mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, &updated)).To(Succeed())
+			Expect(updated.Annotations[projectCreateActivityRecordedAnnotation]).To(Equal("true"))
 		})
 	})
 


### PR DESCRIPTION
## What changed
- backfill the missing project create activity event during project reconcile and mark the project once recorded so it is not duplicated
- emit structured fatal SSE error events when a pod log stream fails to open
- add focused coverage for both behaviors, including a failing log-stream test harness that exercises the real stream-open error path

Closes #334.
Closes #335.

## Why
Some projects could miss their initial create activity entry, and log streaming startup failures were only exposed as plain text lines with no structured error metadata for the UI.

## Impact
Activity history now self-heals for older projects without duplicating create events, and the logs UX can distinguish fatal stream startup failures from normal log lines.

## Checks
- `go test ./internal/api -run '^TestLogsStreamOpenFailureUsesStructuredErrorPayload$'`
- `go test ./internal/controller -run '^TestControllers$' -ginkgo.focus='project create activity backfill'`
