### PR TITLE
fix: preview env duplication, stale drawer tabs, env deletion, PE convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Normalized project not-found errors**: all project lookup API paths now
   return a consistent `project "name" not found` message (404 JSON) instead of
   leaking raw Kubernetes API error strings.
+- **Preview envs duplicate in env switcher** (#374): preview environments
+  created via PR webhooks appeared twice in the environment switcher (once as
+  a normal env, once as a PR env). The `ProjectEnvironment` type now carries a
+  `preview` boolean so the UI can filter them from the standard env list.
+- **Env deletion blocked by app overrides** (#375): deleting a project
+  environment that had app-level overrides returned a 409 error. The API now
+  auto-strips overrides from all apps referencing the deleted environment and
+  proceeds with deletion.
+- **Drawer tabs show stale data on env switch** (#376): switching environments
+  in the app drawer left the Variables and Metrics tabs showing data from the
+  previous environment. Both tabs now reset state and re-fetch when the active
+  environment changes.
+- **Preview envs don't converge on reconcile** (#373): preview environments
+  were only created in response to webhook events; missed webhooks left the
+  cluster out of sync with the forge. A new `PreviewConvergenceReconciler`
+  periodically polls for open PRs and creates/deletes `PreviewEnvironment` CRs
+  to match.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Fatal log stream banner**: log viewer and deploy log components now display
   an inline error banner when the SSE stream encounters a fatal error, instead
   of silently stopping.
-- **Preview switcher opens new tab**: preview entries in the environment
-  switcher now open in a new browser tab instead of switching the current view.
-
 ### Fixed
 
 - **Normalized project not-found errors**: all project lookup API paths now
@@ -44,8 +41,8 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Preview envs don't converge on reconcile** (#373): preview environments
   were only created in response to webhook events; missed webhooks left the
   cluster out of sync with the forge. A new `PreviewConvergenceReconciler`
-  periodically polls for open PRs and creates/deletes `PreviewEnvironment` CRs
-  to match.
+  watches Project changes and re-queues every 10 minutes, polling the forge
+  for open PRs and creating/deleting `PreviewEnvironment` CRs to match.
 
 ### Changed
 

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -62,6 +62,11 @@ type ProjectEnvironment struct {
 	// environment. Owners are unaffected. Typical use: protect production.
 	// +optional
 	Restricted bool `json:"restricted,omitempty"`
+
+	// Preview marks this environment as a preview (PR) environment. Set by the
+	// preview environment controller; filtered from the normal env list in the UI.
+	// +optional
+	Preview bool `json:"preview,omitempty"`
 }
 
 // ProjectSpec defines the desired state of a Project — the top-level grouping

--- a/charts/mortise-core/crds/mortise.mortise.dev_projects.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_projects.yaml
@@ -97,6 +97,11 @@ spec:
                       maxLength: 63
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    preview:
+                      description: |-
+                        Preview marks this environment as a preview (PR) environment. Set by the
+                        preview environment controller; filtered from the normal env list in the UI.
+                      type: boolean
                     restricted:
                       description: |-
                         Restricted, when true, limits Developers to read-only in this

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -443,11 +443,19 @@ func main() {
 		setupLog.Error(err, "Failed to create controller", "controller", "GitProvider")
 		os.Exit(1)
 	}
-	if err := (&controller.PreviewEnvironmentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	peReconciler := &controller.PreviewEnvironmentReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		GitAPIFactory: git.NewGitAPIFromProvider,
+	}
+	if err := peReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "PreviewEnvironment")
+		os.Exit(1)
+	}
+	if err := (&controller.PreviewConvergenceReconciler{
+		PEReconciler: peReconciler,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create controller", "controller", "PreviewConvergence")
 		os.Exit(1)
 	}
 	// Admission webhooks — enforce cross-resource invariants (App env names

--- a/config/crd/bases/mortise.mortise.dev_projects.yaml
+++ b/config/crd/bases/mortise.mortise.dev_projects.yaml
@@ -97,6 +97,11 @@ spec:
                       maxLength: 63
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    preview:
+                      description: |-
+                        Preview marks this environment as a preview (PR) environment. Set by the
+                        preview environment controller; filtered from the normal env list in the UI.
+                      type: boolean
                     restricted:
                       description: |-
                         Restricted, when true, limits Developers to read-only in this

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -167,6 +167,18 @@ Tooling that reads PreviewEnvironment resources must be updated. Existing
 PreviewEnvironment objects will be re-reconciled automatically on
 upgrade; no manual cleanup is needed.
 
+**ProjectEnvironment `preview` field (post-1.0.1)**: The
+`ProjectEnvironment` struct now includes a `preview` boolean field.
+Preview environments created by the operator have `preview: true`, which
+allows the UI and API to distinguish them from user-created environments.
+Tooling that lists or inspects `project.spec.environments` should handle
+this new field.
+
+**Environment deletion auto-strips overrides (post-1.0.1)**: Deleting a
+project environment that has app-level overrides no longer returns a 409
+error. The API now removes overrides from all apps referencing the deleted
+environment and proceeds with the deletion.
+
 **App Degraded phase (post-1.0.1)**: The `AppPhase` enum now includes
 `Degraded`. This phase indicates a build failed but a previously-deployed
 image is still serving. Tooling or dashboards that switch on `AppPhase`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5126,8 +5126,9 @@ paths:
       - environments
   /projects/{project}/environments/{name}:
     delete:
-      description: Removes an environment from the project. Fails if apps still have
-        overrides for it.
+      description: Removes an environment from the project. Automatically strips per-env
+        overrides from all apps referencing the deleted environment before removing
+        it.
       parameters:
       - description: Project name
         in: path
@@ -5158,10 +5159,6 @@ paths:
             $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/api.errorResponse'
-        "409":
-          description: Conflict
           schema:
             $ref: '#/definitions/api.errorResponse'
       security:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -555,6 +555,8 @@ definitions:
         $ref: '#/definitions/api.EnvHealth'
       name:
         type: string
+      preview:
+        type: boolean
       restricted:
         type: boolean
     type: object
@@ -2124,7 +2126,7 @@ info:
   description: Self-hosted Railway-style deploy platform for Kubernetes. Manages projects,
     apps, deployments, env vars, secrets, domains, and git providers.
   title: Mortise API
-  version: 0.1.0
+  version: 1.0.0
 paths:
   /activity:
     get:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -5126,8 +5126,9 @@ paths:
       - environments
   /projects/{project}/environments/{name}:
     delete:
-      description: Removes an environment from the project. Fails if apps still have
-        overrides for it.
+      description: Removes an environment from the project. Automatically strips per-env
+        overrides from all apps referencing the deleted environment before removing
+        it.
       parameters:
       - description: Project name
         in: path
@@ -5158,10 +5159,6 @@ paths:
             $ref: '#/definitions/api.errorResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/api.errorResponse'
-        "409":
-          description: Conflict
           schema:
             $ref: '#/definitions/api.errorResponse'
       security:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -555,6 +555,8 @@ definitions:
         $ref: '#/definitions/api.EnvHealth'
       name:
         type: string
+      preview:
+        type: boolean
       restricted:
         type: boolean
     type: object
@@ -2124,7 +2126,7 @@ info:
   description: Self-hosted Railway-style deploy platform for Kubernetes. Manages projects,
     apps, deployments, env vars, secrets, domains, and git providers.
   title: Mortise API
-  version: 0.1.0
+  version: 1.0.0
 paths:
   /activity:
     get:

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -47,6 +47,7 @@ type projectEnvResponse struct {
 	DisplayOrder int       `json:"displayOrder"`
 	Health       EnvHealth `json:"health"`
 	Restricted   bool      `json:"restricted,omitempty"`
+	Preview      bool      `json:"preview,omitempty"`
 }
 
 type createProjectEnvRequest struct {
@@ -114,6 +115,7 @@ func (s *Server) ListProjectEnvironments(w http.ResponseWriter, r *http.Request)
 			DisplayOrder: env.DisplayOrder,
 			Health:       aggregateEnvHealth(env.Name, apps.Items),
 			Restricted:   env.Restricted,
+			Preview:      env.Preview,
 		})
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -422,15 +424,9 @@ func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusBadRequest, errorResponse{"cannot delete the last environment on a project — delete the project instead"})
 		return
 	}
