### PR TITLE
Fix preview convergence regressions

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -66,8 +67,9 @@ func PreviewEnvironmentPrefix(repo string, multiRepo bool) string {
 	if !multiRepo {
 		return "preview-pr-"
 	}
-	slug := previewRepoSlug(repo)
-	hash := previewRepoHash(repo)
+	canonicalRepo := CanonicalRepoKey(repo)
+	slug := previewRepoSlug(canonicalRepo)
+	hash := previewRepoHash(canonicalRepo)
 	maxSlugLen := 63 - len("preview-") - len("-") - previewRepoHashLen - len("-pr-") - maxPreviewPRNumberDigits
 	if maxSlugLen < 1 {
 		maxSlugLen = 1
@@ -79,6 +81,30 @@ func PreviewEnvironmentPrefix(repo string, multiRepo bool) string {
 		}
 	}
 	return fmt.Sprintf("preview-%s-%s-pr-", slug, hash)
+}
+
+// CanonicalRepoKey returns a stable lowercased repository key suitable for
+// matching and deterministic naming across owner/repo, URL, and SSH forms.
+func CanonicalRepoKey(repo string) string {
+	repo = strings.TrimSpace(strings.TrimSuffix(repo, ".git"))
+	if repo == "" {
+		return ""
+	}
+
+	if strings.Contains(repo, "://") {
+		if u, err := url.Parse(repo); err == nil {
+			repo = strings.TrimPrefix(u.Path, "/")
+		}
+	}
+	if idx := strings.Index(repo, "@"); idx >= 0 && strings.Contains(repo[idx:], ":") {
+		repo = repo[strings.LastIndex(repo, ":")+1:]
+	}
+	repo = strings.TrimSuffix(repo, "/")
+	parts := strings.Split(repo, "/")
+	if len(parts) >= 2 {
+		return strings.ToLower(parts[len(parts)-2] + "/" + parts[len(parts)-1])
+	}
+	return strings.ToLower(repo)
 }
 
 func previewRepoSlug(repo string) string {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -23,6 +24,9 @@ const (
 
 	// AppFinalizer gates App deletion until cross-namespace cleanup completes.
 	AppFinalizer = "mortise.dev/app-finalizer"
+
+	maxPreviewPRNumberDigits = 19
+	previewRepoHashLen       = 8
 )
 
 // ControlNamespace returns the control-namespace name for a Project
@@ -44,6 +48,75 @@ func EnvNamespace(projectName, envName string) string {
 // (e.g. `pj-my-saas-pr-42`). Created on PR open, deleted on PR close or TTL.
 func PreviewNamespace(projectName string, prNumber int) string {
 	return fmt.Sprintf("%s%s-pr-%d", ControlNamespacePrefix, projectName, prNumber)
+}
+
+// PreviewEnvironmentName returns the PreviewEnvironment object name for a PR.
+// Single-repo projects keep the legacy preview-pr-{n} format; multi-repo
+// projects include a repo-qualified RFC1123-safe prefix.
+func PreviewEnvironmentName(repo string, prNumber int, multiRepo bool) string {
+	if !multiRepo {
+		return fmt.Sprintf("preview-pr-%d", prNumber)
+	}
+	return fmt.Sprintf("%s%d", PreviewEnvironmentPrefix(repo, true), prNumber)
+}
+
+// PreviewEnvironmentPrefix returns the prefix used for multi-repo
+// PreviewEnvironment names, excluding the PR number.
+func PreviewEnvironmentPrefix(repo string, multiRepo bool) string {
+	if !multiRepo {
+		return "preview-pr-"
+	}
+	slug := previewRepoSlug(repo)
+	hash := previewRepoHash(repo)
+	maxSlugLen := 63 - len("preview-") - len("-") - previewRepoHashLen - len("-pr-") - maxPreviewPRNumberDigits
+	if maxSlugLen < 1 {
+		maxSlugLen = 1
+	}
+	if len(slug) > maxSlugLen {
+		slug = strings.Trim(slug[:maxSlugLen], "-")
+		if slug == "" {
+			slug = "repo"
+		}
+	}
+	return fmt.Sprintf("preview-%s-%s-pr-", slug, hash)
+}
+
+func previewRepoSlug(repo string) string {
+	slug := strings.TrimSuffix(strings.TrimSpace(repo), "/")
+	if idx := strings.LastIndex(slug, "/"); idx >= 0 {
+		slug = slug[idx+1:]
+	}
+	if idx := strings.LastIndex(slug, ":"); idx >= 0 {
+		slug = slug[idx+1:]
+	}
+	slug = strings.TrimSuffix(strings.ToLower(slug), ".git")
+
+	var b strings.Builder
+	b.Grow(len(slug))
+	lastDash := false
+	for _, r := range slug {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	slug = strings.Trim(b.String(), "-")
+	if slug == "" {
+		return "repo"
+	}
+	return slug
+}
+
+func previewRepoHash(repo string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(repo)))
+	return hex.EncodeToString(sum[:])[:previewRepoHashLen]
 }
 
 // ValidateProjectEnvLengths returns an error when the combined project+env name

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -1,0 +1,35 @@
+package constants
+
+import "testing"
+
+func TestCanonicalRepoKey(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{name: "https url", repo: "https://github.com/org/repo.git", want: "org/repo"},
+		{name: "host path", repo: "github.com/org/repo", want: "org/repo"},
+		{name: "owner repo", repo: "org/repo", want: "org/repo"},
+		{name: "ssh style", repo: "git@github.com:org/repo.git", want: "org/repo"},
+		{name: "case normalized", repo: "https://GitHub.com/Org/Repo/", want: "org/repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalRepoKey(tt.repo); got != tt.want {
+				t.Fatalf("CanonicalRepoKey(%q) = %q, want %q", tt.repo, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreviewEnvironmentName_CanonicalizesRepoVariants(t *testing.T) {
+	urlName := PreviewEnvironmentName("https://github.com/org/foo.bar", 42, true)
+	shortName := PreviewEnvironmentName("org/foo.bar", 42, true)
+	sshName := PreviewEnvironmentName("git@github.com:org/foo.bar.git", 42, true)
+
+	if urlName != shortName || shortName != sshName {
+		t.Fatalf("expected equivalent repo variants to share preview name, got %q %q %q", urlName, shortName, sshName)
+	}
+}

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -43,6 +45,7 @@ import (
 
 const previewFinalizer = "mortise.dev/preview-finalizer"
 const maxPreviewPRNumberDigits = 19
+const previewRepoHashLen = 8
 
 // convergenceGracePeriod prevents deleting PEs that were just created by a
 // webhook or another controller. Without this, a convergence run that sees
@@ -689,7 +692,8 @@ func convergencePEPrefix(repo string, multiRepo bool) string {
 		return "preview-pr-"
 	}
 	slug := previewRepoSlug(repo)
-	maxSlugLen := 63 - len("preview--pr-") - maxPreviewPRNumberDigits
+	hash := previewRepoHash(repo)
+	maxSlugLen := 63 - len("preview-") - len("-") - previewRepoHashLen - len("-pr-") - maxPreviewPRNumberDigits
 	if maxSlugLen < 1 {
 		maxSlugLen = 1
 	}
@@ -699,7 +703,7 @@ func convergencePEPrefix(repo string, multiRepo bool) string {
 			slug = "repo"
 		}
 	}
-	return fmt.Sprintf("preview-%s-pr-", slug)
+	return fmt.Sprintf("preview-%s-%s-pr-", slug, hash)
 }
 
 func previewRepoSlug(repo string) string {
@@ -733,6 +737,11 @@ func previewRepoSlug(repo string) string {
 		return "repo"
 	}
 	return slug
+}
+
+func previewRepoHash(repo string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(repo)))
+	return hex.EncodeToString(sum[:])[:previewRepoHashLen]
 }
 
 // resolveSourceEnvFromProject mirrors the webhook handler's resolveSourceEnv logic.

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -581,7 +581,8 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 
 		prs, err := gitAPI.ListOpenPullRequests(ctx, rk.repo)
 		if err != nil {
-			return fmt.Errorf("list open PRs for %q: %w", rk.repo, err)
+			log.Error(err, "list open PRs for convergence, skipping repo", "repo", rk.repo, "provider", rk.providerRef)
+			continue
 		}
 
 		for _, pr := range prs {
@@ -656,19 +657,51 @@ func convergencePEName(repo string, number int, multiRepo bool) string {
 	if !multiRepo {
 		return fmt.Sprintf("preview-pr-%d", number)
 	}
-	// Use last path segment of the repo URL as slug (e.g. "repo" from
-	// "https://github.com/org/repo"). Truncate to keep the name under 63 chars.
-	slug := repo
-	if idx := len(slug) - 1; idx >= 0 && slug[idx] == '/' {
-		slug = slug[:idx]
+	slug := previewRepoSlug(repo)
+	maxSlugLen := 63 - len("preview--pr-") - len(fmt.Sprintf("%d", number))
+	if maxSlugLen < 1 {
+		maxSlugLen = 1
 	}
+	if len(slug) > maxSlugLen {
+		slug = strings.Trim(slug[:maxSlugLen], "-")
+		if slug == "" {
+			slug = "repo"
+		}
+	}
+	return fmt.Sprintf("preview-%s-pr-%d", slug, number)
+}
+
+func previewRepoSlug(repo string) string {
+	slug := strings.TrimSuffix(strings.TrimSpace(repo), "/")
 	if idx := strings.LastIndex(slug, "/"); idx >= 0 {
 		slug = slug[idx+1:]
 	}
-	if len(slug) > 20 {
-		slug = slug[:20]
+	if idx := strings.LastIndex(slug, ":"); idx >= 0 {
+		slug = slug[idx+1:]
 	}
-	return fmt.Sprintf("preview-%s-pr-%d", slug, number)
+	slug = strings.TrimSuffix(strings.ToLower(slug), ".git")
+
+	var b strings.Builder
+	b.Grow(len(slug))
+	lastDash := false
+	for _, r := range slug {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	slug = strings.Trim(b.String(), "-")
+	if slug == "" {
+		return "repo"
+	}
+	return slug
 }
 
 // resolveSourceEnvFromProject mirrors the webhook handler's resolveSourceEnv logic.

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -520,10 +520,10 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 		if src.Type != mortisev1alpha1.SourceTypeGit || src.Repo == "" {
 			continue
 		}
-		k := repoKey{repo: src.Repo, providerRef: src.ProviderRef}
+		k := repoKey{repo: constants.CanonicalRepoKey(src.Repo), providerRef: src.ProviderRef}
 		if !seen[k] {
 			seen[k] = true
-			repos = append(repos, k)
+			repos = append(repos, repoKey{repo: src.Repo, providerRef: src.ProviderRef})
 		}
 	}
 	if len(repos) == 0 {

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -42,6 +42,7 @@ import (
 )
 
 const previewFinalizer = "mortise.dev/preview-finalizer"
+const maxPreviewPRNumberDigits = 19
 
 // convergenceGracePeriod prevents deleting PEs that were just created by a
 // webhook or another controller. Without this, a convergence run that sees
@@ -548,10 +549,12 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 
 	// Track which PE names are still open.
 	openPEs := make(map[string]bool)
+	protectedPEs := make(map[string]bool)
 
 	botPR := project.Spec.Preview.BotPR == nil || *project.Spec.Preview.BotPR
 
 	sourceEnv := resolveSourceEnvFromProject(project)
+	multiRepo := len(repos) > 1
 
 	for _, rk := range repos {
 		if rk.providerRef == "" {
@@ -582,6 +585,7 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 		prs, err := gitAPI.ListOpenPullRequests(ctx, rk.repo)
 		if err != nil {
 			log.Error(err, "list open PRs for convergence, skipping repo", "repo", rk.repo, "provider", rk.providerRef)
+			r.protectRepoPreviewEnvironments(protectedPEs, existingByPR, rk.repo, multiRepo)
 			continue
 		}
 
@@ -590,7 +594,7 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 				continue
 			}
 
-			peName := convergencePEName(rk.repo, pr.Number, len(repos) > 1)
+			peName := convergencePEName(rk.repo, pr.Number, multiRepo)
 			openPEs[peName] = true
 
 			if _, exists := existingByPR[peName]; exists {
@@ -633,6 +637,10 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 		if openPEs[peName] {
 			continue
 		}
+		if protectedPEs[peName] {
+			log.Info("convergence: preserving PE for repo with failed PR listing", "project", project.Name, "pe", peName)
+			continue
+		}
 		if r.clock().Since(pe.CreationTimestamp.Time) < convergenceGracePeriod {
 			log.Info("convergence: skipping recent PE", "project", project.Name, "pe", peName, "age", r.clock().Since(pe.CreationTimestamp.Time))
 			continue
@@ -649,6 +657,22 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 	return nil
 }
 
+func (r *PreviewEnvironmentReconciler) protectRepoPreviewEnvironments(protectedPEs map[string]bool, existingByPR map[string]*mortisev1alpha1.PreviewEnvironment, repo string, multiRepo bool) {
+	if !multiRepo {
+		for peName := range existingByPR {
+			protectedPEs[peName] = true
+		}
+		return
+	}
+
+	prefix := convergencePEPrefix(repo, true)
+	for peName := range existingByPR {
+		if strings.HasPrefix(peName, prefix) {
+			protectedPEs[peName] = true
+		}
+	}
+}
+
 // convergencePEName returns the PE object name for a given repo and PR number.
 // When multiRepo is false (single git-source repo), the classic format
 // "preview-pr-{number}" is used. When true, a short repo slug is included to
@@ -657,8 +681,15 @@ func convergencePEName(repo string, number int, multiRepo bool) string {
 	if !multiRepo {
 		return fmt.Sprintf("preview-pr-%d", number)
 	}
+	return fmt.Sprintf("%s%d", convergencePEPrefix(repo, true), number)
+}
+
+func convergencePEPrefix(repo string, multiRepo bool) string {
+	if !multiRepo {
+		return "preview-pr-"
+	}
 	slug := previewRepoSlug(repo)
-	maxSlugLen := 63 - len("preview--pr-") - len(fmt.Sprintf("%d", number))
+	maxSlugLen := 63 - len("preview--pr-") - maxPreviewPRNumberDigits
 	if maxSlugLen < 1 {
 		maxSlugLen = 1
 	}
@@ -668,7 +699,7 @@ func convergencePEName(repo string, number int, multiRepo bool) string {
 			slug = "repo"
 		}
 	}
-	return fmt.Sprintf("preview-%s-pr-%d", slug, number)
+	return fmt.Sprintf("preview-%s-pr-", slug)
 }
 
 func previewRepoSlug(repo string) string {

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -18,8 +18,6 @@ package controller
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -44,8 +42,6 @@ import (
 )
 
 const previewFinalizer = "mortise.dev/preview-finalizer"
-const maxPreviewPRNumberDigits = 19
-const previewRepoHashLen = 8
 
 // convergenceGracePeriod prevents deleting PEs that were just created by a
 // webhook or another controller. Without this, a convergence run that sees
@@ -681,67 +677,11 @@ func (r *PreviewEnvironmentReconciler) protectRepoPreviewEnvironments(protectedP
 // "preview-pr-{number}" is used. When true, a short repo slug is included to
 // avoid name collisions across repos.
 func convergencePEName(repo string, number int, multiRepo bool) string {
-	if !multiRepo {
-		return fmt.Sprintf("preview-pr-%d", number)
-	}
-	return fmt.Sprintf("%s%d", convergencePEPrefix(repo, true), number)
+	return constants.PreviewEnvironmentName(repo, number, multiRepo)
 }
 
 func convergencePEPrefix(repo string, multiRepo bool) string {
-	if !multiRepo {
-		return "preview-pr-"
-	}
-	slug := previewRepoSlug(repo)
-	hash := previewRepoHash(repo)
-	maxSlugLen := 63 - len("preview-") - len("-") - previewRepoHashLen - len("-pr-") - maxPreviewPRNumberDigits
-	if maxSlugLen < 1 {
-		maxSlugLen = 1
-	}
-	if len(slug) > maxSlugLen {
-		slug = strings.Trim(slug[:maxSlugLen], "-")
-		if slug == "" {
-			slug = "repo"
-		}
-	}
-	return fmt.Sprintf("preview-%s-%s-pr-", slug, hash)
-}
-
-func previewRepoSlug(repo string) string {
-	slug := strings.TrimSuffix(strings.TrimSpace(repo), "/")
-	if idx := strings.LastIndex(slug, "/"); idx >= 0 {
-		slug = slug[idx+1:]
-	}
-	if idx := strings.LastIndex(slug, ":"); idx >= 0 {
-		slug = slug[idx+1:]
-	}
-	slug = strings.TrimSuffix(strings.ToLower(slug), ".git")
-
-	var b strings.Builder
-	b.Grow(len(slug))
-	lastDash := false
-	for _, r := range slug {
-		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
-		if isAlphaNum {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-
-	slug = strings.Trim(b.String(), "-")
-	if slug == "" {
-		return "repo"
-	}
-	return slug
-}
-
-func previewRepoHash(repo string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(repo)))
-	return hex.EncodeToString(sum[:])[:previewRepoHashLen]
+	return constants.PreviewEnvironmentPrefix(repo, multiRepo)
 }
 
 // resolveSourceEnvFromProject mirrors the webhook handler's resolveSourceEnv logic.

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -1619,6 +1619,103 @@ func TestConvergeProjectPreviews_MultiRepoSanitizesNames(t *testing.T) {
 	}
 }
 
+func TestConvergeProjectPreviews_MixedRepoSyntaxStaysSingleRepo(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-mixedsyntax"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	apps := []client.Object{
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "https://github.com/org/repo.git",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "git@github.com:org/repo.git",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	objects := append([]client.Object{project, gp, pm, tokenSecret}, apps...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+
+	mock := &mockGitAPI{
+		openPRsByRepo: map[string][]git.PullRequestSnapshot{
+			"https://github.com/org/repo.git": {{Number: 10, Branch: "feat-a", SHA: "aaa"}},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 1 {
+		t.Fatalf("expected 1 PE, got %d", len(peList.Items))
+	}
+	if peList.Items[0].Name != "preview-pr-10" {
+		t.Fatalf("expected legacy single-repo PE name, got %q", peList.Items[0].Name)
+	}
+}
+
 func TestConvergeProjectPreviews_MultiRepoCollisionCreatesDistinctPEs(t *testing.T) {
 	ctx := context.Background()
 	s := newTestScheme(t)

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -1601,6 +1601,7 @@ func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing
 	s := newTestScheme(t)
 	projectName := "converge-continue"
 	nsName := constants.ControlNamespace(projectName)
+	oldEnough := metav1.NewTime(time.Now().Add(-convergenceGracePeriod - time.Minute))
 
 	project := &mortisev1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: projectName},
@@ -1659,7 +1660,20 @@ func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing
 		Data: map[string][]byte{"token": []byte("fake-token")},
 	}
 
-	objects := append([]client.Object{project, gp, pm, tokenSecret}, apps...)
+	existingFailedRepoPE := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "preview-fails-pr-30",
+			Namespace:         nsName,
+			CreationTimestamp: oldEnough,
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef:  projectName,
+			SourceEnv:   "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{Number: 30, Branch: "old", SHA: "old"},
+		},
+	}
+
+	objects := append([]client.Object{project, gp, pm, tokenSecret, existingFailedRepoPE}, apps...)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
 
 	mock := &mockGitAPI{
@@ -1688,11 +1702,21 @@ func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing
 	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
 		t.Fatalf("list PEs: %v", err)
 	}
-	if len(peList.Items) != 1 {
-		t.Fatalf("expected 1 PE from the healthy repo, got %d", len(peList.Items))
+	if len(peList.Items) != 2 {
+		t.Fatalf("expected preserved failed-repo PE plus 1 PE from the healthy repo, got %d", len(peList.Items))
 	}
-	if peList.Items[0].Name != "preview-works-pr-31" {
-		t.Fatalf("expected PE from healthy repo, got %q", peList.Items[0].Name)
+
+	gotNames := map[string]bool{}
+	for _, pe := range peList.Items {
+		if pe.DeletionTimestamp.IsZero() {
+			gotNames[pe.Name] = true
+		}
+	}
+	if !gotNames["preview-fails-pr-30"] {
+		t.Fatalf("expected failed repo PE to be preserved, got %v", gotNames)
+	}
+	if !gotNames["preview-works-pr-31"] {
+		t.Fatalf("expected PE from healthy repo, got %v", gotNames)
 	}
 }
 

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -976,11 +977,19 @@ func TestCloneEnvironment_DeepCopiesAllFields(t *testing.T) {
 // --- Convergence tests (#373) ---
 
 type mockGitAPI struct {
-	openPRs []git.PullRequestSnapshot
-	err     error
+	openPRs       []git.PullRequestSnapshot
+	openPRsByRepo map[string][]git.PullRequestSnapshot
+	err           error
+	errByRepo     map[string]error
 }
 
 func (m *mockGitAPI) ListOpenPullRequests(ctx context.Context, repo string) ([]git.PullRequestSnapshot, error) {
+	if err, ok := m.errByRepo[repo]; ok {
+		return nil, err
+	}
+	if prs, ok := m.openPRsByRepo[repo]; ok {
+		return prs, nil
+	}
 	return m.openPRs, m.err
 }
 func (m *mockGitAPI) RegisterWebhook(ctx context.Context, repo string, cfg git.WebhookConfig) error {
@@ -1351,7 +1360,7 @@ func TestConvergeProjectPreviews_BotPRFiltering(t *testing.T) {
 	}
 }
 
-func TestConvergeProjectPreviews_GitAPIError(t *testing.T) {
+func TestConvergeProjectPreviews_GitAPIErrorSkipsRepo(t *testing.T) {
 	ctx := context.Background()
 	s := newTestScheme(t)
 	projectName := "converge-err"
@@ -1415,8 +1424,8 @@ func TestConvergeProjectPreviews_GitAPIError(t *testing.T) {
 	}
 
 	err := reconciler.ConvergeProjectPreviews(ctx, project)
-	if err == nil {
-		t.Fatal("expected error from GitAPI, got nil")
+	if err != nil {
+		t.Fatalf("expected nil when PR listing fails for a repo, got %v", err)
 	}
 
 	var peList mortisev1alpha1.PreviewEnvironmentList
@@ -1425,6 +1434,265 @@ func TestConvergeProjectPreviews_GitAPIError(t *testing.T) {
 	}
 	if len(peList.Items) != 0 {
 		t.Errorf("expected no PEs on error, got %d", len(peList.Items))
+	}
+}
+
+func TestConvergencePEName_MultiRepoSanitizesSlug(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      string
+		number    int
+		multiRepo bool
+		want      string
+	}{
+		{
+			name:      "single repo keeps classic name",
+			repo:      "https://github.com/org/repo_name.git",
+			number:    42,
+			multiRepo: false,
+			want:      "preview-pr-42",
+		},
+		{
+			name:      "underscores and git suffix are normalized",
+			repo:      "https://github.com/org/repo_name.git",
+			number:    42,
+			multiRepo: true,
+			want:      "preview-repo-name-pr-42",
+		},
+		{
+			name:      "ssh style repo URL is normalized",
+			repo:      "git@github.com:org/another.repo_name/",
+			number:    7,
+			multiRepo: true,
+			want:      "preview-another-repo-name-pr-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convergencePEName(tt.repo, tt.number, tt.multiRepo)
+			if got != tt.want {
+				t.Fatalf("convergencePEName(%q, %d, %t) = %q, want %q", tt.repo, tt.number, tt.multiRepo, got, tt.want)
+			}
+		})
+	}
+
+	longName := convergencePEName("https://github.com/org/THIS_IS_A_VERY_LONG_REPOSITORY_NAME_WITH_EXTRA_PARTS_AND_SUFFIX.git", 123456, true)
+	if len(longName) > 63 {
+		t.Fatalf("expected PE name to fit DNS label limit, got %q (%d chars)", longName, len(longName))
+	}
+	if strings.ContainsAny(longName, "_.") {
+		t.Fatalf("expected sanitized PE name without invalid DNS label chars, got %q", longName)
+	}
+}
+
+func TestConvergeProjectPreviews_MultiRepoSanitizesNames(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-multirepo"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	apps := []client.Object{
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "https://github.com/org/repo_name.git",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "git@github.com:org/another.repo_name/",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	objects := append([]client.Object{project, gp, pm, tokenSecret}, apps...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+
+	mock := &mockGitAPI{
+		openPRsByRepo: map[string][]git.PullRequestSnapshot{
+			"https://github.com/org/repo_name.git":  {{Number: 10, Branch: "feat-a", SHA: "aaa"}},
+			"git@github.com:org/another.repo_name/": {{Number: 20, Branch: "feat-b", SHA: "bbb"}},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 2 {
+		t.Fatalf("expected 2 PEs, got %d", len(peList.Items))
+	}
+
+	gotNames := map[string]bool{}
+	for _, pe := range peList.Items {
+		gotNames[pe.Name] = true
+		if len(pe.Name) > 63 {
+			t.Fatalf("PE name %q exceeds 63 chars", pe.Name)
+		}
+	}
+
+	if !gotNames["preview-repo-name-pr-10"] {
+		t.Fatalf("expected sanitized PE name for repo_name.git, got %v", gotNames)
+	}
+	if !gotNames["preview-another-repo-name-pr-20"] {
+		t.Fatalf("expected sanitized PE name for another.repo_name, got %v", gotNames)
+	}
+}
+
+func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-continue"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	apps := []client.Object{
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "https://github.com/org/fails",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+		&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        "https://github.com/org/works",
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		},
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	objects := append([]client.Object{project, gp, pm, tokenSecret}, apps...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+
+	mock := &mockGitAPI{
+		openPRsByRepo: map[string][]git.PullRequestSnapshot{
+			"https://github.com/org/works": {{Number: 31, Branch: "human-feat", SHA: "eee"}},
+		},
+		errByRepo: map[string]error{
+			"https://github.com/org/fails": fmt.Errorf("forge API unavailable"),
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("expected convergence to continue after per-repo PR list failure, got %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 1 {
+		t.Fatalf("expected 1 PE from the healthy repo, got %d", len(peList.Items))
+	}
+	if peList.Items[0].Name != "preview-works-pr-31" {
+		t.Fatalf("expected PE from healthy repo, got %q", peList.Items[0].Name)
 	}
 }
 

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -1439,40 +1439,43 @@ func TestConvergeProjectPreviews_GitAPIErrorSkipsRepo(t *testing.T) {
 
 func TestConvergencePEName_MultiRepoSanitizesSlug(t *testing.T) {
 	tests := []struct {
-		name      string
-		repo      string
-		number    int
-		multiRepo bool
-		want      string
+		name       string
+		repo       string
+		number     int
+		multiRepo  bool
+		wantPrefix string
 	}{
 		{
-			name:      "single repo keeps classic name",
-			repo:      "https://github.com/org/repo_name.git",
-			number:    42,
-			multiRepo: false,
-			want:      "preview-pr-42",
+			name:       "single repo keeps classic name",
+			repo:       "https://github.com/org/repo_name.git",
+			number:     42,
+			multiRepo:  false,
+			wantPrefix: "preview-pr-42",
 		},
 		{
-			name:      "underscores and git suffix are normalized",
-			repo:      "https://github.com/org/repo_name.git",
-			number:    42,
-			multiRepo: true,
-			want:      "preview-repo-name-pr-42",
+			name:       "underscores and git suffix are normalized",
+			repo:       "https://github.com/org/repo_name.git",
+			number:     42,
+			multiRepo:  true,
+			wantPrefix: "preview-repo-name-",
 		},
 		{
-			name:      "ssh style repo URL is normalized",
-			repo:      "git@github.com:org/another.repo_name/",
-			number:    7,
-			multiRepo: true,
-			want:      "preview-another-repo-name-pr-7",
+			name:       "ssh style repo URL is normalized",
+			repo:       "git@github.com:org/another.repo_name/",
+			number:     7,
+			multiRepo:  true,
+			wantPrefix: "preview-another-repo-name-",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convergencePEName(tt.repo, tt.number, tt.multiRepo)
-			if got != tt.want {
-				t.Fatalf("convergencePEName(%q, %d, %t) = %q, want %q", tt.repo, tt.number, tt.multiRepo, got, tt.want)
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Fatalf("convergencePEName(%q, %d, %t) = %q, want prefix %q", tt.repo, tt.number, tt.multiRepo, got, tt.wantPrefix)
+			}
+			if tt.multiRepo && !strings.HasSuffix(got, fmt.Sprintf("-pr-%d", tt.number)) {
+				t.Fatalf("expected PR suffix in %q", got)
 			}
 		})
 	}
@@ -1483,6 +1486,26 @@ func TestConvergencePEName_MultiRepoSanitizesSlug(t *testing.T) {
 	}
 	if strings.ContainsAny(longName, "_.") {
 		t.Fatalf("expected sanitized PE name without invalid DNS label chars, got %q", longName)
+	}
+}
+
+func TestConvergencePEName_MultiRepoCollisionGetsDistinctNames(t *testing.T) {
+	repos := []string{
+		"https://github.com/org/foo.bar",
+		"https://github.com/org/foo_bar",
+		"https://github.com/org/foo-bar",
+	}
+
+	got := map[string]string{}
+	for _, repo := range repos {
+		name := convergencePEName(repo, 42, true)
+		if !strings.HasPrefix(name, "preview-foo-bar-") {
+			t.Fatalf("expected normalized readable prefix for %q, got %q", repo, name)
+		}
+		if existingRepo, exists := got[name]; exists {
+			t.Fatalf("expected distinct names, but %q and %q both produced %q", existingRepo, repo, name)
+		}
+		got[name] = repo
 	}
 }
 
@@ -1588,11 +1611,116 @@ func TestConvergeProjectPreviews_MultiRepoSanitizesNames(t *testing.T) {
 		}
 	}
 
-	if !gotNames["preview-repo-name-pr-10"] {
+	if !gotNames[convergencePEName("https://github.com/org/repo_name.git", 10, true)] {
 		t.Fatalf("expected sanitized PE name for repo_name.git, got %v", gotNames)
 	}
-	if !gotNames["preview-another-repo-name-pr-20"] {
+	if !gotNames[convergencePEName("git@github.com:org/another.repo_name/", 20, true)] {
 		t.Fatalf("expected sanitized PE name for another.repo_name, got %v", gotNames)
+	}
+}
+
+func TestConvergeProjectPreviews_MultiRepoCollisionCreatesDistinctPEs(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-collision"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+
+	repos := []string{
+		"https://github.com/org/foo.bar",
+		"https://github.com/org/foo_bar",
+		"https://github.com/org/foo-bar",
+	}
+
+	var apps []client.Object
+	for i, repo := range repos {
+		apps = append(apps, &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("web-%d", i), Namespace: nsName},
+			Spec: mortisev1alpha1.AppSpec{
+				Source: mortisev1alpha1.AppSource{
+					Type:        mortisev1alpha1.SourceTypeGit,
+					Repo:        repo,
+					Branch:      "main",
+					ProviderRef: "github-converge",
+				},
+			},
+		})
+	}
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	objects := append([]client.Object{project, gp, pm, tokenSecret}, apps...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+
+	mock := &mockGitAPI{
+		openPRsByRepo: map[string][]git.PullRequestSnapshot{
+			repos[0]: {{Number: 42, Branch: "feat-a", SHA: "aaa"}},
+			repos[1]: {{Number: 42, Branch: "feat-b", SHA: "bbb"}},
+			repos[2]: {{Number: 42, Branch: "feat-c", SHA: "ccc"}},
+		},
+	}
+
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	if err := reconciler.ConvergeProjectPreviews(ctx, project); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := c.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+	if len(peList.Items) != 3 {
+		t.Fatalf("expected 3 distinct PEs, got %d", len(peList.Items))
+	}
+
+	gotNames := map[string]bool{}
+	for _, repo := range repos {
+		gotNames[convergencePEName(repo, 42, true)] = false
+	}
+	for _, pe := range peList.Items {
+		gotNames[pe.Name] = true
+	}
+	for name, present := range gotNames {
+		if !present {
+			t.Fatalf("expected PE %q to exist, got %v", name, gotNames)
+		}
 	}
 }
 
@@ -1662,7 +1790,7 @@ func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing
 
 	existingFailedRepoPE := &mortisev1alpha1.PreviewEnvironment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "preview-fails-pr-30",
+			Name:              convergencePEName("https://github.com/org/fails", 30, true),
 			Namespace:         nsName,
 			CreationTimestamp: oldEnough,
 		},
@@ -1712,10 +1840,10 @@ func TestConvergeProjectPreviews_ListOpenPullRequestsContinuesPerRepo(t *testing
 			gotNames[pe.Name] = true
 		}
 	}
-	if !gotNames["preview-fails-pr-30"] {
+	if !gotNames[convergencePEName("https://github.com/org/fails", 30, true)] {
 		t.Fatalf("expected failed repo PE to be preserved, got %v", gotNames)
 	}
-	if !gotNames["preview-works-pr-31"] {
+	if !gotNames[convergencePEName("https://github.com/org/works", 31, true)] {
 		t.Fatalf("expected PE from healthy repo, got %v", gotNames)
 	}
 }

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -265,7 +265,7 @@ func wrapGitHubError(err error) error {
 		return nil
 	}
 	var ghErr *gogithub.ErrorResponse
-	if errors.Is(err, ghErr) || errors.As(err, &ghErr) {
+	if errors.As(err, &ghErr) {
 		if ghErr.Response != nil && (ghErr.Response.StatusCode == 401 || ghErr.Response.StatusCode == 403) {
 			return fmt.Errorf("%w: token may be expired or revoked (HTTP %d)", ErrAuthFailed, ghErr.Response.StatusCode)
 		}

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -6,11 +6,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	gogithub "github.com/google/go-github/v66/github"
 )
 
 // newTestGitHubAPI creates a GitHubAPI pointing at the given httptest server.
@@ -422,5 +426,22 @@ func TestGitHub_PostCommitStatus_InvalidRepo(t *testing.T) {
 	err := api.PostCommitStatus(context.Background(), "noslash", "abc", CommitStatus{State: StatusSuccess})
 	if err == nil {
 		t.Error("expected error for invalid repo format")
+	}
+}
+
+func TestWrapGitHubError_AuthFailure(t *testing.T) {
+	err := wrapGitHubError(fmt.Errorf("github call failed: %w", &gogithub.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusUnauthorized},
+	}))
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("expected ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestWrapGitHubError_NonGitHubErrorResponse(t *testing.T) {
+	original := fmt.Errorf("network down")
+	err := wrapGitHubError(original)
+	if err != original {
+		t.Fatalf("expected original error, got %v", err)
 	}
 }

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -339,7 +339,7 @@ func projectHasMultipleGitRepos(apps []mortisev1alpha1.App, projectName string) 
 		if app.Namespace != controlNs || app.Spec.Source.Type != mortisev1alpha1.SourceTypeGit || app.Spec.Source.Repo == "" {
 			continue
 		}
-		key := app.Spec.Source.ProviderRef + "\x00" + app.Spec.Source.Repo
+		key := app.Spec.Source.ProviderRef + "\x00" + constants.CanonicalRepoKey(app.Spec.Source.Repo)
 		seen[key] = true
 		if len(seen) > 1 {
 			return true

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -10,7 +10,6 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -210,6 +209,7 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 	// PR's repo and provider. We only need one PE per project.
 	projectCache := make(map[string]*mortisev1alpha1.Project)
 	projectKnown := make(map[string]bool)
+	projectMultiRepo := make(map[string]bool)
 
 	for i := range apps {
 		app := &apps[i]
@@ -229,6 +229,7 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 			log.Info("skipping app not in control namespace", "app", app.Name, "namespace", app.Namespace)
 			continue
 		}
+		projectMultiRepo[projectName] = projectHasMultipleGitRepos(apps, projectName)
 		if projectKnown[projectName] {
 			continue
 		}
@@ -249,7 +250,7 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 
 	for projectName, project := range projectCache {
 		controlNs := constants.ControlNamespace(projectName)
-		peName := previewEnvName(pr.Number)
+		peName := previewEnvName(pr.Repo, pr.Number, projectMultiRepo[projectName])
 
 		if pr.Action == "closed" {
 			h.deletePreviewForPR(ctx, controlNs, peName, projectName, pr.Number)
@@ -327,8 +328,25 @@ func (h *Handler) deletePreviewForPR(ctx context.Context, namespace, name, proje
 	log.Info("deleted PreviewEnvironment", "project", projectName, "pe", name, "pr", prNumber)
 }
 
-func previewEnvName(prNumber int) string {
-	return fmt.Sprintf("preview-pr-%d", prNumber)
+func previewEnvName(repo string, prNumber int, multiRepo bool) string {
+	return constants.PreviewEnvironmentName(repo, prNumber, multiRepo)
+}
+
+func projectHasMultipleGitRepos(apps []mortisev1alpha1.App, projectName string) bool {
+	controlNs := constants.ControlNamespace(projectName)
+	seen := make(map[string]bool)
+	for i := range apps {
+		app := &apps[i]
+		if app.Namespace != controlNs || app.Spec.Source.Type != mortisev1alpha1.SourceTypeGit || app.Spec.Source.Repo == "" {
+			continue
+		}
+		key := app.Spec.Source.ProviderRef + "\x00" + app.Spec.Source.Repo
+		seen[key] = true
+		if len(seen) > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveSourceEnv(project *mortisev1alpha1.Project) string {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -395,15 +394,7 @@ func ownerRepo(normalized string) string {
 
 // normalizeRepo returns a canonical lowercased string for comparison.
 func normalizeRepo(raw string) string {
-	raw = strings.TrimSuffix(raw, ".git")
-
-	if strings.Contains(raw, "://") {
-		u, err := url.Parse(raw)
-		if err == nil {
-			return strings.ToLower(u.Host) + "/" + strings.ToLower(strings.TrimPrefix(u.Path, "/"))
-		}
-	}
-	return strings.ToLower(raw)
+	return constants.CanonicalRepoKey(raw)
 }
 
 // BuildRequest is the parsed push event payload.

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -820,14 +820,15 @@ func TestGitHubPREvent_Reopened_CreatesPreviewEnvironment(t *testing.T) {
 func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(t *testing.T) {
 	const secret = "prsecret"
 	const providerName = "github-main"
-	const repo = "org/foo.bar"
+	const eventRepo = "org/foo.bar"
+	const appRepo = "https://github.com/org/foo.bar"
 
 	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
-	targetApp := makeGitApp("target", "pj-default", "https://github.com/"+repo, "main")
+	targetApp := makeGitApp("target", "pj-default", appRepo, "main")
 	otherApp := makeGitApp("other", "pj-default", "https://github.com/org/other-repo", "main")
 	proj := makeProject("default", &mortisev1alpha1.PreviewConfig{Enabled: true})
 	proj.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
-	expectedName := constants.PreviewEnvironmentName(repo, 42, true)
+	expectedName := constants.PreviewEnvironmentName(appRepo, 42, true)
 
 	kr := &fakeK8sReader{
 		provider: gp,
@@ -837,7 +838,7 @@ func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(
 	}
 	h := newTestHandler(kr)
 
-	openedBody := githubPRPayloadJSON("opened", 42, "feature/x", "sha-opened", repo)
+	openedBody := githubPRPayloadJSON("opened", 42, "feature/x", "sha-opened", eventRepo)
 	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(openedBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "pull_request")
@@ -861,7 +862,7 @@ func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(
 		"pj-default/" + expectedName: &existing,
 	}
 
-	syncBody := githubPRPayloadJSON("synchronize", 42, "feature/x", "sha-sync", repo)
+	syncBody := githubPRPayloadJSON("synchronize", 42, "feature/x", "sha-sync", eventRepo)
 	req = httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(syncBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "pull_request")
@@ -883,7 +884,7 @@ func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(
 		t.Fatalf("synchronize: expected SHA sha-sync, got %q", kr.updatedPreviews[0].Spec.PullRequest.SHA)
 	}
 
-	closedBody := githubPRPayloadJSON("closed", 42, "feature/x", "sha-sync", repo)
+	closedBody := githubPRPayloadJSON("closed", 42, "feature/x", "sha-sync", eventRepo)
 	req = httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(closedBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "pull_request")

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -904,6 +904,44 @@ func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(
 	}
 }
 
+func TestGitHubPREvent_MixedRepoSyntaxStaysSingleRepo(t *testing.T) {
+	const secret = "prsecret"
+	const providerName = "github-main"
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	appA := makeGitApp("target", "pj-default", "https://github.com/org/repo.git", "main")
+	appB := makeGitApp("other", "pj-default", "git@github.com:org/repo.git", "main")
+	proj := makeProject("default", &mortisev1alpha1.PreviewConfig{Enabled: true})
+	proj.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
+
+	kr := &fakeK8sReader{
+		provider: gp,
+		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
+		apps:     []mortisev1alpha1.App{appA, appB},
+		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+	}
+	h := newTestHandler(kr)
+
+	body := githubPRPayloadJSON("opened", 42, "feature/x", "sha-opened", "org/repo")
+	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("opened: expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.createdPreviews) != 1 {
+		t.Fatalf("opened: expected 1 PE created, got %d", len(kr.createdPreviews))
+	}
+	if kr.createdPreviews[0].Name != "preview-pr-42" {
+		t.Fatalf("opened: expected legacy single-repo PE name, got %q", kr.createdPreviews[0].Name)
+	}
+}
+
 func TestGiteaPREvent_Opened_CreatesPreviewEnvironment(t *testing.T) {
 	const secret = "giteaprsecret"
 	const providerName = "gitea-homelab"

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
 	"github.com/mortise-org/mortise/internal/git"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -813,6 +814,92 @@ func TestGitHubPREvent_Reopened_CreatesPreviewEnvironment(t *testing.T) {
 	}
 	if pe.Spec.PullRequest.SHA != "shareopened" {
 		t.Errorf("sha mismatch: %q", pe.Spec.PullRequest.SHA)
+	}
+}
+
+func TestGitHubPREvent_MultiRepoUsesConvergencePreviewNameForCreateUpdateDelete(t *testing.T) {
+	const secret = "prsecret"
+	const providerName = "github-main"
+	const repo = "org/foo.bar"
+
+	gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+	targetApp := makeGitApp("target", "pj-default", "https://github.com/"+repo, "main")
+	otherApp := makeGitApp("other", "pj-default", "https://github.com/org/other-repo", "main")
+	proj := makeProject("default", &mortisev1alpha1.PreviewConfig{Enabled: true})
+	proj.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
+	expectedName := constants.PreviewEnvironmentName(repo, 42, true)
+
+	kr := &fakeK8sReader{
+		provider: gp,
+		secrets:  map[string]string{"mortise-system/wh-secret/value": secret},
+		apps:     []mortisev1alpha1.App{targetApp, otherApp},
+		projects: map[string]*mortisev1alpha1.Project{"default": proj},
+	}
+	h := newTestHandler(kr)
+
+	openedBody := githubPRPayloadJSON("opened", 42, "feature/x", "sha-opened", repo)
+	req := httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(openedBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(openedBody, secret))
+
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("opened: expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.createdPreviews) != 1 {
+		t.Fatalf("opened: expected 1 PE created, got %d", len(kr.createdPreviews))
+	}
+	if kr.createdPreviews[0].Name != expectedName {
+		t.Fatalf("opened: expected PE name %q, got %q", expectedName, kr.createdPreviews[0].Name)
+	}
+
+	existing := kr.createdPreviews[0]
+	kr.previewEnvs = map[string]*mortisev1alpha1.PreviewEnvironment{
+		"pj-default/" + expectedName: &existing,
+	}
+
+	syncBody := githubPRPayloadJSON("synchronize", 42, "feature/x", "sha-sync", repo)
+	req = httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(syncBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(syncBody, secret))
+
+	rr = httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("synchronize: expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.updatedPreviews) != 1 {
+		t.Fatalf("synchronize: expected 1 PE updated, got %d", len(kr.updatedPreviews))
+	}
+	if kr.updatedPreviews[0].Name != expectedName {
+		t.Fatalf("synchronize: expected update to target %q, got %q", expectedName, kr.updatedPreviews[0].Name)
+	}
+	if kr.updatedPreviews[0].Spec.PullRequest.SHA != "sha-sync" {
+		t.Fatalf("synchronize: expected SHA sha-sync, got %q", kr.updatedPreviews[0].Spec.PullRequest.SHA)
+	}
+
+	closedBody := githubPRPayloadJSON("closed", 42, "feature/x", "sha-sync", repo)
+	req = httptest.NewRequest(http.MethodPost, "/"+providerName, bytes.NewReader(closedBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", githubSignature(closedBody, secret))
+
+	rr = httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("closed: expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(kr.deletedKeys) != 1 {
+		t.Fatalf("closed: expected 1 PE delete, got %d", len(kr.deletedKeys))
+	}
+	if kr.deletedKeys[0] != "pj-default/"+expectedName {
+		t.Fatalf("closed: expected delete key %q, got %q", "pj-default/"+expectedName, kr.deletedKeys[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix preview convergence PE naming so multi-repo names strip `.git`, normalize invalid slug characters, and stay within the Kubernetes DNS label limit
- skip per-repo `ListOpenPullRequests` failures during convergence instead of aborting the whole project
- remove the unsafe nil-sensitive `errors.Is` path from `wrapGitHubError` and keep auth error wrapping on `errors.As`

Closes #381.

## Validation
- `go test ./internal/controller -run 'TestConvergeProjectPreviews_|TestConvergencePEName_|TestCloneEnvironment_NoSourceEnv_ReturnsBare'`
- `go test ./internal/git -run 'TestGitHub_|TestWrapGitHubError_'`
- `make test`
