### PR TITLE
docs: changelog and migration entries for post-1.0.1 PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to Mortise are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Preview environments as clone environments**: preview environments are now
+  real project environments (`pr-{number}`) managed through the app controller's
+  existing environment fan-out. Previews appear in the environment switcher,
+  use standard domain templates, and are cleaned up immediately on PR close
+  with no TTL delay.
+- **Degraded app phase**: when the latest build fails but an older image is
+  still serving successfully, the app phase is now `Degraded` (warning) instead
+  of `Failed`. CrashLooping takes priority over Degraded when both conditions
+  are true.
+- **Fatal log stream banner**: log viewer and deploy log components now display
+  an inline error banner when the SSE stream encounters a fatal error, instead
+  of silently stopping.
+- **Preview switcher opens new tab**: preview entries in the environment
+  switcher now open in a new browser tab instead of switching the current view.
+
+### Fixed
+
+- **Normalized project not-found errors**: all project lookup API paths now
+  return a consistent `project "name" not found` message (404 JSON) instead of
+  leaking raw Kubernetes API error strings.
+
+### Changed
+
+- **PreviewEnvironment CRD simplified**: the `PreviewEnvironment` spec now
+  carries only `projectRef`, `sourceEnv`, and `pullRequest` metadata. Removed
+  fields: `appRef`, `replicas`, `resources`, `env`, `bindings`, `domain`,
+  `ttl`. Status reduced to `environmentName` and `conditions`; removed `url`,
+  `image`, `currentBuildRunRef`, `lastSuccessfulBuildRunRef`, `expiresAt`.
+  Phase enum reduced from `Pending|Building|Ready|Failed|Expired` to
+  `Pending|Ready|Failed`.
+- **PreviewConfig simplified**: removed `domain`, `ttl`, `resources` fields;
+  added `sourceEnvironment` (optional string).
+- **App environment branch override**: `spec.environments[].branch` is a new
+  optional field allowing per-environment git branch overrides (used internally
+  by preview cloning).
+- **AppPhase enum**: added `Degraded` value. Consumers of the phase enum must
+  handle this new value.
+
 ## [1.0.1] - 2026-05-12
 
 Bug fix release addressing issues found after the 1.0.0 GA launch. All 49

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -147,6 +147,32 @@ webhook events. This is self-healing but means:
   during reconciliation. Ensure your git provider token has read access
   to pull requests.
 
+**Preview environment rework (post-1.0.1)**: Preview environments are
+now real clone environments (`pr-{number}`) managed through the app
+controller, replacing the per-app `previewsync` model. This changes the
+`PreviewEnvironment` CRD significantly:
+
+- **Removed spec fields**: `appRef`, `replicas`, `resources`, `env`,
+  `bindings`, `domain`, `ttl`. The spec now carries only `projectRef`,
+  `sourceEnv`, and `pullRequest` metadata.
+- **Removed status fields**: `url`, `image`, `currentBuildRunRef`,
+  `lastSuccessfulBuildRunRef`, `expiresAt`. Status now has only
+  `environmentName` and `conditions`.
+- **Phase enum reduced**: `Pending|Building|Ready|Failed|Expired` →
+  `Pending|Ready|Failed`.
+- **PreviewConfig changes**: `domain`, `ttl`, `resources` fields
+  removed; `sourceEnvironment` (optional string) added.
+
+Tooling that reads PreviewEnvironment resources must be updated. Existing
+PreviewEnvironment objects will be re-reconciled automatically on
+upgrade; no manual cleanup is needed.
+
+**App Degraded phase (post-1.0.1)**: The `AppPhase` enum now includes
+`Degraded`. This phase indicates a build failed but a previously-deployed
+image is still serving. Tooling or dashboards that switch on `AppPhase`
+must handle the new value — treat it as a warning state between `Ready`
+and `CrashLooping`.
+
 ### CLI changes
 
 **Confirmation prompts**: `mortise app delete` and `mortise secret delete`


### PR DESCRIPTION
## Summary
- Adds `[Unreleased]` section to CHANGELOG.md covering PRs #369, #364, #358, #357, #356
- Updates docs/migration-v1.md with breaking changes from the preview environment rework (#369) and new Degraded app phase (#358)

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)