-	offenders, err := s.appsReferencingEnv(r.Context(), projectNs(project), envName)
+	stripped, err := s.stripAppEnvOverrides(r.Context(), projectNs(project), envName)
 	if err != nil {
 		writeError(w, r, err)
-		return
-	}
-	if len(offenders) > 0 {
-		writeJSON(w, http.StatusConflict, errorResponse{
-			fmt.Sprintf("cannot remove environment %q while App overrides still reference it: %v — remove the entries from spec.environments on those Apps first", envName, offenders),
-		})
 		return
 	}
 
@@ -444,7 +440,11 @@ func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	s.recordActivity(r, projectName, "delete", "environment", envName, "Deleted project environment "+envName, "")
+	msg := "Deleted project environment " + envName
+	if len(stripped) > 0 {
+		msg += fmt.Sprintf(" (stripped overrides from %v)", stripped)
+	}
+	s.recordActivity(r, projectName, "delete", "environment", envName, msg, "")
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "name": envName})
 }
@@ -792,6 +792,53 @@ func cloneAppEnvSecret(ctx context.Context, appName, sourceEnvNs, targetEnvNs st
 		return fmt.Errorf("copy env secret for app %q to %q: %w", appName, targetEnvNs, err)
 	}
 	return nil
+}
+
+// stripAppEnvOverrides removes the env override entry from every App in the
+// project namespace that references envName. Uses RetryOnConflict per App to
+// handle concurrent modifications. Returns the list of app names that had
+// overrides stripped.
+func (s *Server) stripAppEnvOverrides(ctx context.Context, ns, envName string) ([]string, error) {
+	var apps mortisev1alpha1.AppList
+	if err := s.client.List(ctx, &apps, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	var stripped []string
+	for i := range apps.Items {
+		app := &apps.Items[i]
+		has := false
+		for _, env := range app.Spec.Environments {
+			if env.Name == envName {
+				has = true
+				break
+			}
+		}
+		if !has {
+			continue
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var fresh mortisev1alpha1.App
+			if err := s.client.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+				return err
+			}
+			idx := -1
+			for j, env := range fresh.Spec.Environments {
+				if env.Name == envName {
+					idx = j
+					break
+				}
+			}
+			if idx < 0 {
+				return nil
+			}
+			fresh.Spec.Environments = append(fresh.Spec.Environments[:idx], fresh.Spec.Environments[idx+1:]...)
+			return s.client.Update(ctx, &fresh)
+		}); err != nil {
+			return stripped, fmt.Errorf("strip env override from app %q: %w", app.Name, err)
+		}
+		stripped = append(stripped, app.Name)
+	}
+	return stripped, nil
 }
 
 func (s *Server) appsReferencingEnv(ctx context.Context, ns, envName string) ([]string, error) {

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -385,14 +385,14 @@ func (s *Server) updateProjectEnvironment(ctx context.Context, projectName, envN
 	return updated, nil
 }
 
-// DeleteProjectEnvironment removes an env from spec.environments. The
-// admission webhook rejects the call if any App still carries an override for
-// the env; the API surfaces that 403 verbatim.
+// DeleteProjectEnvironment removes an env from spec.environments. Any Apps
+// that carry per-env overrides for the deleted environment are automatically
+// stripped before the project update, so deletion always succeeds.
 //
 // DELETE /api/projects/{project}/environments/{name}
 //
 // @Summary Delete a project environment
-// @Description Removes an environment from the project. Fails if apps still have overrides for it.
+// @Description Removes an environment from the project. Automatically strips per-env overrides from all apps referencing the deleted environment before removing it.
 // @Tags environments
 // @Produce json
 // @Security BearerAuth
@@ -402,7 +402,6 @@ func (s *Server) updateProjectEnvironment(ctx context.Context, projectName, envN
 // @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
-// @Failure 409 {object} errorResponse
 // @Router /projects/{project}/environments/{name} [delete]
 func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request) {
 	projectName := chi.URLParam(r, "project")
@@ -839,26 +838,6 @@ func (s *Server) stripAppEnvOverrides(ctx context.Context, ns, envName string) (
 		stripped = append(stripped, app.Name)
 	}
 	return stripped, nil
-}
-
-func (s *Server) appsReferencingEnv(ctx context.Context, ns, envName string) ([]string, error) {
-	var apps mortisev1alpha1.AppList
-	if err := s.client.List(ctx, &apps, client.InNamespace(ns)); err != nil {
-		return nil, err
-	}
-	var offenders []string
-	for i := range apps.Items {
-		app := &apps.Items[i]
-		for _, env := range app.Spec.Environments {
-			if env.Name != envName {
-				continue
-			}
-			offenders = append(offenders, app.Name)
-			break
-		}
-	}
-	sort.Strings(offenders)
-	return offenders, nil
 }
 
 func (s *Server) ensureProjectEnvNamespace(ctx context.Context, project *mortisev1alpha1.Project, envName string, active bool) error {

--- a/internal/api/project_envs_test.go
+++ b/internal/api/project_envs_test.go
@@ -655,9 +655,9 @@ func TestDeleteProjectEnvironment(t *testing.T) {
 	}
 }
 
-// TestDeleteProjectEnvironmentRejectsReferencedOverride verifies the REST API
-// enforces the same protection as the optional admission webhook.
-func TestDeleteProjectEnvironmentRejectsReferencedOverride(t *testing.T) {
+// TestDeleteProjectEnvironmentStripsOverrides verifies the REST API auto-strips
+// App env overrides when deleting an environment, instead of rejecting.
+func TestDeleteProjectEnvironmentStripsOverrides(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)
 	h := srv.Handler()
@@ -675,20 +675,90 @@ func TestDeleteProjectEnvironmentRejectsReferencedOverride(t *testing.T) {
 	}
 
 	w := doRequest(h, http.MethodDelete, "/api/projects/demo/environments/staging", nil)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Env should be removed from project.
+	var proj mortisev1alpha1.Project
+	_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: "demo"}, &proj)
+	if len(proj.Spec.Environments) != 1 || proj.Spec.Environments[0].Name != "production" {
+		t.Fatalf("expected only production env, got %+v", proj.Spec.Environments)
+	}
+
+	// App override should be stripped.
+	var got mortisev1alpha1.App
+	_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "web"}, &got)
+	if len(got.Spec.Environments) != 0 {
+		t.Fatalf("expected app overrides stripped, got %+v", got.Spec.Environments)
+	}
+}
+
+// TestDeleteProjectEnvironmentStripsMultipleApps verifies deletion strips
+// overrides from multiple Apps.
+func TestDeleteProjectEnvironmentStripsMultipleApps(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	const projectName = "demo-strip-multi"
+	ns := seedProject(t, k8sClient, projectName, "production", "staging")
+
+	for _, name := range []string{"web", "api", "worker"} {
+		app := &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: mortisev1alpha1.AppSpec{
+				Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+				Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+			},
+		}
+		if err := k8sClient.Create(context.Background(), app); err != nil {
+			t.Fatalf("create app %s: %v", name, err)
+		}
+	}
+
+	w := doRequest(h, http.MethodDelete, "/api/projects/"+projectName+"/environments/staging", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, name := range []string{"web", "api", "worker"} {
+		var got mortisev1alpha1.App
+		_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &got)
+		if len(got.Spec.Environments) != 0 {
+			t.Errorf("app %s: expected overrides stripped, got %+v", name, got.Spec.Environments)
+		}
+	}
+}
+
+// TestDeleteProjectEnvironmentNoOverrides verifies deletion works when no Apps
+// have overrides for the env (no regression).
+func TestDeleteProjectEnvironmentNoOverrides(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	const projectName = "demo-strip-none"
+	ns := seedProject(t, k8sClient, projectName, "production", "staging")
+
+	// App with no overrides for staging.
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	w := doRequest(h, http.MethodDelete, "/api/projects/"+projectName+"/environments/staging", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var proj mortisev1alpha1.Project
-	_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: "demo"}, &proj)
-	if len(proj.Spec.Environments) != 2 {
-		t.Fatalf("expected project envs unchanged, got %+v", proj.Spec.Environments)
-	}
-
-	var got mortisev1alpha1.App
-	_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "web"}, &got)
-	if len(got.Spec.Environments) != 1 || got.Spec.Environments[0].Name != "staging" {
-		t.Fatalf("expected app override unchanged, got %+v", got.Spec.Environments)
+	_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: projectName}, &proj)
+	if len(proj.Spec.Environments) != 1 || proj.Spec.Environments[0].Name != "production" {
+		t.Fatalf("expected only production env, got %+v", proj.Spec.Environments)
 	}
 }
 
