### PR TITLE
docs: add changelog and migration guide checks to REVIEW.md

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -271,6 +271,15 @@ Code that works but confuses future readers is a maintenance liability.
 - [ ] No hardcoded secrets, passwords, or API keys anywhere in code,
       charts, or test fixtures
 
+## 14. Documentation
+
+- [ ] `CHANGELOG.md` updated if the PR introduces user-facing changes
+      (new features, behavior changes, bug fixes, deprecations, breaking
+      changes) — add an entry under the appropriate `[Unreleased]` heading
+- [ ] `docs/migration-v1.md` updated if the PR introduces breaking
+      changes, CRD schema changes, renamed fields, removed features, or
+      anything that requires action from operators upgrading Mortise
+
 ---
 
 ## Red Flags


### PR DESCRIPTION
## Summary
- Adds section 14 (Documentation) to REVIEW.md requiring reviewers to verify CHANGELOG.md and docs/migration-v1.md are updated for user-facing or breaking changes.

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)