### PR TITLE
[codex] API conflict and delete contract cleanup

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -867,8 +867,8 @@ cluster's default SC). For v1:
   Copies per-app CRD overrides (replicas, resources, probes, bindings,
   schedule, annotations) and Secret-level env vars (set via the UI/API).
   Binding-sourced vars are excluded — the controller re-resolves them
-  in the new namespace. The operation is retry-safe: partial failures
-  can be retried without duplication.
+  in the new namespace. If the target environment already exists on the
+  project, the API returns `409 Conflict`.
 - **Preview environments (project-level toggle, §5.0 `spec.preview.enabled`).**
   When enabled on the parent Project, PR opens → operator creates one
   `PreviewEnvironment` per App in the project. The preview controller

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,8 +328,8 @@ curl -s -X POST "$BASE/api/projects/$PROJECT/environments/$SOURCE_ENV/clone" \
   -d "{\"name\":\"staging\",\"displayOrder\":1}" | jq
 ```
 
-The operation is retry-safe: if a previous call partially completed, a
-repeat call finishes the remaining work without duplicating anything.
+If the target environment already exists on the project, the API returns
+`409 Conflict` instead of treating the call as a retry-safe replay.
 
 ### Preview environments
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3237,8 +3237,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Termination accepted
           schema:
             additionalProperties:
               type: string
@@ -5230,10 +5230,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: 'Creates a new environment pre-populated with the source''s config
+      description: Creates a new environment pre-populated with the source's config
         for every app. CRD overrides are cloned on the App, while Secret-backed env
-        vars remain in the Secret layer. Retry-safe: returns 200 if the target already
-        exists.'
+        vars remain in the Secret layer. Returns 409 Conflict if the target environment
+        already exists on the project.
       parameters:
       - description: Project name
         in: path
@@ -5254,10 +5254,6 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: 'Retry: target env already existed'
-          schema:
-            $ref: '#/definitions/api.projectEnvResponse'
         "201":
           description: Created
           schema:
@@ -5272,6 +5268,10 @@ paths:
             $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/api.errorResponse'
       security:

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -314,7 +314,7 @@ func (s *Server) UpdateApp(w http.ResponseWriter, r *http.Request) {
 // @Security BearerAuth
 // @Param project path string true "Project name"
 // @Param app path string true "App name"
-// @Success 200 {object} map[string]string
+// @Success 202 {object} map[string]string "Termination accepted"
 // @Failure 401 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -163,6 +164,17 @@ func (s *Server) CreateApp(w http.ResponseWriter, r *http.Request) {
 		Spec: req.Spec,
 	}
 	controllerutil.AddFinalizer(app, constants.AppFinalizer)
+
+	var existing mortisev1alpha1.App
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: req.Name, Namespace: ns}, &existing); err == nil {
+		if !existing.DeletionTimestamp.IsZero() {
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("app %q is still terminating; wait for deletion to complete before recreating it", req.Name)})
+			return
+		}
+	} else if !errors.IsNotFound(err) {
+		writeError(w, r, err)
+		return
+	}
 
 	if err := s.client.Create(r.Context(), app); err != nil {
 		writeError(w, r, err)
@@ -325,9 +337,12 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.client.Delete(r.Context(), &app); err != nil {
-		writeError(w, r, err)
-		return
+	firstDelete := app.DeletionTimestamp.IsZero()
+	if firstDelete {
+		if err := s.client.Delete(r.Context(), &app); err != nil {
+			writeError(w, r, err)
+			return
+		}
 	}
 
 	if err := s.deleteAppDeployTokens(r.Context(), ns, app.Name); err != nil {
@@ -335,9 +350,11 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.recordActivity(r, projectName, "delete", "app", app.Name, "Deleted app "+app.Name, "")
+	if firstDelete {
+		s.recordActivity(r, projectName, "delete", "app", app.Name, "Deleted app "+app.Name, "")
+	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "terminating", "app": app.Name})
 }
 
 func (s *Server) deleteAppDeployTokens(ctx context.Context, ns, appName string) error {
@@ -362,15 +379,15 @@ func (s *Server) deleteAppDeployTokens(ctx context.Context, ns, appName string) 
 // writeError maps k8s API errors to HTTP status codes.
 func writeError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.IsNotFound(err) {
-		writeJSON(w, http.StatusNotFound, errorResponse{err.Error()})
+		writeJSON(w, http.StatusNotFound, errorResponse{normalizeNotFoundError(err)})
 		return
 	}
 	if errors.IsConflict(err) {
-		writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
+		writeJSON(w, http.StatusConflict, errorResponse{normalizeConflictError(err)})
 		return
 	}
 	if errors.IsAlreadyExists(err) {
-		writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
+		writeJSON(w, http.StatusConflict, errorResponse{normalizeAlreadyExistsError(err)})
 		return
 	}
 	if errors.IsInvalid(err) {
@@ -379,4 +396,80 @@ func writeError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 	slog.Error("internal API error", "error", err, "method", r.Method, "path", r.URL.Path, "request_id", r.Header.Get("X-Request-ID"))
 	writeJSON(w, http.StatusInternalServerError, errorResponse{"internal server error"})
+}
+
+func normalizeNotFoundError(err error) string {
+	kind, name := errorResource(err)
+	switch {
+	case kind != "" && name != "":
+		return fmt.Sprintf("%s %q not found", kind, name)
+	case name != "":
+		return fmt.Sprintf("resource %q not found", name)
+	default:
+		return "resource not found"
+	}
+}
+
+func normalizeConflictError(err error) string {
+	kind, name := errorResource(err)
+	if strings.Contains(strings.ToLower(err.Error()), "the object has been modified") {
+		if kind == "" {
+			kind = "resource"
+		}
+		if name != "" {
+			return fmt.Sprintf("%s %q was modified by another operation; retry the request", kind, name)
+		}
+		return fmt.Sprintf("%s was modified by another operation; retry the request", kind)
+	}
+	if kind != "" && name != "" {
+		return fmt.Sprintf("%s %q is in conflict with another operation; retry the request", kind, name)
+	}
+	return "request conflicts with another operation; retry the request"
+}
+
+func normalizeAlreadyExistsError(err error) string {
+	kind, name := errorResource(err)
+	if kind != "" && name != "" {
+		return fmt.Sprintf("%s %q already exists", kind, name)
+	}
+	return "resource already exists"
+}
+
+func errorResource(err error) (kind, name string) {
+	var statusErr *errors.StatusError
+	if !stderrors.As(err, &statusErr) || statusErr.ErrStatus.Details == nil {
+		return "", ""
+	}
+	details := statusErr.ErrStatus.Details
+	return normalizeErrorKind(details.Kind), details.Name
+}
+
+func normalizeErrorKind(kind string) string {
+	kind = strings.TrimSpace(strings.ToLower(kind))
+	if kind == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(kind, '.'); idx > 0 {
+		kind = kind[:idx]
+	}
+	switch kind {
+	case "apps", "app":
+		return "app"
+	case "projects", "project":
+		return "project"
+	case "secrets", "secret":
+		return "secret"
+	case "gitproviders", "gitprovider":
+		return "git provider"
+	case "projectmembers", "projectmember":
+		return "project member"
+	case "buildruns", "buildrun":
+		return "build run"
+	case "previewenvironments", "previewenvironment":
+		return "preview environment"
+	case "namespaces", "namespace":
+		return "namespace"
+	default:
+		return strings.TrimSuffix(kind, "s")
+	}
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3237,8 +3237,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Termination accepted
           schema:
             additionalProperties:
               type: string
@@ -5230,10 +5230,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: 'Creates a new environment pre-populated with the source''s config
+      description: Creates a new environment pre-populated with the source's config
         for every app. CRD overrides are cloned on the App, while Secret-backed env
-        vars remain in the Secret layer. Retry-safe: returns 200 if the target already
-        exists.'
+        vars remain in the Secret layer. Returns 409 Conflict if the target environment
+        already exists on the project.
       parameters:
       - description: Project name
         in: path
@@ -5254,10 +5254,6 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: 'Retry: target env already existed'
-          schema:
-            $ref: '#/definitions/api.projectEnvResponse'
         "201":
           description: Created
           schema:
@@ -5272,6 +5268,10 @@ paths:
             $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/api.errorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/api.errorResponse'
       security:

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -462,15 +462,10 @@ type cloneProjectEnvRequest struct {
 // Binding-sourced vars are excluded because the controller re-resolves them in
 // the new namespace.
 //
-// The operation is retry-safe: if a previous call partially completed
-// (project env created but app overrides not fully applied), a repeat
-// call skips the project update and continues cloning app overrides,
-// returning 200 instead of 201.
-//
 // POST /api/projects/{project}/environments/{source}/clone  { "name": "staging" }
 //
 // @Summary Clone a project environment
-// @Description Creates a new environment pre-populated with the source's config for every app. CRD overrides are cloned on the App, while Secret-backed env vars remain in the Secret layer. Retry-safe: returns 200 if the target already exists.
+// @Description Creates a new environment pre-populated with the source's config for every app. CRD overrides are cloned on the App, while Secret-backed env vars remain in the Secret layer. Returns 409 Conflict if the target environment already exists on the project.
 // @Tags environments
 // @Accept json
 // @Produce json
@@ -478,11 +473,11 @@ type cloneProjectEnvRequest struct {
 // @Param project path string true "Project name"
 // @Param source path string true "Source environment name"
 // @Param body body cloneProjectEnvRequest true "Target environment name and display order"
-// @Success 200 {object} projectEnvResponse "Retry: target env already existed"
 // @Success 201 {object} projectEnvResponse "Created"
 // @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
+// @Failure 409 {object} errorResponse
 // @Router /projects/{project}/environments/{source}/clone [post]
 func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -510,31 +510,25 @@ func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Retry-safe: if the target env already exists on the project (partial
-	// failure added the env but didn't finish cloning app overrides), skip
-	// the project update and continue with per-app cloning.
-	targetExists := false
 	for _, existing := range project.Spec.Environments {
 		if existing.Name == req.Name {
-			targetExists = true
-			break
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("environment %q already exists on project %q", req.Name, project.Name)})
+			return
 		}
 	}
 
-	if !targetExists {
-		project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
-			Name:         req.Name,
-			DisplayOrder: req.DisplayOrder,
-		})
-		if err := s.ensureProjectEnvNamespace(r.Context(), project, req.Name, false); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if err := s.client.Update(r.Context(), project); err != nil {
-			_ = s.deleteProjectEnvNamespace(r.Context(), project, req.Name)
-			writeError(w, r, err)
-			return
-		}
+	project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
+		Name:         req.Name,
+		DisplayOrder: req.DisplayOrder,
+	})
+	if err := s.ensureProjectEnvNamespace(r.Context(), project, req.Name, false); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if err := s.client.Update(r.Context(), project); err != nil {
+		_ = s.deleteProjectEnvNamespace(r.Context(), project, req.Name)
+		writeError(w, r, err)
+		return
 	}
 	if err := s.ensureProjectEnvNamespace(r.Context(), project, req.Name, true); err != nil {
 		writeError(w, r, err)
@@ -554,11 +548,7 @@ func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request)
 	s.recordActivity(r, projectName, "create", "environment", req.Name,
 		fmt.Sprintf("Cloned environment %s from %s", req.Name, sourceName), "")
 
-	status := http.StatusCreated
-	if targetExists {
-		status = http.StatusOK
-	}
-	writeJSON(w, status, projectEnvResponse{
+	writeJSON(w, http.StatusCreated, projectEnvResponse{
 		Name:         req.Name,
 		DisplayOrder: req.DisplayOrder,
 		Health:       EnvHealthUnknown,

--- a/internal/api/project_envs_test.go
+++ b/internal/api/project_envs_test.go
@@ -969,9 +969,8 @@ func TestCloneProjectEnvironmentSourceNotFound(t *testing.T) {
 	}
 }
 
-// TestCloneProjectEnvironmentDuplicateTarget returns 200 (retry-safe) when
-// the target env already exists on the project — the handler skips the
-// project update and continues with per-app cloning.
+// TestCloneProjectEnvironmentDuplicateTarget rejects cloning onto an existing
+// target environment.
 func TestCloneProjectEnvironmentDuplicateTarget(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
@@ -981,8 +980,8 @@ func TestCloneProjectEnvironmentDuplicateTarget(t *testing.T) {
 	w := doRequest(h, http.MethodPost, "/api/projects/demo/environments/production/clone", map[string]any{
 		"name": "staging",
 	})
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 (retry-safe), got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/pull_credentials_test.go
+++ b/internal/api/pull_credentials_test.go
@@ -67,8 +67,15 @@ func TestPullCredentialsCRUDAndDeleteAppDefersCleanupToController(t *testing.T) 
 	}
 
 	del := doRequest(h, http.MethodDelete, "/api/projects/default/apps/web", nil)
-	if del.Code != http.StatusOK {
-		t.Fatalf("delete app: expected 200, got %d: %s", del.Code, del.Body.String())
+	if del.Code != http.StatusAccepted {
+		t.Fatalf("delete app: expected 202, got %d: %s", del.Code, del.Body.String())
+	}
+	var deleted map[string]any
+	if err := json.NewDecoder(del.Body).Decode(&deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted["status"] != "terminating" || deleted["app"] != "web" {
+		t.Fatalf("unexpected delete response: %+v", deleted)
 	}
 
 	for _, env := range []string{"staging", "production"} {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -582,6 +582,21 @@ func TestDeleteApp(t *testing.T) {
 	if get.Code != http.StatusOK {
 		t.Fatalf("get terminating app: expected 200, got %d: %s", get.Code, get.Body.String())
 	}
+
+	list := doRequest(h, http.MethodGet, "/api/projects/default/apps", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list terminating app: expected 200, got %d: %s", list.Code, list.Body.String())
+	}
+	var apps []mortisev1alpha1.App
+	if err := json.NewDecoder(list.Body).Decode(&apps); err != nil {
+		t.Fatalf("decode app list: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != "delete-me" {
+		t.Fatalf("expected terminating app to remain listed, got %+v", apps)
+	}
+	if apps[0].DeletionTimestamp == nil || apps[0].DeletionTimestamp.IsZero() {
+		t.Fatalf("expected listed app to be marked terminating, got %+v", apps[0].ObjectMeta)
+	}
 }
 
 func TestDeleteAppRemovesAppDeployTokensOnly(t *testing.T) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -53,6 +53,44 @@ func (c *appDeleteFailingClient) Delete(ctx context.Context, obj client.Object, 
 	return c.Client.Delete(ctx, obj, opts...)
 }
 
+type appUpdateConflictClient struct {
+	client.Client
+}
+
+func (c *appUpdateConflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if app, ok := obj.(*mortisev1alpha1.App); ok {
+		return apierrors.NewConflict(
+			mortisev1alpha1.GroupVersion.WithResource("apps").GroupResource(),
+			app.Name,
+			fmt.Errorf("Operation cannot be fulfilled on apps.mortise.dev %q: the object has been modified; apply your changes to the latest version and try again", app.Name),
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+type appStatusConflictClient struct {
+	client.Client
+}
+
+func (c *appStatusConflictClient) Status() client.SubResourceWriter {
+	return &appStatusConflictWriter{SubResourceWriter: c.Client.Status()}
+}
+
+type appStatusConflictWriter struct {
+	client.SubResourceWriter
+}
+
+func (w *appStatusConflictWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if app, ok := obj.(*mortisev1alpha1.App); ok {
+		return apierrors.NewConflict(
+			mortisev1alpha1.GroupVersion.WithResource("apps").GroupResource(),
+			app.Name,
+			fmt.Errorf("Operation cannot be fulfilled on apps.mortise.dev %q: the object has been modified; apply your changes to the latest version and try again", app.Name),
+		)
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
 func (g *gitfake) RegisterWebhook(context.Context, string, git.WebhookConfig) error { return nil }
 func (g *gitfake) ListWebhooks(context.Context, string) ([]git.WebhookInfo, error)  { return nil, nil }
 func (g *gitfake) DeleteWebhook(context.Context, string, int64) error               { return nil }
@@ -528,8 +566,8 @@ func TestDeleteApp(t *testing.T) {
 	})
 
 	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/delete-me", nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("delete app: expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("delete app: expected 202, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var app mortisev1alpha1.App
@@ -538,6 +576,11 @@ func TestDeleteApp(t *testing.T) {
 	}
 	if app.DeletionTimestamp == nil || app.DeletionTimestamp.IsZero() {
 		t.Error("expected app to be pending deletion after delete")
+	}
+
+	get := doRequest(h, http.MethodGet, "/api/projects/default/apps/delete-me", nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("get terminating app: expected 200, got %d: %s", get.Code, get.Body.String())
 	}
 }
 
@@ -587,8 +630,8 @@ func TestDeleteAppRemovesAppDeployTokensOnly(t *testing.T) {
 	}
 
 	w := doRequest(h, http.MethodDelete, "/api/projects/default/apps/delete-me", nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("delete app with tokens: expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("delete app with tokens: expected 202, got %d: %s", w.Code, w.Body.String())
 	}
 
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: appToken.Name, Namespace: ns}, &corev1.Secret{}); !apierrors.IsNotFound(err) {
@@ -641,6 +684,105 @@ func TestDeleteAppPreservesDeployTokensWhenAppDeleteFails(t *testing.T) {
 	var app mortisev1alpha1.App
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "delete-me", Namespace: ns}, &app); err != nil {
 		t.Fatalf("expected app to remain after failed delete, got %v", err)
+	}
+}
+
+func TestCreateAppRejectedWhileSameNameIsTerminating(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+
+	doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "delete-me",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.25.0"},
+		},
+	})
+
+	del := doRequest(h, http.MethodDelete, "/api/projects/default/apps/delete-me", nil)
+	if del.Code != http.StatusAccepted {
+		t.Fatalf("delete app: expected 202, got %d: %s", del.Code, del.Body.String())
+	}
+
+	create := doRequest(h, http.MethodPost, "/api/projects/default/apps", map[string]any{
+		"name": "delete-me",
+		"spec": map[string]any{
+			"source": map[string]any{"type": "image", "image": "nginx:1.26.0"},
+		},
+	})
+	if create.Code != http.StatusConflict {
+		t.Fatalf("recreate terminating app: expected 409, got %d: %s", create.Code, create.Body.String())
+	}
+}
+
+func TestUpdateAppConflictIsNormalized(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, "pj-default", "conflict-app")
+
+	srv := newAdminServer(t, &appUpdateConflictClient{Client: k8sClient})
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPut, "/api/projects/default/apps/conflict-app", map[string]any{
+		"source": map[string]any{"type": "image", "image": "nginx:1.26.0"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("update app conflict: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "object has been modified") {
+		t.Fatalf("expected normalized conflict message, got %s", w.Body.String())
+	}
+}
+
+func TestDeployConflictIsNormalized(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, "pj-default", "deploy-conflict")
+
+	srv := newAdminServer(t, &appUpdateConflictClient{Client: k8sClient})
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/deploy-conflict/deploy", map[string]any{
+		"image": "nginx:1.26.0",
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("deploy conflict: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "object has been modified") {
+		t.Fatalf("expected normalized conflict message, got %s", w.Body.String())
+	}
+}
+
+func TestRedeployConflictIsNormalized(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ns := seedProject(t, k8sClient, "default")
+	seedImageApp(t, k8sClient, ns, "redeploy-conflict")
+
+	envNs := constants.EnvNamespace("default", "production")
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "redeploy-conflict", Namespace: envNs},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "redeploy-conflict"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "redeploy-conflict"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25.0"}}},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+
+	srv := newAdminServer(t, &appStatusConflictClient{Client: k8sClient})
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPost, "/api/projects/default/apps/redeploy-conflict/redeploy?environment=production", nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("redeploy conflict: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "object has been modified") {
+		t.Fatalf("expected normalized conflict message, got %s", w.Body.String())
 	}
 }
 

--- a/test/integration/env_clone_test.go
+++ b/test/integration/env_clone_test.go
@@ -359,7 +359,8 @@ func TestPreviewEnvironmentRefreshesAfterEnvAPIUpdate(t *testing.T) {
 // TestEnvironmentCloneCreatesEnvWithConfig creates a project with production
 // env + an app with Secret-level env vars, then calls the clone API endpoint
 // to clone production→staging, and verifies the controller reconciles the new
-// env with the cloned env vars. Also verifies retry-safety (second call → 200).
+// env with the cloned env vars. Also verifies strict duplicate handling
+// (second call -> 409).
 func TestEnvironmentCloneCreatesEnvWithConfig(t *testing.T) {
 	t.Parallel()
 	projectName := "clone-" + randSuffix()
@@ -401,13 +402,13 @@ func TestEnvironmentCloneCreatesEnvWithConfig(t *testing.T) {
 		t.Fatalf("clone: expected 201, got %d: %s", resp.StatusCode, resp.Body)
 	}
 
-	// Verify retry-safety: second call returns 200.
+	// Verify strict duplicate handling: second call returns 409.
 	resp = doCloneJSON(t, http.MethodPost, cloneURL, token, map[string]any{
 		"name":         "staging",
 		"displayOrder": 1,
 	})
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("retry clone: expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("retry clone: expected 409, got %d: %s", resp.StatusCode, resp.Body)
 	}
 
 	// Verify the project now has both envs.

--- a/test/integration/project_lifecycle_test.go
+++ b/test/integration/project_lifecycle_test.go
@@ -441,8 +441,8 @@ func TestDeleteAppCleansUpCustomSecretsViaAPI(t *testing.T) {
 
 	deleteURL := fmt.Sprintf("%s/api/projects/%s/apps/%s", mortiseURL, projectName, appName)
 	resp = doProjectLifecycleJSON(t, http.MethodDelete, deleteURL, token, nil)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("delete app: expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("delete app: expected 202, got %d: %s", resp.StatusCode, resp.Body)
 	}
 
 	helpers.RequireEventually(t, 60*time.Second, func() bool {
@@ -595,8 +595,8 @@ func TestDeleteAppRemovesPreviewsFromAPIAndCluster(t *testing.T) {
 
 	deleteURL := fmt.Sprintf("%s/api/projects/%s/apps/%s", mortiseURL, projectName, app.Name)
 	resp := doProjectLifecycleJSON(t, http.MethodDelete, deleteURL, token, nil)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("delete app: expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("delete app: expected 202, got %d: %s", resp.StatusCode, resp.Body)
 	}
 
 	helpers.RequireEventually(t, 90*time.Second, func() bool {


### PR DESCRIPTION
## What changed
- normalize API conflict, already-exists, and not-found responses into stable resource-oriented messages
- return `202 Accepted` with terminating status for app deletion and block app recreation while the previous object is still terminating
- reject cloning a project environment onto an existing target instead of treating it as a retry-safe success
- update focused API and integration tests to cover the revised contracts

Closes #329.
Closes #330.
Closes #331.

## Why
These paths were returning inconsistent or misleading contracts during conflicts, deletes, and not-found handling. The cleanup makes the API behavior explicit and keeps tests aligned with the intended lifecycle semantics.

## Impact
Clients now get stable conflict/not-found messages, app delete callers see a terminating response instead of an immediate deleted response, and env clone callers get a real conflict on duplicate targets.

## Checks
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run '^(TestCloneProjectEnvironmentDuplicateTarget|TestCloneProjectEnvironmentSourceNotFound|TestDeleteProjectEnvironmentNotFound|TestUpdateProjectEnvironmentNotFound)$'`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run '^(TestDeleteApp|TestDeleteAppRemovesAppDeployTokensOnly|TestDeleteAppPreservesDeployTokensWhenAppDeleteFails|TestCreateAppRejectedWhileSameNameIsTerminating|TestUpdateAppConflictIsNormalized|TestDeployConflictIsNormalized|TestRedeployConflictIsNormalized|TestGetAppNotFound)$'`
- `go test -v -tags integration -run '^(TestDeleteAppCleansUpCustomSecretsViaAPI|TestDeleteAppRemovesPreviewsFromAPIAndCluster)$' ./test/integration/...` against the existing shared cluster failed because the deployed Mortise instance still served the old `200 {"status":"deleted"}` contract
- attempted isolated `make dev-up` validation also blocked in local k3d bootstrap before Mortise deployment (`kubectl get nodes` returned no schedulable nodes; server logs reported `too many open files`)