@@ -739,6 +809,58 @@ func TestAppEnvRejectsUnknownProjectEnv(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/projects/demo/apps/web/env?environment=ghost", nil)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestListProjectEnvironmentsPreviewField verifies that the preview flag is
+// correctly returned for normal and preview-marked environments.
+func TestListProjectEnvironmentsPreviewField(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "demo-preview-flag", "production", "staging")
+
+	// Add a preview env to the project.
+	var proj mortisev1alpha1.Project
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "demo-preview-flag"}, &proj); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	proj.Spec.Environments = append(proj.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
+		Name:    "pr-42",
+		Preview: true,
+	})
+	if err := k8sClient.Update(context.Background(), &proj); err != nil {
+		t.Fatalf("update project: %v", err)
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/demo-preview-flag/environments", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envs []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&envs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(envs) != 3 {
+		t.Fatalf("expected 3 envs, got %d", len(envs))
+	}
+
+	envByName := map[string]map[string]any{}
+	for _, e := range envs {
+		envByName[e["name"].(string)] = e
+	}
+
+	// Normal envs should not have preview=true.
+	if preview, ok := envByName["production"]["preview"]; ok && preview == true {
+		t.Errorf("production should not be preview")
+	}
+	if preview, ok := envByName["staging"]["preview"]; ok && preview == true {
+		t.Errorf("staging should not be preview")
+	}
+	// Preview env should have preview=true.
+	if envByName["pr-42"]["preview"] != true {
+		t.Errorf("pr-42 should have preview=true, got %v", envByName["pr-42"]["preview"])
 	}
 }
 

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -19,6 +19,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -527,17 +530,22 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 		return fmt.Errorf("list preview environments: %w", err)
 	}
 
-	// Index existing PEs by PR number.
-	existingByPR := make(map[int]*mortisev1alpha1.PreviewEnvironment, len(peList.Items))
+	// Index existing PEs by name. Using PE name as the key avoids PR number
+	// collisions across different repos (multi-repo projects disambiguate
+	// with a repo slug in the PE name).
+	existingByPR := make(map[string]*mortisev1alpha1.PreviewEnvironment, len(peList.Items))
 	for i := range peList.Items {
 		pe := &peList.Items[i]
-		existingByPR[pe.Spec.PullRequest.Number] = pe
+		// Use the PE name as a unique handle; map all repo variants to it.
+		existingByPR[pe.Name] = pe
 	}
 
