### PR TITLE
[codex] Fix docs/spec drift for auth, quickstart, and test inventory

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,10 +113,12 @@ make test-integration-fast  # run suite against existing dev cluster (requires m
   tears down.
 - `make test-integration-fast` runs the same Go tests against whatever
   cluster your kubeconfig points at (typically the `make dev-up` cluster).
-- Tests live in `test/integration/`: `app_image_source_test.go`,
-  `app_git_source_test.go`, `bindings_test.go`, `ingress_test.go`,
-  `project_lifecycle_test.go`, `preview_test.go`, `gitprovider_admin_test.go`,
-  `observer_test.go`.
+- Tests live in `test/integration/`: currently 19 `_test.go` files
+  (including `suite_test.go`). Coverage spans app image/git sources,
+  config files, cron jobs, external/full-stack/multi-service apps,
+  bindings, domains, environment cloning, previews + preview webhooks,
+  storage, ingress, observer, git provider admin flows, and overall
+  project lifecycle behavior.
 - `TestMain` in `suite_test.go` asserts the cluster is reachable, the
   Mortise Deployment is available, and the observer is healthy (soft
   check — observer tests skip if unavailable) before any test runs.
@@ -140,21 +142,23 @@ make test-e2e               # requires make dev-up: handles port-forward, admin 
 - **All tests hit the real API**: no mocking of business logic. This
   verifies the full UI → API integration path. Each test creates its own
   projects/apps and cleans up after itself.
-- 64 tests across 7 files:
-
-| File | Tests | What it covers |
-|------|-------|----------------|
-| `auth.spec.ts` | 14 | Setup page validation, login, auth redirects, setup wizard |
-| `projects.spec.ts` | 7 | Dashboard, project CRUD via UI, name validation |
-| `apps.spec.ts` | 8 | New-app page, Docker deploy, template deploys (Postgres, Redis) |
-| `app-detail.spec.ts` | 12 | Deploy, env vars, secrets, domains, logs, delete: all via real API |
-| `navigation.spec.ts` | 18 | Header, project switcher, extensions, breadcrumbs |
-| `git-providers.spec.ts` | 1 | Git provider CRUD |
-| `journey.spec.ts` | 4 | Full user lifecycle journeys (login → deploy → manage → delete) |
-
-- The `journey.spec.ts` file contains end-to-end user journeys that chain
-  multiple pages and API operations in sequence: the most valuable tests
-  for catching real integration bugs.
+- Current snapshot: 20 Playwright spec files with roughly 152
+  `test(...)` cases. Exact counts change frequently, so treat this as a
+  moving inventory rather than a fixed contract.
+- The suite now splits app-detail coverage across focused specs such as
+  `app-settings-sections.spec.ts`, `app-variables-full.spec.ts`,
+  `deployments.spec.ts`, `domains.spec.ts`, `volumes.spec.ts`, and
+  `staged-changes-deploy.spec.ts`; `app-detail.spec.ts` no longer exists.
+- The remaining spec layout is broad rather than monolithic:
+  `auth.spec.ts`, `navigation.spec.ts`, `projects.spec.ts`,
+  `project-settings.spec.ts`, `project-members-and-envs.spec.ts`,
+  `admin-settings.spec.ts`, `platform-settings-actions.spec.ts`,
+  `apps.spec.ts`, `build-and-deploy.spec.ts`, `bindings.spec.ts`,
+  `deploy-tokens.spec.ts`, `environments.spec.ts`,
+  `git-providers.spec.ts`, and `journey.spec.ts`, plus the focused app
+  management specs above.
+- `journey.spec.ts` still provides the chained login → deploy → manage →
+  delete flows that are most valuable for catching cross-page regressions.
 
 ### Live cluster (manual smoke test)
 

--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -83,8 +83,11 @@ curl -s -X POST "$BASE/api/projects/$PROJECT/apps" \
         {\"name\":\"$ENV\",\"replicas\":1,\"resources\":{\"cpu\":\"100m\",\"memory\":\"128Mi\"}}
       ]
     }
