### PR TITLE
docs: add CHANGELOG, migration guide, fix swagger version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,275 @@
+# Changelog
+
+All notable changes to Mortise are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2026-05-12
+
+Bug fix release addressing issues found after the 1.0.0 GA launch. All 49
+commits are stability, security, and correctness fixes with no new features.
+
+### Fixed
+
+- **Reserved runtime secrets**: prevent user writes to operator-managed secrets
+  (`PORT`, `DATABASE_URL`, etc.) via the env-var API.
+- **Stack create rollback**: partial failures during multi-app stack creation
+  now roll back already-created apps instead of leaving orphans.
+- **Domain self-collision**: auto-generated domains no longer conflict with
+  themselves when re-reconciling an unchanged app.
+- **Viewer token leak**: project viewers can no longer list deploy token
+  inventories (previously returned full token metadata).
+- **Deploy token cleanup**: deleting an app now removes its deploy tokens;
+  ordering fixed so token secrets are gone before the app finalizer completes.
+- **Pull credential ownership**: mutation ordering and cleanup fixed so stale
+  pull secrets don't block app deletion or cause dangling image-pull references.
+- **Exec container targeting**: `POST /api/.../exec` now targets the correct
+  container when pods have sidecars.
+- **Env clone secret ownership**: cloned environment secrets are now owned by
+  the correct environment, preventing cross-env garbage collection.
+- **Preview shared-env fallback**: preview environments correctly inherit from
+  the source environment when shared env vars are missing.
+- **Preview rebuild on seeded images**: previews with a pre-seeded ready image
+  no longer skip the build step on refresh.
+- **Preview env reconcile without source secrets**: previews no longer fail when
+  the source environment has no secrets configured.
+- **SSE token revalidation**: token issue-time is checked on refresh, rejecting
+  tokens minted before a password change.
+- **Git token cache**: stale git provider tokens are no longer reused across
+  preview reconcile loops.
+- **GitProvider webhook secrets**: webhook HMAC secrets are now read from the
+  correct key in the provider Secret.
+- **BuildRun recovery**: orphaned BuildRuns from a crashed operator are
+  detected and re-adopted on startup.
+- **Webhook latching**: duplicate webhook deliveries within a short window
+  are deduplicated instead of creating duplicate builds.
+- **Activity backfill**: project creation no longer produces duplicate
+  "project created" activity entries.
+- **Log stream stability**: SSE log streams handle observer connection errors
+  gracefully instead of dropping the client connection.
+- **Env redaction**: secret values in env-var API responses are redacted;
+  reserved keys are rejected on write.
+- **API conflict handling**: k8s Conflict errors now map to HTTP 409 instead
+  of 500; delete operations return 202 Accepted with a `"terminating"` status.
+- **Proxy teardown**: `mortise proxy disconnect` now passes the environment
+  parameter correctly.
+- **Dev cluster reliability**: `make dev-up` now polls for readiness instead
+  of a fixed sleep, and handles fresh clusters without pre-existing state.
+
+## [1.0.0] - 2026-05-08
+
+First general-availability release.
+
+### Added
+
+#### BuildRun CRD
+- New `BuildRun` custom resource for durable build execution tracking. Each
+  build produces a BuildRun object with full lifecycle (Pending, Running,
+  Succeeded, Failed), retry attempts, log references, and image digest.
+- `BuildRunReconciler` controller manages build jobs and updates status.
+- REST API: `GET /projects/{p}/build-runs`, `GET /projects/{p}/build-runs/{name}`,
+  `GET /projects/{p}/build-runs/{name}/logs`.
+
+#### Preview environment sync
+- State-reconciliation model replaces the old event-driven webhook dispatch.
+  The operator now queries the git forge for open PRs and converges preview
+  state, making previews self-healing after missed webhooks.
+- New `previewsync` package implements the reconciliation loop.
+- `ListOpenPullRequests` method added to GitHub, GitLab, and Gitea providers.
+- GitLab MR `reopened` action now correctly maps to `opened`, enabling
+  preview recreation on PR reopen.
+
+#### SSE token system
+- Server-sent event streams now authenticate via short-lived, single-use
+  opaque tokens obtained from `POST /api/auth/sse-token`. Replaces direct
+  JWT-in-query-param pattern.
+
+#### Pull credentials API
+- `GET/POST/DELETE /projects/{p}/apps/{a}/pull-credentials` for managing
+  private registry image-pull credentials per app.
+
+#### Environment cloning
+- `POST /projects/{p}/environments/{env}/clone` creates a copy of an
+  environment with all its env vars and configuration. Returns 409 Conflict
+  if the target already exists.
+
+#### Domain validation
+- `POST /api/domains/validate` checks domain availability and detects
+  cross-app collisions before assignment.
+
+#### Per-environment build args and image overrides
+- `spec.environments[].buildArgs` allows per-env build arguments.
+- `spec.environments[].image` allows per-env image override (set by the
+  deploy handler for environment-specific deploys).
+
+#### Certificate status tracking
+- `EnvironmentStatus` now surfaces `certificateStatus` (Ready, Pending,
+  Failed) and `certificateMessage` from cert-manager Certificate resources.
+- Operator RBAC expanded with read access to `cert-manager.io/certificates`.
+
+#### Platform configuration
+- `PlatformConfig.spec.externalDomain`: separate hostname for where the
+  Mortise API is publicly reachable (webhook callbacks, deploy tokens, UI).
+  Falls back to `spec.domain` when unset.
+- Platform-level default CPU and memory (`PATCH /api/platform`).
+- Platform-level GitHub OAuth client ID configuration.
+- Platform-level domain template customization.
+
+#### Auth improvements
+- JWT tokens now carry `iss: mortise` and `aud: mortise-api` claims.
+- Token refresh endpoint (`POST /api/auth/refresh`) with 7-day leeway.
+- Password management: `POST /api/me/password` (self-service),
+  `POST /api/admin/users/{email}/password` (admin reset).
+- Minimum 8-character password enforcement.
+- Last-admin protection: API rejects demoting or deleting the sole
+  remaining admin.
+
+#### Viewer role
+- `viewer` role added alongside `admin` and `member`. Viewers can read
+  project resources but cannot modify apps, secrets, or settings.
+
+#### Auto-redeploy with stale detection
+- Per-environment hash tracking (`pendingEnvHash` / `deployedEnvHash`) moved
+  from top-level AppStatus to per-environment EnvironmentStatus.
+- `POST /projects/{p}/apps/{a}/redeploy-stale` triggers redeployment only
+  for environments with unapplied env-var changes.
+- UI shows a per-environment stale banner with individual redeploy buttons.
+
+#### Helm chart
+- New `ClusterIssuer` template: set `tls.acme.email` to auto-create a
+  cert-manager ClusterIssuer for automatic TLS.
+- Security hardening defaults: `podSecurityContext` and
+  `containerSecurityContext` in mortise-core values. Observer pod also
+  hardened (non-root, read-only root FS, drop all capabilities).
+- New `operator.tmpSizeLimit` value for `/tmp` emptyDir sizing.
+
+#### CLI
+- `app delete` and `secret delete` now prompt for confirmation; use
+  `--yes`/`-y` to skip.
+- Automatic JWT refresh on 401 with `"session expired"` fallback message.
+
+#### UI
+- Settings and Variables tabs decomposed from monolithic components
+  (~1800 lines) into 12 focused section components.
+- Preview environments appear in the environment switcher dropdown.
+- Previews page wired to real API data.
+- Real-time project name availability checking on the new-project form.
+- Per-environment stale redeploy controls.
+- Platform settings expanded: external domain, domain template, default
+  resources, GitHub OAuth client ID.
+- App detail pages subscribe to SSE for live updates.
+
+#### CI / supply chain
+- Cosign keyless image signing for operator and observer images.
+- SBOM and provenance attestations on release builds.
+- Playwright E2E tests run in CI.
+
+#### Observability
+- Operator RBAC now includes read access to `batch/jobs` (for BuildRun
+  state) and `cert-manager.io/certificates` (for TLS status).
+
+### Changed
+
+- Webhook repo matching requires full owner/repo match (was suffix-based).
+- Apps only trigger from their configured `providerRef` webhook (was any
+  matching provider).
+- `DELETE /projects/{p}/apps/{a}` returns 202 Accepted with
+  `{"status":"terminating"}` instead of 200.
+- Internal server errors no longer leak raw error messages; logged via
+  `slog.Error`, user sees `"internal server error"`.
+- `X-Forwarded-Proto` validated against `"http"` or `"https"`.
+- `req.Host` HTML-escaped in OG image URLs (XSS fix).
+- Error helpers (`writeError`) now include the request for structured logging.
+- RBAC rules in Helm chart restructured for auditability (functionally
+  equivalent, split into per-resource rules with comments).
+- Secrets API query parameter renamed from `?env=` to `?environment=`.
+
+### Removed
+
+- Hardcoded GitHub OAuth client ID default (`Ov23lizLTd25E32VrWwl`) cleared
+  from chart values. Must be set explicitly if using GitHub device flow.
+
+## [0.1.4] - 2026-05-05
+
+### Added
+
+- Domain editing, password management, build args in Variables tab.
+- Preview environment inheritance and environment clone API.
+- Observer integration tests (metrics, traffic, logs).
+- Full-stack integration test with git-source backend + bindings.
+- Domain collision detection and multi-label template validation.
+- BYO Traefik access logs documentation, `llms.txt`, local-only recipe.
+
+### Fixed
+
+- Security hardening for password management and session invalidation.
+- Credential Secret NotFound retries instead of partial reconciliation.
+- Preview env secret-before-build gate.
+- Domain collision status reporting.
+- Clone reads Secret-level env vars correctly.
+- Observer traffic mismatch, SQLite contention, chart coupling.
+- Webhook `.git` suffix handling, stale hook cleanup.
+- Nil-replicas rollout detection, conflict windows.
+- Deploy history ordering, redeploy visibility, rebuild cache bypass.
+
+## [0.1.3] - 2026-05-05
+
+### Fixed
+
+- Integration test reliability: parallel execution, pre-pulled images,
+  increased timeouts, verbose output.
+- k3d install via direct binary download.
+- Helm repo + dependency build in integration target.
+- Network port in test fixtures for probe compatibility.
+
+## [0.1.2] - 2026-05-05
+
+### Added
+
+- Integration test CI job.
+- Observer poll interval tuning.
+
+### Fixed
+
+- PSA namespace labels.
+- Webhook `.git` suffix and stale hook cleanup.
+- Log channel backpressure with drop counter.
+- specOverride race and build args key collisions.
+- UI save clobber, CPU defaults, build args UI.
+
+## [0.1.1] - 2026-05-05
+
+### Fixed
+
+- Observer traffic mismatch, SQLite contention.
+- Chart coupling and CPU default handling.
+
+## [0.1.0] - 2026-05-05
+
+Initial release.
+
+### Added
+
+- Project and App CRDs with full lifecycle management.
+- Git and image source types with automatic builds via BuildKit.
+- Multi-environment support (production, staging, custom).
+- Preview environments from pull requests.
+- Domain management with automatic TLS via cert-manager.
+- Environment variables and secrets management.
+- Service bindings for backing services.
+- Bundled infrastructure: BuildKit, OCI registry, Traefik, cert-manager.
+- SvelteKit UI with canvas-based project visualization.
+- CLI (`mortise`) with login, project, app, secret, proxy commands.
+- Observer binary for metrics, logs, and traffic collection.
+- GitHub, GitLab, and Gitea git provider support.
+- Webhook-driven automatic deployments.
+- Native auth with JWT tokens and role-based access (admin, member).
+
+[1.0.1]: https://github.com/mortise-org/mortise/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/mortise-org/mortise/compare/v0.1.4...v1.0.0
+[0.1.4]: https://github.com/mortise-org/mortise/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/mortise-org/mortise/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/mortise-org/mortise/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/mortise-org/mortise/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/mortise-org/mortise/releases/tag/v0.1.0

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,192 @@
+# PR Review Checklist
+
+Quick-reference for reviewing Mortise PRs. This is the reviewer's
+counterpart to [CLAUDE.md](CLAUDE.md) (coding conventions) and
+[SPEC.md](SPEC.md) (product spec). It does not duplicate them — it
+tells you what to check and where to look.
+
+## How to use this
+
+Skim the section headings. Check every box that applies to the diff.
+Any unchecked box that applies is a reason to request changes.
+
+---
+
+## 1. Architecture
+
+- [ ] No third-party SDKs imported in `internal/controller/` files —
+      only Mortise packages (`internal/`, `api/`) and stdlib/k8s
+      (see CLAUDE.md "Controllers never import third-party SDKs")
+- [ ] External calls go through interfaces in `internal/<name>/`
+      (BuildClient, GitAPI, GitClient, IngressProvider, RegistryBackend)
+- [ ] No Traefik-specific CRDs (IngressRoute, Middleware) — standard
+      k8s Ingress only (see CLAUDE.md "Standards, not implementations")
+- [ ] No new CRD kinds for things that should be Apps — backing
+      services are Apps with `network.public: false`
+- [ ] No addon/plug-in architecture, subcharts, or extension points
+      (see SPEC.md §6.1)
+- [ ] No new interface without an in-tree implementation behind it
+- [ ] Resources only modified after ownership check — Mortise never
+      touches resources it didn't create
+
+## 2. Namespace & Naming
+
+- [ ] Namespace prefixes use `internal/constants` helpers
+      (`ControlNamespace()`, `EnvNamespace()`), never hardcoded strings
+- [ ] No legacy `project-` prefix — current convention is `pj-`
+- [ ] Workload resources (Deployment, Service, Ingress, Pod, PVC,
+      env-scoped Secret/ConfigMap) placed in per-env namespace
+      `pj-{project}-{env}`, NOT control namespace `pj-{project}`
+- [ ] Project-scoped CRDs (App, PreviewEnvironment) and project-level
+      resources (activity ConfigMap, registry creds) in control namespace
+- [ ] `constants.ValidateProjectEnvLengths()` called when accepting
+      new project or environment names (63-char DNS label limit)
+- [ ] Label keys use defined constants (`mortise.dev/project`,
+      `mortise.dev/environment`, `app.kubernetes.io/name`) — no inline
+      string literals for label keys, finalizer names, or annotation keys
+
+## 3. CRDs & API Types
+
+- [ ] New fields have `kubebuilder:validation` markers (Required, Enum,
+      Pattern, MinLength, MaxLength) where applicable
+- [ ] `make manifests` regenerated if types changed — CRD YAML in
+      `charts/mortise-core/crds/` matches Go types
+- [ ] `make generate` run — `zz_generated.deepcopy.go` is up to date
+- [ ] Status phase transitions well-defined (Pending/Ready/Terminating/
+      Failed) — no new phases without justification
+- [ ] Schema changes are additive and optional — do not break existing
+      resources on upgrade
+
+## 4. Controllers
+
+- [ ] Reconcile functions are idempotent (safe to re-run at any time)
+- [ ] Owner references set via `controllerutil.SetControllerReference`
+      for garbage collection
+- [ ] Finalizers added when cross-namespace cleanup is needed, removed
+      only after cleanup completes
+- [ ] Uses `clock.Clock` for time-dependent logic, never `time.Now()`
+- [ ] Status conditions updated with meaningful reasons and messages
+- [ ] No long-running operations in the reconcile loop — requeue with
+      backoff instead
+- [ ] Error handling distinguishes transient vs permanent failures
+      (transient: requeue; permanent: set Failed status, don't retry)
+- [ ] No overcomplicated reconcile logic — if a reconcile function is
+      growing past a few hundred lines, it likely needs decomposition
+      into helper methods, not abstraction layers
+
+## 5. REST API
+
+- [ ] Endpoints protected by auth middleware unless explicitly public
+      (setup, login, health)
+- [ ] Authorization checked via `PolicyEngine.Authorize()` — admin vs
+      member vs viewer scoping correct for the operation
+- [ ] Input validated before use (lengths, patterns, required fields)
+- [ ] Errors return structured JSON via `writeError` helpers, not raw
+      strings or leaked internal details
+- [ ] New endpoints documented in SPEC.md API route table and swagger
+      annotations updated
+- [ ] No assumptions about request shape — validate, don't trust
+
+## 6. Helm Charts
+
+- [ ] `Chart.yaml` version/appVersion NOT manually edited — CI owns
+      these (see RELEASING.md)
+- [ ] New `values.yaml` keys have sensible defaults — existing
+      installs must not break on upgrade
+- [ ] Templates reference `.Values`, not hardcoded values
+- [ ] Security contexts preserved (`podSecurityContext`,
+      `containerSecurityContext` from values)
+- [ ] No `:latest` image tags — pinned versions or digest references
+- [ ] `make test-charts` passes (helm lint + template tests)
+- [ ] CRD YAML in `charts/mortise-core/crds/` matches `config/crd/bases/`
+
+## 7. UI
+
+- [ ] `make check-ui` passes (svelte-check, no TypeScript diagnostics)
+- [ ] No `page.route()` mocking of Mortise business logic in E2E — use
+      real API via helpers (`loginViaAPI`, `createProjectViaAPI`, etc.)
+- [ ] `getByRole` calls use `{ exact: true }` — without it, canvas
+      AppNode divs silently match and tests time out
+- [ ] Headings located via `getByRole('heading')`, not `getByText`
+      (getByText does partial substring matching)
+- [ ] Variable placeholders use correct names: `'VARIABLE_NAME'` for
+      key, `'value or binding ref'` for value
+- [ ] New interactive elements have E2E coverage
+
+## 8. Tests
+
+- [ ] **Happy AND sad paths covered** — every new code path needs tests
+      for success, expected failures, edge cases, and error conditions.
+      Golden-path-only coverage is insufficient.
+- [ ] Unit tests beside the code they test (`_test.go` in same package)
+- [ ] Integration tests in `test/integration/` with
+      `//go:build integration` tag
+- [ ] Test fixtures loaded from `test/fixtures/` via `LoadFixture()` —
+      never hand-write App YAML in test code
+- [ ] Integration tests create own namespace via `CreateTestNamespace(t)`
+      with `t.Cleanup` — no shared state between tests
+- [ ] Tests do not depend on execution order — each test stands alone
+- [ ] Mock policy followed: mock interfaces in unit tests, real services
+      (BuildKit, Gitea, Pebble, registry) in integration tests
+- [ ] `make test` passes (<10s), `make test-charts` passes (<30s)
+- [ ] Error messages in test assertions are descriptive — when a test
+      fails, the message should make the failure obvious without reading
+      the test source
+
+## 9. Code Quality
+
+- [ ] Comments explain WHY, not WHAT — if the code is clear, no
+      comment needed
+- [ ] No unrelated formatting changes, refactors, or cleanups mixed in
+- [ ] No overcomplicated code — if 200 lines could be 50, it needs
+      rewriting. Simple beats clever.
+- [ ] No abstraction for the sake of abstraction — single-use code
+      does not need a helper function. Three similar lines is better
+      than a premature abstraction.
+- [ ] No unjustified assumptions — if the change assumes something
+      about system behavior, state it explicitly or validate it. Don't
+      silently pick one interpretation when multiple exist.
+- [ ] Constants used where available — `internal/constants` provides
+      helpers for namespace prefixes, label keys, finalizer names, and
+      naming conventions. Use them.
+- [ ] Imports cleaned up — no unused imports left by the change
+- [ ] Every changed line traces directly to the task — no drive-by
+      improvements
+- [ ] CI checks pass: `make test`, `make test-charts`, `go vet`,
+      `staticcheck`, `svelte-check`
+- [ ] PR template checklist is filled out honestly
+
+## 10. Security
+
+- [ ] Webhook payloads verified via HMAC before processing
+- [ ] No secrets, credentials, or tokens logged or returned in API
+      responses
+- [ ] RBAC (ClusterRole) changes are minimal — new verbs or resources
+      need explicit justification in the PR description
+- [ ] Admission webhooks validate user input at the k8s API boundary
+- [ ] Bearer tokens validated before any protected operation
+- [ ] No hardcoded secrets, passwords, or API keys anywhere in code,
+      charts, or test fixtures
+
+---
+
+## Red Flags
+
+Any one of these blocks the PR. These are bugs, not style preferences.
+
+1. Third-party SDK imported in `internal/controller/`
+2. Traefik-specific IngressRoute instead of standard k8s Ingress
+3. New CRD kind for something that should be an App
+4. `time.Now()` in controller code instead of injected `clock.Clock`
+5. `:latest` image tag anywhere in code or charts
+6. Hardcoded `project-` or `pj-` prefix instead of `constants` helpers
+7. Workload resources written to control namespace `pj-{project}`
+8. `page.route()` mocking Mortise business logic in E2E tests
+9. `getByRole` without `{ exact: true }` in Playwright tests
+10. Resources modified without ownership check
+11. Plugin/addon architecture (subcharts, extension registry, plug-in SDK)
+12. Manual `Chart.yaml` version/appVersion edits
+13. Tests covering only happy path with no error/edge-case coverage
+14. Inline string literals for values that exist in `internal/constants`
+15. Unjustified assumptions — silently choosing one interpretation
+    without stating alternatives

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -74,7 +74,110 @@ Any unchecked box that applies is a reason to request changes.
       growing past a few hundred lines, it likely needs decomposition
       into helper methods, not abstraction layers
 
-## 5. REST API
+## 5. Correctness & Bug Hunting
+
+Look for logic errors, missed edge cases, and behavior that will
+silently produce wrong results.
+
+- [ ] **Off-by-one and boundary conditions** — loops, slices, index
+      arithmetic, pagination offsets. Trace the first iteration, last
+      iteration, and empty-input case mentally.
+- [ ] **Nil/zero-value handling** — does the code crash or behave
+      incorrectly when a pointer is nil, a slice is empty, a map is
+      uninitialized, or a string is `""`? Check every dereference of
+      a pointer that could be nil.
+- [ ] **Error paths that silently continue** — `if err != nil` blocks
+      that log but don't return, swallowed errors in goroutines,
+      `_ = someFunc()` discarding meaningful errors. Every error must
+      either be returned, cause a requeue, or have an explicit comment
+      explaining why it's safe to ignore.
+- [ ] **Partial failure cleanup** — if a function creates resources A,
+      B, C in sequence and C fails, are A and B cleaned up? Or does
+      the system leak orphaned resources?
+- [ ] **Status lies** — does the code set status to Ready/Succeeded
+      before the operation is actually complete? Status must reflect
+      observed reality, not intent.
+- [ ] **Stale reads** — is the code acting on a cached or stale copy
+      of a resource that may have changed since it was fetched? Watch
+      for `Get` followed by much later `Update` without re-fetching.
+- [ ] **Semantic correctness** — does the code actually do what the PR
+      description says it does? Read the diff without the description
+      first, form your own understanding, then compare.
+- [ ] **Behavior change without test change** — if behavior changed
+      but no test was added or updated, either the change is untested
+      or the old tests were inadequate. Both are problems.
+
+## 6. Concurrency & Race Conditions
+
+Kubernetes controllers are inherently concurrent. Multiple reconcile
+loops, webhooks, and API handlers run in parallel.
+
+- [ ] **Shared mutable state** — any package-level variable, struct
+      field, or map accessed from multiple goroutines must be protected
+      by a mutex or be replaced with a concurrent-safe alternative.
+      Check: is there a `sync.Mutex` or `sync.RWMutex` guarding it?
+- [ ] **Read-modify-write races on k8s resources** — `Get` + modify +
+      `Update` without `retry.RetryOnConflict` is a race condition.
+      Another reconcile or API call can modify the resource between
+      Get and Update. The update will either silently overwrite changes
+      or fail with a Conflict error.
+- [ ] **Map concurrent access** — Go maps are not goroutine-safe. Any
+      map shared between goroutines (caches, stores, registries) needs
+      synchronization. This includes struct fields that are maps.
+- [ ] **Goroutine leaks** — goroutines started without a shutdown path
+      (context cancellation, done channel, or WaitGroup) will leak.
+      Every `go func()` needs a way to stop.
+- [ ] **Channel operations** — sends to unbuffered or full channels
+      block forever if nobody is receiving. Receives from channels
+      that are never closed block forever. Check for deadlock paths.
+- [ ] **Reconcile reentrancy** — a reconcile function can be called
+      again while a previous invocation's requeue is pending. The
+      function must not assume it runs to completion before being
+      called again. Watch for state set early in reconcile that gets
+      stomped by a concurrent invocation.
+- [ ] **Webhook and API handler concurrency** — multiple requests can
+      hit the same handler simultaneously. Handlers must not share
+      mutable state without synchronization.
+- [ ] **Finalizer ordering** — if multiple controllers have finalizers
+      on the same resource, does the ordering matter? Can one
+      finalizer's cleanup break another's assumptions?
+
+## 7. Unclear & Surprising Behavior
+
+Code that works but confuses future readers is a maintenance liability.
+
+- [ ] **Magic values** — hardcoded numbers, strings, or durations
+      without explanation. What does `3`, `"default"`, or
+      `5 * time.Minute` mean? Use named constants or add a comment
+      explaining the choice.
+- [ ] **Implicit ordering dependencies** — does the code rely on
+      operations happening in a specific order without making that
+      order explicit? Sequential operations that would break if
+      reordered need a comment or structural enforcement.
+- [ ] **Silent fallbacks** — code that falls through to a default
+      behavior when a condition isn't met, without logging or
+      indicating that the fallback was taken. The reader (and operator)
+      should be able to tell which path executed.
+- [ ] **Naming mismatches** — function or variable names that don't
+      match what the code actually does. A function called
+      `deleteApp()` that also deletes secrets and tokens should be
+      called `deleteAppAndDependents()` or similar.
+- [ ] **Side effects in getters** — functions named `Get*` or `Find*`
+      that modify state, create resources, or trigger reconciliation
+      as a side effect. Getters should be read-only.
+- [ ] **Boolean parameters** — `doThing(true, false, true)` is
+      unreadable at the call site. Prefer options structs, named
+      constants, or separate functions.
+- [ ] **Conditional complexity** — deeply nested if/else chains,
+      multiple negations (`!notDisabled`), or conditions that require
+      a truth table to reason about. Simplify or extract into a
+      named predicate.
+- [ ] **Undocumented preconditions** — does the function assume the
+      caller has already done something (acquired a lock, validated
+      input, checked permissions)? If yes and it's not obvious from
+      the signature, document it.
+
+## 8. REST API
 
 - [ ] Endpoints protected by auth middleware unless explicitly public
       (setup, login, health)
@@ -87,7 +190,7 @@ Any unchecked box that applies is a reason to request changes.
       annotations updated
 - [ ] No assumptions about request shape — validate, don't trust
 
-## 6. Helm Charts
+## 9. Helm Charts
 
 - [ ] `Chart.yaml` version/appVersion NOT manually edited — CI owns
       these (see RELEASING.md)
@@ -100,7 +203,7 @@ Any unchecked box that applies is a reason to request changes.
 - [ ] `make test-charts` passes (helm lint + template tests)
 - [ ] CRD YAML in `charts/mortise-core/crds/` matches `config/crd/bases/`
 
-## 7. UI
+## 10. UI
 
 - [ ] `make check-ui` passes (svelte-check, no TypeScript diagnostics)
 - [ ] No `page.route()` mocking of Mortise business logic in E2E — use
@@ -113,7 +216,7 @@ Any unchecked box that applies is a reason to request changes.
       key, `'value or binding ref'` for value
 - [ ] New interactive elements have E2E coverage
 
-## 8. Tests
+## 11. Tests
 
 - [ ] **Happy AND sad paths covered** — every new code path needs tests
       for success, expected failures, edge cases, and error conditions.
@@ -133,7 +236,7 @@ Any unchecked box that applies is a reason to request changes.
       fails, the message should make the failure obvious without reading
       the test source
 
-## 9. Code Quality
+## 12. Code Quality
 
 - [ ] Comments explain WHY, not WHAT — if the code is clear, no
       comment needed
@@ -156,7 +259,7 @@ Any unchecked box that applies is a reason to request changes.
       `staticcheck`, `svelte-check`
 - [ ] PR template checklist is filled out honestly
 
-## 10. Security
+## 13. Security
 
 - [ ] Webhook payloads verified via HMAC before processing
 - [ ] No secrets, credentials, or tokens logged or returned in API

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // @title Mortise API
-// @version 0.1.0
+// @version 1.0.0
 // @description Self-hosted Railway-style deploy platform for Kubernetes. Manages projects, apps, deployments, env vars, secrets, domains, and git providers.
 // @host localhost:8090
 // @BasePath /api

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -1,0 +1,242 @@
+# Migrating from v0.x to v1.0
+
+This guide covers upgrading Mortise from any 0.1.x release to 1.0.x.
+
+## Before you start
+
+- Back up your cluster state: `kubectl get apps,projects,previewenvironments,gitproviders,platformconfigs -A -o yaml > mortise-backup.yaml`
+- The upgrade **invalidates all user sessions** (JWT claim changes). All
+  users will need to log in again.
+- CRDs remain at `mortise.mortise.dev/v1alpha1`. No changes to existing
+  resource `apiVersion` fields are needed.
+
+## Upgrade steps
+
+### 1. Update the Helm repo
+
+```bash
+helm repo update mortise
+```
+
+### 2. Review your values overrides
+
+Check your values file against the changes below, then upgrade:
+
+```bash
+helm upgrade mortise mortise/mortise --version 1.0.1 -f values.yaml
+```
+
+The new `BuildRun` CRD is installed automatically. Existing App and
+PreviewEnvironment resources will be reconciled with the new fields on
+the next operator restart.
+
+### 3. Re-authenticate
+
+All sessions are invalidated. Every user must log in again:
+
+```bash
+mortise login
+```
+
+The CLI will automatically attempt token refresh on 401. If the refresh
+window (7 days) has passed, a fresh login is required.
+
+## Breaking changes
+
+### Authentication
+
+**JWT claims**: Tokens now include `iss: mortise` and `aud: mortise-api`.
+Tokens issued by v0.x lack these claims and are rejected immediately.
+There is no grace period — all sessions are invalidated on upgrade.
+
+**Minimum password length**: User creation now enforces an 8-character
+minimum. Existing users with shorter passwords can still log in but
+cannot be re-created via the API.
+
+**Password generation tracking**: User secrets now carry a `password_gen`
+field (initialized to `"0"`). Changing a password increments this value
+and invalidates all tokens issued before the change.
+
+### SSE (server-sent events) authentication
+
+Log streams and live event feeds no longer accept a JWT in the `?token=`
+query parameter. Clients must:
+
+1. `POST /api/auth/sse-token` with a Bearer JWT to obtain a short-lived
+   opaque token (`msse_...`).
+2. Pass that token as `?token=msse_...` on the SSE endpoint.
+
+The UI and CLI handle this automatically. Custom integrations that
+consume SSE streams directly must update their auth flow.
+
+### API changes
+
+| Change | Before (v0.x) | After (v1.0) |
+|---|---|---|
+| Delete app response | `200 {"status":"deleted"}` | `202 {"status":"terminating","app":"..."}` |
+| Secrets query param | `?env=production` | `?environment=production` |
+| Clone environment (duplicate) | `200` (idempotent) | `409 Conflict` |
+| Internal errors | Raw error in response body | `"internal server error"` (details in server logs) |
+| k8s Conflict errors | `500` | `409 Conflict` |
+
+### CRD schema changes
+
+**Moved fields** (App status):
+- `status.pendingEnvHash` → `status.environments[].pendingEnvHash`
+- `status.deployedEnvHash` → `status.environments[].deployedEnvHash`
+
+Any tooling that reads these top-level status fields must update to read
+from the per-environment status instead. The operator populates the new
+location on first reconcile after upgrade.
+
+**New validation on `EnvVar.name`**:
+- Must match `^[a-zA-Z_][a-zA-Z0-9_]*$`
+- Maximum 253 characters
+
+Existing Apps with non-conforming env var names will pass initial
+reconciliation but **fail validation on the next update**. Audit env var
+names before upgrading if you have vars with dashes, dots, or leading
+digits.
+
+**New CRD**: `BuildRun` (namespaced). Installed automatically by Helm.
+If you run OPA/Kyverno policies that allowlist CRD kinds, add
+`buildruns.mortise.mortise.dev`.
+
+### Helm values changes
+
+**`github.clientID` default cleared**: v0.x shipped a hardcoded dev
+OAuth client ID (`Ov23lizLTd25E32VrWwl`). v1.0 defaults to `""`. If you
+use GitHub device-flow login and relied on the default, add your own
+client ID to your values:
+
+```yaml
+mortise-core:
+  github:
+    clientID: "your-github-oauth-app-client-id"
+```
+
+**Security contexts now on by default**: The operator pod runs with:
+- `seccompProfile: RuntimeDefault`
+- `allowPrivilegeEscalation: false`
+- `capabilities.drop: [ALL]`
+
+The observer pod additionally runs with `readOnlyRootFilesystem: true`.
+If your environment requires privileged pods, override
+`podSecurityContext` and `containerSecurityContext` in your values.
+
+### Webhook behavior
+
+**Stricter repo matching**: Webhooks now require a full `owner/repo`
+match. The v0.x suffix-based matching could produce false positives
+(e.g., `org/app` matching `other-org/app`).
+
+**Provider filtering**: Apps only respond to webhooks from their
+configured `spec.source.git.providerRef`. In v0.x, any provider with a
+matching repo URL could trigger a build. If you have multiple
+GitProviders pointing at the same forge, verify that each app's
+`providerRef` is set correctly.
+
+**Preview reconciliation model**: Preview environments now converge
+against the forge's open-PR state on every reconcile, not just on
+webhook events. This is self-healing but means:
+- Previews for PRs closed while the operator was down are cleaned up
+  automatically.
+- Previews for PRs opened while the operator was down are created
+  automatically.
+- The operator makes `ListOpenPullRequests` API calls to the forge
+  during reconciliation. Ensure your git provider token has read access
+  to pull requests.
+
+### CLI changes
+
+**Confirmation prompts**: `mortise app delete` and `mortise secret delete`
+now prompt for confirmation. Scripts that call these commands must pass
+`--yes` or `-y` to skip the prompt.
+
+**`secret set --value` deprecated**: Use stdin instead:
+```bash
+echo "my-value" | mortise secret set MY_KEY
+```
+The `--value` flag still works but prints a deprecation warning.
+
+## New features to configure
+
+These are optional but recommended.
+
+### External domain
+
+If your Mortise API is reachable at a different hostname than your app
+domain (common with tunnels, NAT, or reverse proxies), set
+`externalDomain`:
+
+```yaml
+platformConfig:
+  externalDomain: mortise.example.com
+```
+
+Webhook callbacks and deploy token URLs use this hostname. Falls back to
+`domain` when unset.
+
+### Automatic TLS via ACME
+
+The umbrella chart can now create a cert-manager ClusterIssuer
+automatically:
+
+```yaml
+tls:
+  acme:
+    email: ops@example.com
+    # issuerName: letsencrypt-prod    (default)
+    # server: https://acme-v02.api.letsencrypt.org/directory  (default)
+```
+
+This requires `cert-manager.enabled: true` (the default in the umbrella
+chart).
+
+### Viewer role
+
+v1.0 adds a `viewer` role that can read project resources but not modify
+them. Assign via the members API or UI.
+
+## Verifying the upgrade
+
+After upgrading:
+
+1. Confirm the operator is running:
+   ```bash
+   kubectl get pods -n mortise-system -l app.kubernetes.io/name=mortise
+   ```
+
+2. Check CRDs are updated (BuildRun should be present):
+   ```bash
+   kubectl get crd | grep mortise
+   ```
+
+3. Verify an existing app reconciles:
+   ```bash
+   kubectl get apps -A
+   ```
+   All apps should show `Ready` phase within a few minutes.
+
+4. Log in and confirm UI access:
+   ```bash
+   mortise login
+   ```
+
+## Rolling back
+
+If you need to roll back to v0.x:
+
+```bash
+helm rollback mortise
+```
+
+Note that `BuildRun` resources created by v1.0 will remain in the
+cluster as orphans. Clean them up manually if needed:
+
+```bash
+kubectl delete buildruns -A --all
+```
+
+The `pendingEnvHash` / `deployedEnvHash` fields will revert to top-level
+status on the next v0.x reconcile. No data is lost.


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Full changelog covering v0.1.0 through v1.0.1 following Keep a Changelog format. Categorizes all 105 commits across 6 releases into Added/Changed/Fixed/Removed sections.
- **docs/migration-v1.md**: Step-by-step migration guide for v0.x → v1.0 users covering: Helm upgrade steps, all breaking changes (JWT auth, SSE tokens, API response shapes, CRD schema moves, Helm values, webhook behavior, CLI prompts), new features to configure (external domain, ACME TLS, viewer role), verification steps, and rollback procedure.
- **cmd/main.go**: Fix swagger `@version` annotation from `0.1.0` to `1.0.0`.

## Breaking changes documented

- JWT `iss`/`aud` claim enforcement (all sessions invalidated)
- SSE auth moved to opaque tokens (`POST /api/auth/sse-token`)
- `?env=` → `?environment=` query param rename
- Delete app returns 202 instead of 200
- Clone environment returns 409 on duplicate
- `pendingEnvHash`/`deployedEnvHash` moved to per-environment status
- `github.clientID` default cleared
- EnvVar name validation added
- Webhook repo matching stricter
- CLI delete commands now prompt for confirmation

## Test plan

- [ ] Verify CHANGELOG entries match `git log` between tags
- [ ] Verify migration guide steps against a real v0.1.4 → v1.0.1 upgrade
- [ ] Confirm swagger version renders correctly in generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)