-	// Track which PR numbers are open across all repos.
-	openPRs := make(map[int]bool)
+	// Track which PE names are still open.
+	openPEs := make(map[string]bool)
 
 	botPR := project.Spec.Preview.BotPR == nil || *project.Spec.Preview.BotPR
+
+	sourceEnv := resolveSourceEnvFromProject(project)
 
 	for _, rk := range repos {
 		if rk.providerRef == "" {
@@ -570,26 +578,26 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 			return fmt.Errorf("list open PRs for %q: %w", rk.repo, err)
 		}
 
-		sourceEnv := resolveSourceEnvFromProject(project)
-
 		for _, pr := range prs {
 			if !botPR && pr.Author.IsBot {
 				continue
 			}
-			openPRs[pr.Number] = true
 
-			if _, exists := existingByPR[pr.Number]; exists {
+			peName := convergencePEName(rk.repo, pr.Number, len(repos) > 1)
+			openPEs[peName] = true
+
+			if _, exists := existingByPR[peName]; exists {
 				continue
 			}
 
 			if sourceEnv == "" {
-				log.Info("no source env to clone from, skipping PR", "project", project.Name, "pr", pr.Number)
+				log.Info("no source env to clone from, skipping PR", "project", project.Name, "pr", pr.Number, "repo", rk.repo)
 				continue
 			}
 
 			pe := &mortisev1alpha1.PreviewEnvironment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("preview-pr-%d", pr.Number),
+					Name:      peName,
 					Namespace: controlNs,
 				},
 				Spec: mortisev1alpha1.PreviewEnvironmentSpec{
@@ -606,27 +614,50 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 				if errors.IsAlreadyExists(err) {
 					continue
 				}
-				return fmt.Errorf("create PE for PR #%d: %w", pr.Number, err)
+				return fmt.Errorf("create PE for PR #%d (%s): %w", pr.Number, rk.repo, err)
 			}
-			log.Info("convergence: created PE for open PR", "project", project.Name, "pr", pr.Number)
+			log.Info("convergence: created PE for open PR", "project", project.Name, "pr", pr.Number, "repo", rk.repo)
 		}
 	}
 
 	// Delete PE CRs for PRs that are no longer open.
-	for prNum, pe := range existingByPR {
-		if openPRs[prNum] {
+	for peName, pe := range existingByPR {
+		if openPEs[peName] {
 			continue
 		}
 		if err := r.Delete(ctx, pe); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return fmt.Errorf("delete stale PE for PR #%d: %w", prNum, err)
+			return fmt.Errorf("delete stale PE %q: %w", peName, err)
 		}
-		log.Info("convergence: deleted PE for closed PR", "project", project.Name, "pr", prNum)
+		log.Info("convergence: deleted PE for closed PR", "project", project.Name, "pe", peName)
 	}
 
 	return nil
+}
+
+// convergencePEName returns the PE object name for a given repo and PR number.
+// When multiRepo is false (single git-source repo), the classic format
+// "preview-pr-{number}" is used. When true, a short repo slug is included to
+// avoid name collisions across repos.
+func convergencePEName(repo string, number int, multiRepo bool) string {
+	if !multiRepo {
+		return fmt.Sprintf("preview-pr-%d", number)
+	}
+	// Use last path segment of the repo URL as slug (e.g. "repo" from
+	// "https://github.com/org/repo"). Truncate to keep the name under 63 chars.
+	slug := repo
+	if idx := len(slug) - 1; idx >= 0 && slug[idx] == '/' {
+		slug = slug[:idx]
+	}
+	if idx := strings.LastIndex(slug, "/"); idx >= 0 {
+		slug = slug[idx+1:]
+	}
+	if len(slug) > 20 {
+		slug = slug[:20]
+	}
+	return fmt.Sprintf("preview-%s-pr-%d", slug, number)
 }
 
 // resolveSourceEnvFromProject mirrors the webhook handler's resolveSourceEnv logic.
@@ -667,7 +698,7 @@ func (r *PreviewEnvironmentReconciler) reconcileProjectConvergence(ctx context.C
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 10 * time.Minute}, nil
 }
 
 func (r *PreviewEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -43,6 +43,12 @@ import (
 
 const previewFinalizer = "mortise.dev/preview-finalizer"
 
+// convergenceGracePeriod prevents deleting PEs that were just created by a
+// webhook or another controller. Without this, a convergence run that sees
+// no matching open PR (e.g. because the forge API hasn't propagated yet)
+// would race against the creator.
+const convergenceGracePeriod = 15 * time.Minute
+
 // PreviewEnvironmentReconciler coordinates preview environments as a thin layer:
 // it adds/removes a ProjectEnvironment entry on the parent Project and clones
 // per-app env overrides. The app controller handles all build/deploy work.
@@ -620,9 +626,14 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 		}
 	}
 
-	// Delete PE CRs for PRs that are no longer open.
+	// Delete PE CRs for PRs that are no longer open. Skip recently-created
+	// PEs to avoid racing with webhooks or in-flight reconciles.
 	for peName, pe := range existingByPR {
 		if openPEs[peName] {
+			continue
+		}
+		if r.clock().Since(pe.CreationTimestamp.Time) < convergenceGracePeriod {
+			log.Info("convergence: skipping recent PE", "project", project.Name, "pe", peName, "age", r.clock().Since(pe.CreationTimestamp.Time))
 			continue
 		}
 		if err := r.Delete(ctx, pe); err != nil {

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -35,6 +35,7 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/envstore"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 const previewFinalizer = "mortise.dev/preview-finalizer"
@@ -44,8 +45,9 @@ const previewFinalizer = "mortise.dev/preview-finalizer"
 // per-app env overrides. The app controller handles all build/deploy work.
 type PreviewEnvironmentReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Clock  clock.Clock
+	Scheme        *runtime.Scheme
+	Clock         clock.Clock
+	GitAPIFactory func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
 }
 
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=previewenvironments,verbs=get;list;watch;create;update;patch;delete
@@ -168,7 +170,7 @@ func (r *PreviewEnvironmentReconciler) ensureProjectEnv(ctx context.Context, pro
 				return nil
 			}
 		}
-		project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{Name: envName})
+		project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{Name: envName, Preview: true})
 		return r.Update(ctx, &project)
 	})
 }
@@ -476,9 +478,218 @@ func (r *PreviewEnvironmentReconciler) clock() clock.Clock {
 	return clock.RealClock{}
 }
 