-  }" | jq '{name: .metadata.name, phase: .status.phase, source: .spec.source.type}'
+  }" | jq '{name: .metadata.name, source: .spec.source.type, environments: [.spec.environments[].name]}'
 ```
+
+The create response is the App object. `.status` is populated asynchronously by
+the controller, so it may be absent immediately after create.
 
 ## 5) Set env vars and a secret
 
@@ -94,16 +97,16 @@ Set environment variables:
 curl -s -X PATCH "$BASE/api/projects/$PROJECT/apps/$APP/env?environment=$ENV" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"set":{"PORT":"8080","LOG_LEVEL":"info"},"unset":[]}' | jq
+  -d '{"set":{"PORT":"8080","LOG_LEVEL":"info"},"unset":[]}' | jq '{status}'
 ```
 
 Create a secret:
 
 ```bash
-curl -s -X POST "$BASE/api/projects/$PROJECT/apps/$APP/secrets?env=$ENV" \
+curl -s -X POST "$BASE/api/projects/$PROJECT/apps/$APP/secrets?environment=$ENV" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name":"web-secret","data":{"API_KEY":"supersecret"}}' | jq
+  -d '{"name":"web-secret","data":{"API_KEY":"supersecret"}}' | jq '{name, keys}'
 ```
 
 ## 6) Clone an environment
@@ -135,7 +138,7 @@ curl -s "$BASE/api/projects/$PROJECT/environments" \
 curl -s -X POST "$BASE/api/projects/$PROJECT/apps/$APP/deploy" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d "{\"environment\":\"$ENV\",\"image\":\"nginx:1.27.1\"}" | jq
+  -d "{\"environment\":\"$ENV\",\"image\":\"nginx:1.27.1\"}" | jq '{status, app, image}'
 ```
 
 ## 8) Inspect runtime state

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -726,7 +726,6 @@ definitions:
       id:
         type: string
       passwordGen:
-        format: int64
         type: integer
       role:
         $ref: '#/definitions/auth.Role'

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -136,6 +136,20 @@ func TestLoginValid(t *testing.T) {
 	if token == "" {
 		t.Error("expected a non-empty token")
 	}
+	user, ok := resp["user"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected user object in login response, got %#v", resp["user"])
+	}
+	for _, key := range []string{"id", "email", "role", "passwordGen"} {
+		if _, ok := user[key]; !ok {
+			t.Fatalf("expected login response user.%s, got %#v", key, user)
+		}
+	}
+	for _, key := range []string{"ID", "Email", "Role", "PasswordGen"} {
+		if _, ok := user[key]; ok {
+			t.Fatalf("unexpected legacy login response key %q in %#v", key, user)
+		}
+	}
 }
 
 // TestLoginInvalidCredentials verifies wrong password returns 401.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -726,7 +726,6 @@ definitions:
       id:
         type: string
       passwordGen:
-        format: int64
         type: integer
       role:
         $ref: '#/definitions/auth.Role'

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -16,10 +16,10 @@ type Credentials struct {
 }
 
 type Principal struct {
-	ID          string
-	Email       string
-	Role        Role
-	PasswordGen int64
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	Role        Role   `json:"role"`
+	PasswordGen int64  `json:"passwordGen"`
 }
 
 type SessionToken string


### PR DESCRIPTION
## Summary
- normalize auth login/setup/refresh user JSON keys to match the published OpenAPI contract
- update the API quickstart so its create/app env/secret/deploy examples reflect the current live responses and canonical query parameter usage
- refresh `DEVELOPMENT.md` with the current integration and Playwright test inventory

## Root Cause
The docs and generated OpenAPI had drifted away from the live API surface in a few places, and the auth response contract had also drifted in code because `auth.Principal` was serialized without JSON tags.

## Impact
Generated clients now receive the lower-camel login user object the OpenAPI describes, the quickstart examples match current response shapes, and contributor docs no longer point people at removed or undercounted test suites.

## Validation
- `make generate-api`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.35.0-linux-amd64" go test ./internal/api -run 'Test(LoginValid|TestRefreshAllowsRecentlyExpiredToken|TestRefreshReflectsUpdatedRole|TestOpenAPISpecIncludesBuildRunRoutes)' -count=1`

Closes #338
Closes #339
Closes #340