+// ConvergeProjectPreviews synchronises preview environments with the forge's
+// open-PR state. Called when a Project with previews enabled is reconciled.
+// Creates PE CRs for open PRs that lack one and deletes PE CRs for PRs that
+// are no longer open.
+func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Context, project *mortisev1alpha1.Project) error {
+	log := logf.FromContext(ctx)
+
+	if project.Spec.Preview == nil || !project.Spec.Preview.Enabled {
+		return nil
+	}
+	if r.GitAPIFactory == nil {
+		return nil
+	}
+
+	controlNs := constants.ControlNamespace(project.Name)
+
+	var apps mortisev1alpha1.AppList
+	if err := r.List(ctx, &apps, client.InNamespace(controlNs)); err != nil {
+		return fmt.Errorf("list apps: %w", err)
+	}
+
+	// Collect unique repos from git-source apps with their provider refs.
+	type repoKey struct {
+		repo        string
+		providerRef string
+	}
+	seen := make(map[repoKey]bool)
+	var repos []repoKey
+	for i := range apps.Items {
+		src := apps.Items[i].Spec.Source
+		if src.Type != mortisev1alpha1.SourceTypeGit || src.Repo == "" {
+			continue
+		}
+		k := repoKey{repo: src.Repo, providerRef: src.ProviderRef}
+		if !seen[k] {
+			seen[k] = true
+			repos = append(repos, k)
+		}
+	}
+	if len(repos) == 0 {
+		return nil
+	}
+
+	// List existing PE CRs in the project control namespace.
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := r.List(ctx, &peList, client.InNamespace(controlNs)); err != nil {
+		return fmt.Errorf("list preview environments: %w", err)
+	}
+
+	// Index existing PEs by PR number.
+	existingByPR := make(map[int]*mortisev1alpha1.PreviewEnvironment, len(peList.Items))
+	for i := range peList.Items {
+		pe := &peList.Items[i]
+		existingByPR[pe.Spec.PullRequest.Number] = pe
+	}
+
+	// Track which PR numbers are open across all repos.
+	openPRs := make(map[int]bool)
+
+	botPR := project.Spec.Preview.BotPR == nil || *project.Spec.Preview.BotPR
+
+	for _, rk := range repos {
+		if rk.providerRef == "" {
+			continue
+		}
+
+		var gp mortisev1alpha1.GitProvider
+		if err := r.Get(ctx, types.NamespacedName{Name: rk.providerRef}, &gp); err != nil {
+			if errors.IsNotFound(err) {
+				log.Info("GitProvider not found, skipping repo", "provider", rk.providerRef, "repo", rk.repo)
+				continue
+			}
+			return fmt.Errorf("get GitProvider %q: %w", rk.providerRef, err)
+		}
+
+		tokenResult, err := git.ResolveGitTokenForApp(ctx, r.Client, rk.providerRef, controlNs, "", "")
+		if err != nil {
+			log.Info("no git token available for convergence, skipping repo", "provider", rk.providerRef, "repo", rk.repo, "error", err)
+			continue
+		}
+
+		gitAPI, err := r.GitAPIFactory(&gp, tokenResult.Token, "")
+		if err != nil {
+			log.Error(err, "build GitAPI for convergence", "provider", rk.providerRef)
+			continue
+		}
+
+		prs, err := gitAPI.ListOpenPullRequests(ctx, rk.repo)
+		if err != nil {
+			return fmt.Errorf("list open PRs for %q: %w", rk.repo, err)
+		}
+
+		sourceEnv := resolveSourceEnvFromProject(project)
+
+		for _, pr := range prs {
+			if !botPR && pr.Author.IsBot {
+				continue
+			}
+			openPRs[pr.Number] = true
+
+			if _, exists := existingByPR[pr.Number]; exists {
+				continue
+			}
+
+			if sourceEnv == "" {
+				log.Info("no source env to clone from, skipping PR", "project", project.Name, "pr", pr.Number)
+				continue
+			}
+
+			pe := &mortisev1alpha1.PreviewEnvironment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("preview-pr-%d", pr.Number),
+					Namespace: controlNs,
+				},
+				Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+					ProjectRef: project.Name,
+					SourceEnv:  sourceEnv,
+					PullRequest: mortisev1alpha1.PullRequestRef{
+						Number: pr.Number,
+						Branch: pr.Branch,
+						SHA:    pr.SHA,
+					},
+				},
+			}
+			if err := r.Create(ctx, pe); err != nil {
+				if errors.IsAlreadyExists(err) {
+					continue
+				}
+				return fmt.Errorf("create PE for PR #%d: %w", pr.Number, err)
+			}
+			log.Info("convergence: created PE for open PR", "project", project.Name, "pr", pr.Number)
+		}
+	}
+
+	// Delete PE CRs for PRs that are no longer open.
+	for prNum, pe := range existingByPR {
+		if openPRs[prNum] {
+			continue
+		}
+		if err := r.Delete(ctx, pe); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("delete stale PE for PR #%d: %w", prNum, err)
+		}
+		log.Info("convergence: deleted PE for closed PR", "project", project.Name, "pr", prNum)
+	}
+
+	return nil
+}
+
+// resolveSourceEnvFromProject mirrors the webhook handler's resolveSourceEnv logic.
+func resolveSourceEnvFromProject(project *mortisev1alpha1.Project) string {
+	if project.Spec.Preview != nil && project.Spec.Preview.SourceEnvironment != "" {
+		return project.Spec.Preview.SourceEnvironment
+	}
+	var firstNonProd string
+	for _, env := range project.Spec.Environments {
+		if env.Preview {
+			continue
+		}
+		if env.Name == "staging" {
+			return "staging"
+		}
+		if env.Name != "production" && firstNonProd == "" {
+			firstNonProd = env.Name
+		}
+	}
+	return firstNonProd
+}
+
+// reconcileProjectConvergence is called when a Project event is received.
+// It converges preview environments for the project.
+func (r *PreviewEnvironmentReconciler) reconcileProjectConvergence(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var project mortisev1alpha1.Project
+	if err := r.Get(ctx, types.NamespacedName{Name: req.Name}, &project); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.ConvergeProjectPreviews(ctx, &project); err != nil {
+		log.Error(err, "converge project previews", "project", project.Name)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
 func (r *PreviewEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mortisev1alpha1.PreviewEnvironment{}).
 		Named("previewenvironment").
 		Complete(r)
+}
+
+// PreviewConvergenceReconciler watches Projects and triggers PE convergence
+// against the forge's open-PR state.
+type PreviewConvergenceReconciler struct {
+	PEReconciler *PreviewEnvironmentReconciler
+}
+
+func (c *PreviewConvergenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return c.PEReconciler.reconcileProjectConvergence(ctx, req)
+}
+
+func (c *PreviewConvergenceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mortisev1alpha1.Project{}).
+		Named("previewconvergence").
+		Complete(c)
 }

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -27,14 +28,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/envstore"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 // helper: create a test Project and its control namespace (`pj-{name}`). The
@@ -741,6 +746,113 @@ var _ = Describe("PreviewEnvironment Controller", func() {
 	})
 })
 
+// newTestScheme builds a scheme containing core and Mortise types for fake clients.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := mortisev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add mortise: %v", err)
+	}
+	return s
+}
+
+// TestEnsureProjectEnvSetsPreviewFlag verifies ensureProjectEnv marks the
+// created environment as Preview: true.
+func TestEnsureProjectEnvSetsPreviewFlag(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "flag-test"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project).Build()
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+
+	if err := reconciler.ensureProjectEnv(ctx, "flag-test", "pr-10"); err != nil {
+		t.Fatalf("ensureProjectEnv: %v", err)
+	}
+
+	var proj mortisev1alpha1.Project
+	if err := c.Get(ctx, types.NamespacedName{Name: "flag-test"}, &proj); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+
+	var found *mortisev1alpha1.ProjectEnvironment
+	for i := range proj.Spec.Environments {
+		if proj.Spec.Environments[i].Name == "pr-10" {
+			found = &proj.Spec.Environments[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("pr-10 env not found on project")
+	}
+	if !found.Preview {
+		t.Errorf("expected Preview=true on pr-10 env")
+	}
+	// Normal envs should not have Preview set.
+	for _, env := range proj.Spec.Environments {
+		if env.Name == "staging" && env.Preview {
+			t.Errorf("staging env should not have Preview=true")
+		}
+	}
+}
+
+// TestEnsureProjectEnvIdempotent verifies calling ensureProjectEnv twice
+// doesn't duplicate the env entry.
+func TestEnsureProjectEnvIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "idemp-test"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project).Build()
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+
+	// Call twice.
+	if err := reconciler.ensureProjectEnv(ctx, "idemp-test", "pr-11"); err != nil {
+		t.Fatalf("first ensureProjectEnv: %v", err)
+	}
+	if err := reconciler.ensureProjectEnv(ctx, "idemp-test", "pr-11"); err != nil {
+		t.Fatalf("second ensureProjectEnv: %v", err)
+	}
+
+	var proj mortisev1alpha1.Project
+	if err := c.Get(ctx, types.NamespacedName{Name: "idemp-test"}, &proj); err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+
+	count := 0
+	for _, env := range proj.Spec.Environments {
+		if env.Name == "pr-11" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 pr-11 env, got %d; envs: %+v", count, proj.Spec.Environments)
+	}
+}
+
 func TestCloneEnvironment_DeepCopiesAllFields(t *testing.T) {
 	app := &mortisev1alpha1.App{
 		Spec: mortisev1alpha1.AppSpec{
@@ -858,6 +970,458 @@ func TestCloneEnvironment_DeepCopiesAllFields(t *testing.T) {
 	}
 	if cloned.BuildArgs["GO_VERSION"] != "1.22" {
 		t.Errorf("clone buildArgs affected by source mutation: %s", cloned.BuildArgs["GO_VERSION"])
+	}
+}
+
+// --- Convergence tests (#373) ---
+
+type mockGitAPI struct {
+	openPRs []git.PullRequestSnapshot
+	err     error
+}
+
+func (m *mockGitAPI) ListOpenPullRequests(ctx context.Context, repo string) ([]git.PullRequestSnapshot, error) {
+	return m.openPRs, m.err
+}
+func (m *mockGitAPI) RegisterWebhook(ctx context.Context, repo string, cfg git.WebhookConfig) error {
+	return nil
+}
+func (m *mockGitAPI) ListWebhooks(ctx context.Context, repo string) ([]git.WebhookInfo, error) {
+	return nil, nil
+}
+func (m *mockGitAPI) DeleteWebhook(ctx context.Context, repo string, hookID int64) error {
+	return nil
+}
+func (m *mockGitAPI) PostCommitStatus(ctx context.Context, repo, sha string, status git.CommitStatus) error {
+	return nil
+}
+func (m *mockGitAPI) VerifyWebhookSignature(body []byte, header http.Header) error { return nil }
+func (m *mockGitAPI) ResolveCloneCredentials(ctx context.Context, repo string) (git.GitCredentials, error) {
+	return git.GitCredentials{}, nil
+}
+func (m *mockGitAPI) ListRepos(ctx context.Context) ([]git.Repository, error) { return nil, nil }
+func (m *mockGitAPI) ListBranches(ctx context.Context, repo string) ([]git.Branch, error) {
+	return nil, nil
+}
+func (m *mockGitAPI) ResolveBranchHead(ctx context.Context, repo, branch string) (string, error) {
+	return "", nil
+}
+func (m *mockGitAPI) ListTree(ctx context.Context, owner, repo, branch, path string) ([]git.TreeEntry, error) {
+	return nil, nil
+}
+
+func TestConvergeProjectPreviews_CreatesMissing(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-create"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/org/repo",
+				Branch:      "main",
+				ProviderRef: "github-converge",
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "converge-member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "bot@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "bot@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app, gp, pm, tokenSecret).Build()
+
+	mock := &mockGitAPI{
+		openPRs: []git.PullRequestSnapshot{
+			{Number: 10, Branch: "feat-a", SHA: "aaa"},
+			{Number: 20, Branch: "feat-b", SHA: "bbb"},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 2 {
+		t.Fatalf("expected 2 PEs, got %d", len(peList.Items))
+	}
+	prNums := map[int]bool{}
+	for _, pe := range peList.Items {
+		prNums[pe.Spec.PullRequest.Number] = true
+	}
+	if !prNums[10] || !prNums[20] {
+		t.Errorf("expected PEs for PR #10 and #20, got %v", prNums)
+	}
+}
+
+func TestConvergeProjectPreviews_DeletesStale(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-stale"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/org/repo",
+				Branch:      "main",
+				ProviderRef: "github-converge",
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	stalePE := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{Name: "preview-pr-5", Namespace: nsName},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef:  projectName,
+			SourceEnv:   "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{Number: 5, Branch: "old", SHA: "old"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app, gp, pm, tokenSecret, stalePE).Build()
+
+	mock := &mockGitAPI{
+		openPRs: []git.PullRequestSnapshot{
+			{Number: 7, Branch: "new-feat", SHA: "ccc"},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+
+	prNums := map[int]bool{}
+	for _, pe := range peList.Items {
+		if pe.DeletionTimestamp.IsZero() {
+			prNums[pe.Spec.PullRequest.Number] = true
+		}
+	}
+	if prNums[5] {
+		t.Errorf("stale PE for PR #5 should be deleted")
+	}
+	if !prNums[7] {
+		t.Errorf("PE for PR #7 should be created")
+	}
+}
+
+func TestConvergeProjectPreviews_PreviewsDisabled(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-project"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview: &mortisev1alpha1.PreviewConfig{Enabled: false},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project).Build()
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			t.Fatal("GitAPIFactory should not be called when previews are disabled")
+			return nil, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+}
+
+func TestConvergeProjectPreviews_NoGitSourceApps(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-noapp"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "imgapp", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app).Build()
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			t.Fatal("GitAPIFactory should not be called with only image-source apps")
+			return nil, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+}
+
+func TestConvergeProjectPreviews_BotPRFiltering(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-bot"
+	nsName := constants.ControlNamespace(projectName)
+
+	botPRFalse := false
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true, BotPR: &botPRFalse},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/org/repo",
+				Branch:      "main",
+				ProviderRef: "github-converge",
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app, gp, pm, tokenSecret).Build()
+
+	mock := &mockGitAPI{
+		openPRs: []git.PullRequestSnapshot{
+			{Number: 30, Branch: "bot-update", SHA: "ddd", Author: git.PullRequestAuthor{Login: "dependabot", IsBot: true}},
+			{Number: 31, Branch: "human-feat", SHA: "eee", Author: git.PullRequestAuthor{Login: "developer"}},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+
+	// Only PR #31 (human) should get a PE, not PR #30 (bot).
+	if len(peList.Items) != 1 {
+		t.Fatalf("expected 1 PE, got %d", len(peList.Items))
+	}
+	if peList.Items[0].Spec.PullRequest.Number != 31 {
+		t.Errorf("expected PE for PR #31, got #%d", peList.Items[0].Spec.PullRequest.Number)
+	}
+}
+
+func TestConvergeProjectPreviews_GitAPIError(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-err"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/org/repo",
+				Branch:      "main",
+				ProviderRef: "github-converge",
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app, gp, pm, tokenSecret).Build()
+
+	mock := &mockGitAPI{err: fmt.Errorf("forge API unavailable")}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	err := reconciler.ConvergeProjectPreviews(ctx, project)
+	if err == nil {
+		t.Fatal("expected error from GitAPI, got nil")
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 0 {
+		t.Errorf("expected no PEs on error, got %d", len(peList.Items))
 	}
 }
 

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -1148,8 +1148,11 @@ func TestConvergeProjectPreviews_DeletesStale(t *testing.T) {
 		Data: map[string][]byte{"token": []byte("fake-token")},
 	}
 
+	// CreationTimestamp must be older than the convergence grace period so
+	// the stale-PE cleanup logic considers it eligible for deletion.
+	oldEnough := metav1.NewTime(time.Now().Add(-convergenceGracePeriod - time.Minute))
 	stalePE := &mortisev1alpha1.PreviewEnvironment{
-		ObjectMeta: metav1.ObjectMeta{Name: "preview-pr-5", Namespace: nsName},
+		ObjectMeta: metav1.ObjectMeta{Name: "preview-pr-5", Namespace: nsName, CreationTimestamp: oldEnough},
 		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
 			ProjectRef:  projectName,
 			SourceEnv:   "staging",

--- a/test/integration/project_lifecycle_test.go
+++ b/test/integration/project_lifecycle_test.go
@@ -122,7 +122,7 @@ func TestProjectDeleteCascades(t *testing.T) {
 	}
 }
 
-func TestDeleteProjectEnvironmentRejectsReferencedOverrideViaAPI(t *testing.T) {
+func TestDeleteProjectEnvironmentStripsOverridesViaAPI(t *testing.T) {
 	t.Parallel()
 	projectName := "proj-env-del-" + randSuffix()
 	ns := createProjectForTest(t, projectName)
@@ -162,31 +162,30 @@ func TestDeleteProjectEnvironmentRejectsReferencedOverrideViaAPI(t *testing.T) {
 
 	deleteURL := fmt.Sprintf("%s/api/projects/%s/environments/staging", mortiseURL, projectName)
 	resp := doProjectLifecycleJSON(t, http.MethodDelete, deleteURL, token, nil)
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("delete env: expected 409, got %d: %s", resp.StatusCode, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete env: expected 200, got %d: %s", resp.StatusCode, resp.Body)
 	}
 
+	// Verify the project no longer has "staging" in spec.environments.
 	var latestProject mortisev1alpha1.Project
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: projectName}, &latestProject); err != nil {
-		t.Fatalf("get project after delete attempt: %v", err)
+		t.Fatalf("get project after delete: %v", err)
 	}
-	if len(latestProject.Spec.Environments) != 2 {
-		t.Fatalf("expected project envs unchanged, got %+v", latestProject.Spec.Environments)
-	}
-
-	var latestApp mortisev1alpha1.App
-	if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: app.Name}, &latestApp); err != nil {
-		t.Fatalf("get app after delete attempt: %v", err)
-	}
-	foundStaging := false
-	for _, env := range latestApp.Spec.Environments {
+	for _, env := range latestProject.Spec.Environments {
 		if env.Name == "staging" {
-			foundStaging = true
-			break
+			t.Fatalf("expected staging env to be removed from project, got %+v", latestProject.Spec.Environments)
 		}
 	}
-	if !foundStaging {
-		t.Fatalf("expected staging override to remain on app, got %+v", latestApp.Spec.Environments)
+
+	// Verify the app's "staging" override was stripped.
+	var latestApp mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: app.Name}, &latestApp); err != nil {
+		t.Fatalf("get app after delete: %v", err)
+	}
+	for _, env := range latestApp.Spec.Environments {
+		if env.Name == "staging" {
+			t.Fatalf("expected staging override to be stripped from app, got %+v", latestApp.Spec.Environments)
+		}
 	}
 }
 

--- a/ui/src/lib/components/drawer/MetricsTab.svelte
+++ b/ui/src/lib/components/drawer/MetricsTab.svelte
@@ -145,6 +145,8 @@
 	}
 
 	$effect(() => {
+		// Read env to re-trigger when the active environment changes.
+		void env;
 		setRange('live');
 		return () => { if (pollTimer) clearInterval(pollTimer); };
 	});

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -98,6 +98,10 @@
 		if (env === lastLoadedEnv && appName === lastLoadedApp) return;
 		lastLoadedEnv = env;
 		lastLoadedApp = appName;
+		// Reset sections so stale data from the previous env doesn't linger.
+		envSection = makeSection();
+		sharedSection = makeSection();
+		buildSection = makeSection();
 		void loadEnv(env);
 		void loadShared();
 		void loadBuildArgs();

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -206,6 +206,7 @@ export interface ProjectEnvironment {
 	displayOrder: number;
 	health?: EnvHealth;
 	restricted?: boolean;
+	preview?: boolean;
 }
 
 // Canvas edge for GET /api/projects/{p}/bindings?environment=X.

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import { store } from '$lib/store.svelte';
 	import { currentProject } from '$lib/context.svelte';
 	// Lucide icons
-	import { Folder, Puzzle, Settings, LayoutDashboard, List, Bell, Activity, User, LogOut, ChevronDown, Users, Rocket, ExternalLink } from 'lucide-svelte';
+	import { Folder, Puzzle, Settings, LayoutDashboard, List, Bell, Activity, User, LogOut, ChevronDown, Users, Rocket } from 'lucide-svelte';
 	import ActivityRail from '$lib/components/ActivityRail.svelte';
 	import NotificationDropdown from '$lib/components/NotificationDropdown.svelte';
 	import type { EnvHealth, PreviewSummary } from '$lib/types';
@@ -55,8 +55,8 @@
 	const projectEnvs = $derived.by(() => {
 		if (!activeProject) return [] as typeof store.projectEnvs[string];
 		const cached = store.projectEnvs[activeProject];
-		if (cached && cached.length > 0) return cached;
-		return lastRenderedEnvs;
+		const source = (cached && cached.length > 0) ? cached : lastRenderedEnvs;
+		return source.filter((e) => !e.preview);
 	});
 	$effect(() => {
 		if (!activeProject) return;
@@ -78,6 +78,11 @@
 	const activePreviews = $derived.by<PreviewSummary[]>(() => {
 		if (!activeProject) return [];
 		return store.previewEnvs[activeProject] ?? [];
+	});
+
+	const currentPreview = $derived.by<PreviewSummary | null>(() => {
+		if (!currentEnv || activePreviews.length === 0) return null;
+		return activePreviews.find((p) => (p.environmentName || p.name) === currentEnv) ?? null;
 	});
 
 	function dotClass(h: EnvHealth | undefined): string {
@@ -182,10 +187,10 @@
 		envSwitcherOpen = false;
 		const envName = preview.environmentName || preview.name;
 		if (!activeProject) return;
+		store.setEnv(activeProject, envName);
 		const url = new URL(page.url);
-		url.pathname = `/projects/${encodeURIComponent(activeProject)}`;
 		url.searchParams.set('env', envName);
-		window.open(url.toString(), '_blank', 'noopener,noreferrer');
+		history.replaceState(history.state, '', url.toString());
 	}
 
 	function logout() {
@@ -283,8 +288,13 @@
 								onclick={() => (envSwitcherOpen = !envSwitcherOpen)}
 								class="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-gray-400 hover:bg-surface-700 hover:text-white transition-colors"
 							>
-								<span class="h-2 w-2 rounded-full {dotClass(currentEnvHealth)}"></span>
-								<span>{currentEnv}</span>
+								{#if currentPreview}
+									<span class="inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold leading-none bg-purple-500/20 text-purple-400">PR</span>
+									<span>#{currentPreview.pr.number} &middot; {currentPreview.pr.branch}</span>
+								{:else}
+									<span class="h-2 w-2 rounded-full {dotClass(currentEnvHealth)}"></span>
+									<span>{currentEnv}</span>
+								{/if}
 								<ChevronDown class="h-3.5 w-3.5 text-gray-500" />
 							</button>
 							{#if envSwitcherOpen}
@@ -309,14 +319,16 @@
 										<div class="border-t border-surface-600 my-1"></div>
 										<div class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">PR Environments</div>
 										{#each activePreviews as preview}
+											{@const previewEnvName = preview.environmentName || preview.name}
 											<button
 												type="button"
 												onclick={() => openPreview(preview)}
-												class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:bg-surface-700 hover:text-white"
+												class="flex w-full items-center gap-2 px-3 py-2 text-sm {currentEnv === previewEnvName
+													? 'bg-surface-600 text-white'
+													: 'text-gray-300 hover:bg-surface-700 hover:text-white'}"
 											>
 												<span class="inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold leading-none bg-purple-500/20 text-purple-400">PR</span>
 												<span class="min-w-0 flex-1 truncate">#{preview.pr.number} &middot; {preview.pr.branch}</span>
-												<ExternalLink class="h-3.5 w-3.5 shrink-0 text-gray-500" />
 											</button>
 										{/each}
 									{/if}


### PR DESCRIPTION
## Summary

- **#374 (PR envs duplicate in switcher):** Added `Preview` bool field to `ProjectEnvironment` CRD. UI filters preview envs from the standard environment list and navigates in-place instead of opening a new tab. Navbar shows PR badge + number + branch when a preview env is active.
- **#375 (Env deletion blocked by overrides):** `DeleteProjectEnvironment` API now auto-strips app-level overrides referencing the deleted environment instead of returning 409 Conflict.
- **#376 (Stale drawer tab data):** VariablesTab resets sections before reloading on env switch. MetricsTab `$effect` now tracks the `env` prop to re-trigger fetch on env change.
- **#373 (PE convergence):** New `PreviewConvergenceReconciler` watches Projects and periodically polls the forge for open PRs, creating/deleting `PreviewEnvironment` CRs to match. Handles bot PR filtering, multi-repo projects, and token resolution.

Closes #373, closes #374, closes #375, closes #376

## Test plan

- [x] `make test` passes (1017 tests, 22 packages)
- [x] `make check-ui` passes (0 errors, 0 warnings)
- [x] `make test-charts` passes (helm lint + template tests)
- [ ] Manual: verify PR env appears only once in switcher (PR section only)
- [ ] Manual: verify clicking PR env navigates in-place with URL update
- [ ] Manual: verify navbar shows PR badge when preview env is selected
- [ ] Manual: verify deleting env with app overrides succeeds and strips overrides
- [ ] Manual: verify switching envs in drawer clears and reloads variable/metrics data
- [ ] Manual: verify PE convergence creates/deletes PEs for missed webhook events

🤖 Generated with [Claude Code](https://claude.com/claude-code)