### PR TITLE
[codex] Ignore preview-only build failures in app phase

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -888,9 +888,10 @@ func isTerminalBuildFailurePhase(phase mortisev1alpha1.BuildRunPhase) bool {
 	return phase == mortisev1alpha1.BuildRunPhaseFailed
 }
 
-func envExcludedFromTopLevelReadinessAggregation(es mortisev1alpha1.EnvironmentStatus, previewEnvNames, buildAggregationEnvNames map[string]struct{}) bool {
+func envExcludedFromTopLevelReadinessAggregation(es mortisev1alpha1.EnvironmentStatus, previewEnvNames, buildAggregationEnvNames map[string]struct{}, workloadPresent bool) bool {
 	if !envSelectedForBuildFailureAggregation(es.Name, buildAggregationEnvNames) {
 		if _, isPreview := previewEnvNames[es.Name]; isPreview &&
+			!workloadPresent &&
 			es.CurrentBuildRunRef != nil &&
 			isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
 			return true
@@ -2814,9 +2815,11 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			rollingOut := false
 			restartedAt := ""
 			deployedHash := ""
+			workloadPresent := false
 			if isCron {
 				var cj batchv1.CronJob
 				if err := r.Get(ctx, types.NamespacedName{Name: cronJobName(app.Name), Namespace: envNs}, &cj); err == nil {
+					workloadPresent = true
 					es.ReadyReplicas = 1
 					deployedHash = cj.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]
 				}
@@ -2824,6 +2827,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 				name := deploymentName(app.Name)
 				var dep appsv1.Deployment
 				if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &dep); err == nil {
+					workloadPresent = true
 					es.ReadyReplicas = dep.Status.ReadyReplicas
 					if deploymentRollingOut(&dep) {
 						rollingOut = true
@@ -2870,7 +2874,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			// completes, even if readyReplicas temporarily satisfies the check.
 			newRestart := restartedAt != "" && restartedAt != es.LastProcessedRestartedAt
 
-			excludeFromTopLevelReadiness := envExcludedFromTopLevelReadinessAggregation(es, previewEnvNames, buildAggregationEnvNames)
+			excludeFromTopLevelReadiness := envExcludedFromTopLevelReadinessAggregation(es, previewEnvNames, buildAggregationEnvNames, workloadPresent)
 
 			if ready && !newRestart {
 				if restartedAt != "" {

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -532,33 +532,6 @@ type envBuildIdentity struct {
 	revision string
 }
 
-func resolvedPreviewEnvNames(project *mortisev1alpha1.Project, resolvedEnvs []mortisev1alpha1.Environment) map[string]struct{} {
-	if project == nil || len(project.Spec.Environments) == 0 || len(resolvedEnvs) == 0 {
-		return nil
-	}
-
-	projectPreviewByName := make(map[string]struct{}, len(project.Spec.Environments))
-	for _, env := range project.Spec.Environments {
-		if env.Preview {
-			projectPreviewByName[env.Name] = struct{}{}
-		}
-	}
-	if len(projectPreviewByName) == 0 {
-		return nil
-	}
-
-	out := make(map[string]struct{})
-	for _, env := range resolvedEnvs {
-		if _, ok := projectPreviewByName[env.Name]; ok {
-			out[env.Name] = struct{}{}
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
 func (r *AppReconciler) previewBuildIdentitiesByEnv(ctx context.Context, namespace string, previewEnvNames map[string]struct{}) (map[string]previewBuildIdentity, error) {
 	if len(previewEnvNames) == 0 {
 		return nil, nil

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -630,7 +630,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 				if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
 					return "", false, false, false, err
 				}
-				return "", false, false, false, nil
+				return "", false, true, false, nil
 			default:
 				app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 				meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
@@ -670,7 +670,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
 			return "", false, false, false, err
 		}
-		return "", false, false, false, nil
+		return "", false, true, false, nil
 	default:
 		app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 		meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -350,7 +350,8 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
-	if !needsRequeue && app.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+	if !needsRequeue && (app.Status.Phase != mortisev1alpha1.AppPhaseFailed ||
+		shouldRefreshFailedAppStatus(&app, resolvedEnvs, previewEnvNames)) {
 		if err := r.updateStatus(ctx, &app, resolvedEnvs, previewEnvNames); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update status: %w", err)
 		}
@@ -908,6 +909,40 @@ func selectedEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.Environmen
 		}
 	}
 	return false
+}
+
+func previewEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.EnvironmentStatus, previewEnvNames map[string]struct{}) bool {
+	for _, es := range envStatuses {
+		if _, isPreview := previewEnvNames[es.Name]; !isPreview {
+			continue
+		}
+		if es.CurrentBuildRunRef != nil && isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment, previewEnvNames map[string]struct{}) bool {
+	if app.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		return false
+	}
+
+	buildFailureCond := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded")
+	if !isTerminalBuildFailureCondition(buildFailureCond) {
+		return false
+	}
+
+	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
+	if len(buildAggregationEnvNames) == 0 || len(buildAggregationEnvNames) == len(resolvedEnvs) {
+		return false
+	}
+
+	if selectedEnvHasTerminalBuildFailure(app.Status.Environments, buildAggregationEnvNames) {
+		return false
+	}
+
+	return previewEnvHasTerminalBuildFailure(app.Status.Environments, previewEnvNames)
 }
 
 // currentImageForEnv returns the image currently deployed for the given

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -912,9 +912,9 @@ func selectedEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.Environmen
 	return false
 }
 
-func previewEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.EnvironmentStatus, previewEnvNames map[string]struct{}) bool {
+func excludedEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.EnvironmentStatus, aggregationEnvNames map[string]struct{}) bool {
 	for _, es := range envStatuses {
-		if _, isPreview := previewEnvNames[es.Name]; !isPreview {
+		if envSelectedForBuildFailureAggregation(es.Name, aggregationEnvNames) {
 			continue
 		}
 		if es.CurrentBuildRunRef != nil && isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
@@ -935,7 +935,7 @@ func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, resolvedEnvs []morti
 	}
 
 	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
-	if len(buildAggregationEnvNames) == 0 || len(buildAggregationEnvNames) == len(resolvedEnvs) {
+	if len(buildAggregationEnvNames) == 0 {
 		return false
 	}
 
@@ -943,7 +943,7 @@ func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, resolvedEnvs []morti
 		return false
 	}
 
-	return previewEnvHasTerminalBuildFailure(app.Status.Environments, previewEnvNames)
+	return excludedEnvHasTerminalBuildFailure(app.Status.Environments, buildAggregationEnvNames)
 }
 
 // currentImageForEnv returns the image currently deployed for the given
@@ -2920,9 +2920,9 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		}
 
 		buildFailureCond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+		buildFailureOutsideAggregation := excludedEnvHasTerminalBuildFailure(fresh.Status.Environments, buildAggregationEnvNames)
 		buildFailed := isTerminalBuildFailureCondition(buildFailureCond)
-		previewExcludedFromBuildAggregation := len(buildAggregationEnvNames) > 0 && len(buildAggregationEnvNames) < len(envStatuses)
-		if buildFailed && previewExcludedFromBuildAggregation {
+		if buildFailed && buildFailureOutsideAggregation {
 			buildFailed = selectedEnvHasTerminalBuildFailure(envStatuses, buildAggregationEnvNames)
 		}
 		anyServing := false
@@ -2968,7 +2968,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			} else if !anyCrash {
 				phase = mortisev1alpha1.AppPhaseFailed
 			}
-		} else if previewExcludedFromBuildAggregation && buildFailureCond != nil && isTerminalBuildFailureCondition(buildFailureCond) {
+		} else if buildFailureOutsideAggregation && buildFailureCond != nil && isTerminalBuildFailureCondition(buildFailureCond) {
 			meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
 				Type:               "BuildSucceeded",
 				Status:             metav1.ConditionTrue,

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2131,6 +2131,9 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 			})
 		}
 	}
+	if len(existing) == 0 && len(toMerge) == 0 && len(bindingEnvs) == 0 {
+		return nil
+	}
 	return store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels)
 }
 

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -351,7 +351,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if !needsRequeue && app.Status.Phase != mortisev1alpha1.AppPhaseFailed {
-		if err := r.updateStatus(ctx, &app, resolvedEnvs); err != nil {
+		if err := r.updateStatus(ctx, &app, resolvedEnvs, previewEnvNames); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update status: %w", err)
 		}
 	}
@@ -873,6 +873,41 @@ func envStatusFor(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.Env
 		}
 	}
 	return nil
+}
+
+func envSelectedForBuildFailureAggregation(envName string, aggregationEnvNames map[string]struct{}) bool {
+	if len(aggregationEnvNames) == 0 {
+		return false
+	}
+	_, ok := aggregationEnvNames[envName]
+	return ok
+}
+
+func isTerminalBuildFailurePhase(phase mortisev1alpha1.BuildRunPhase) bool {
+	return phase == mortisev1alpha1.BuildRunPhaseFailed
+}
+
+func envExcludedFromTopLevelReadinessAggregation(es mortisev1alpha1.EnvironmentStatus, previewEnvNames, buildAggregationEnvNames map[string]struct{}) bool {
+	if !envSelectedForBuildFailureAggregation(es.Name, buildAggregationEnvNames) {
+		if _, isPreview := previewEnvNames[es.Name]; isPreview &&
+			es.CurrentBuildRunRef != nil &&
+			isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
+			return true
+		}
+	}
+	return false
+}
+
+func selectedEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.EnvironmentStatus, aggregationEnvNames map[string]struct{}) bool {
+	for _, es := range envStatuses {
+		if !envSelectedForBuildFailureAggregation(es.Name, aggregationEnvNames) {
+			continue
+		}
+		if es.CurrentBuildRunRef != nil && isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
+			return true
+		}
+	}
+	return false
 }
 
 // currentImageForEnv returns the image currently deployed for the given
@@ -2696,7 +2731,7 @@ func healthRequeueAfter(app *mortisev1alpha1.App, clk clock.Clock) time.Duration
 // parent project isn't reachable (nil resolvedEnvs), Status.Environments is
 // cleared rather than stale — callers have already logged the underlying
 // cause at fetch time.
-func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment) error {
+func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment, previewEnvNames map[string]struct{}) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Re-read the App first to get the latest resourceVersion and any
 		// status written by the API (e.g. Phase=Deploying from a manual
@@ -2714,6 +2749,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		}
 
 		envStatuses := make([]mortisev1alpha1.EnvironmentStatus, 0, len(resolvedEnvs))
+		buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
 
 		isCron := app.Spec.Kind == mortisev1alpha1.AppKindCron
 
@@ -2799,6 +2835,8 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			// completes, even if readyReplicas temporarily satisfies the check.
 			newRestart := restartedAt != "" && restartedAt != es.LastProcessedRestartedAt
 
+			excludeFromTopLevelReadiness := envExcludedFromTopLevelReadinessAggregation(es, previewEnvNames, buildAggregationEnvNames)
+
 			if ready && !newRestart {
 				if restartedAt != "" {
 					es.LastProcessedRestartedAt = restartedAt
@@ -2810,7 +2848,9 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 					es.Phase = mortisev1alpha1.AppPhaseReady
 				} else {
 					es.Phase = mortisev1alpha1.AppPhaseDeploying
-					anyNotReady = true
+					if !excludeFromTopLevelReadiness {
+						anyNotReady = true
+					}
 				}
 			} else {
 				es.Phase = mortisev1alpha1.AppPhaseDeploying
@@ -2824,7 +2864,9 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 						}
 					}
 				}
-				anyNotReady = true
+				if !excludeFromTopLevelReadiness {
+					anyNotReady = true
+				}
 			}
 
 			if app.Spec.Network.Public && es.Domain != "" {
@@ -2840,6 +2882,10 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 
 		buildFailureCond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
 		buildFailed := isTerminalBuildFailureCondition(buildFailureCond)
+		previewExcludedFromBuildAggregation := len(buildAggregationEnvNames) > 0 && len(buildAggregationEnvNames) < len(envStatuses)
+		if buildFailed && previewExcludedFromBuildAggregation {
+			buildFailed = selectedEnvHasTerminalBuildFailure(envStatuses, buildAggregationEnvNames)
+		}
 		anyServing := false
 		for _, es := range envStatuses {
 			if es.Phase == mortisev1alpha1.AppPhaseReady {
@@ -2883,6 +2929,15 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			} else if !anyCrash {
 				phase = mortisev1alpha1.AppPhaseFailed
 			}
+		} else if previewExcludedFromBuildAggregation && buildFailureCond != nil && isTerminalBuildFailureCondition(buildFailureCond) {
+			meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
+				Type:               "BuildSucceeded",
+				Status:             metav1.ConditionTrue,
+				Reason:             "BuildComplete",
+				Message:            "latest non-preview builds succeeded",
+				LastTransitionTime: metav1.NewTime(r.clock().Now()),
+				ObservedGeneration: app.Generation,
+			})
 		}
 
 		fresh.Status.Phase = phase

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -63,6 +63,50 @@ var (
 // Hoisted to package scope so it is visible from multiple Describe blocks.
 const testImageNginx = "nginx:1.27"
 
+func newAppStatusTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return scheme
+}
+
+func newReadyDeploymentForStatusTest(t *testing.T, app *mortisev1alpha1.App, envName string) *appsv1.Deployment {
+	t.Helper()
+
+	envNs, err := appEnvNs(app, envName)
+	if err != nil {
+		t.Fatalf("app env namespace for %s: %v", envName, err)
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       deploymentName(app.Name),
+			Namespace:  envNs,
+			Generation: 1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](1),
+			Template: corev1.PodTemplateSpec{},
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           1,
+			ReadyReplicas:      1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+		},
+	}
+}
+
 func TestUpdateStatusPreservesBuildRunRefs(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
@@ -103,7 +147,7 @@ func TestUpdateStatusPreservesBuildRunRefs(t *testing.T) {
 		Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	if err := r.updateStatus(context.Background(), app, []mortisev1alpha1.Environment{{Name: "production"}}); err != nil {
+	if err := r.updateStatus(context.Background(), app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 
@@ -171,7 +215,7 @@ func TestUpdateStatusRecomputesTopLevelBuildRunNamesFromTerminalEnvRef(t *testin
 		Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	if err := r.updateStatus(context.Background(), app, []mortisev1alpha1.Environment{{Name: "production"}}); err != nil {
+	if err := r.updateStatus(context.Background(), app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 
@@ -257,7 +301,7 @@ func TestUpdateStatusMarksDegradedWhenLatestBuildFailsButPreviousImageStillServe
 		t.Fatalf("seed deployment status: %v", err)
 	}
 
-	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}); err != nil {
+	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 
@@ -323,7 +367,7 @@ func TestUpdateStatusKeepsFailedWhenLatestBuildFailsAndNothingServes(t *testing.
 		Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}); err != nil {
+	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 
@@ -425,7 +469,7 @@ func TestUpdateStatusClearsDegradedAfterSuccessfulRecovery(t *testing.T) {
 		t.Fatalf("seed recovered status: %v", err)
 	}
 
-	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}); err != nil {
+	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 
@@ -435,6 +479,278 @@ func TestUpdateStatusClearsDegradedAfterSuccessfulRecovery(t *testing.T) {
 	}
 	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
 		t.Fatalf("expected phase %q after recovery, got %q", mortisev1alpha1.AppPhaseReady, fresh.Status.Phase)
+	}
+}
+
+func TestUpdateStatusMasksPreviewOnlyBuildFailureWhilePreviewStillServes(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "BuildFailed",
+				Message: "invalid reference format",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name:           "pr-6",
+					LastBuiltImage: "registry.example/demo:preview-old",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+	previewDep := newReadyDeploymentForStatusTest(t, app, "pr-6")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep, previewDep).
+		WithObjects(app, productionDep, previewDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+	if err := c.Status().Update(ctx, previewDep); err != nil {
+		t.Fatalf("seed preview deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected phase %q, got %q", mortisev1alpha1.AppPhaseReady, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Message != "latest non-preview builds succeeded" {
+		t.Fatalf("expected masked top-level build success, got %+v", cond)
+	}
+	previewStatus := envStatusFor(&fresh, "pr-6")
+	if previewStatus == nil || previewStatus.CurrentBuildRunRef == nil || previewStatus.CurrentBuildRunRef.Phase != mortisev1alpha1.BuildRunPhaseFailed {
+		t.Fatalf("expected preview env to retain failed build ref, got %+v", previewStatus)
+	}
+}
+
+func TestUpdateStatusMasksPreviewBuildFailureFromTopLevelPhase(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "BuildFailed",
+				Message: "invalid reference format",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep).
+		WithObjects(app, productionDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected preview build failure to leave top-level phase %q, got %q", mortisev1alpha1.AppPhaseReady, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected top-level BuildSucceeded to ignore preview-only failure, got %+v", cond)
+	}
+}
+
+func TestUpdateStatusFallsBackToPreviewOnlyBuildFailure(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "BuildFailed",
+				Message: "invalid reference format",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app).
+		WithObjects(app).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		t.Fatalf("expected preview-only app to keep phase %q, got %q", mortisev1alpha1.AppPhaseFailed, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected preview-only app to keep failed BuildSucceeded, got %+v", cond)
+	}
+}
+
+func TestUpdateStatusStillCountsPreviewRolloutFailureInTopLevelPhase(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionTrue,
+				Reason:  "BuildComplete",
+				Message: "built registry.example/demo:prod digest=sha256:prod for production",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name: "pr-6",
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep).
+		WithObjects(app, productionDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
+		t.Fatalf("expected preview rollout gap to keep phase %q, got %q", mortisev1alpha1.AppPhaseDeploying, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected build condition to stay successful for preview rollout gap, got %+v", cond)
 	}
 }
 

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -2554,9 +2554,20 @@ var _ = Describe("App Controller", func() {
 
 			// Update the existing env Secret (created by reconcile) to change the env-hash.
 			var envSec corev1.Secret
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
+			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name: envstore.AppEnvSecretName(appName), Namespace: envNsProduction,
-			}, &envSec)).To(Succeed())
+			}, &envSec)
+			if kerrors.IsNotFound(err) {
+				envSec = corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      envstore.AppEnvSecretName(appName),
+						Namespace: envNsProduction,
+					},
+				}
+				Expect(k8sClient.Create(ctx, &envSec)).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 			if envSec.Data == nil {
 				envSec.Data = make(map[string][]byte)
 			}
@@ -6316,7 +6327,7 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(envData).To(HaveKeyWithValue("USER_VAR", "stays"))
 		})
 
-		It("creates empty {app}-env Secret even when there are no vars and no bindings", func() {
+		It("does not create {app}-env Secret when there are no vars and no bindings", func() {
 			appName := "no-vars-app"
 			app := &mortisev1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
@@ -6341,12 +6352,14 @@ var _ = Describe("App Controller — git source", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Secret must exist (for envFrom Optional mount) even though it has no data.
+			// The app-env envFrom source is optional, so there is no need to
+			// materialize an empty Secret when nothing contributes env vars.
 			var sec corev1.Secret
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
+			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      envstore.AppEnvSecretName(appName),
 				Namespace: envNsProduction,
-			}, &sec)).To(Succeed(), "app-env Secret should exist even with no vars")
+			}, &sec)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(), "app-env Secret should be skipped when empty")
 		})
 
 		It("skips binding gracefully when a binding references a missing App CRD", func() {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -754,6 +754,82 @@ func TestUpdateStatusStillCountsPreviewRolloutFailureInTopLevelPhase(t *testing.
 	}
 }
 
+func TestUpdateStatusCountsPreviewNotReadyWhenWorkloadExistsAfterBuildFailure(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "BuildFailed",
+				Message: "invalid reference format",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+	previewDep := newReadyDeploymentForStatusTest(t, app, "pr-6")
+	previewDep.Status.ReadyReplicas = 0
+	previewDep.Status.AvailableReplicas = 0
+	previewDep.Status.UpdatedReplicas = 1
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep, previewDep).
+		WithObjects(app, productionDep, previewDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+	if err := c.Status().Update(ctx, previewDep); err != nil {
+		t.Fatalf("seed preview deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
+		t.Fatalf("expected preview workload readiness gap to keep phase %q, got %q", mortisev1alpha1.AppPhaseDeploying, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected top-level BuildSucceeded to ignore preview build failure while still counting readiness gap, got %+v", cond)
+	}
+}
+
 func TestShouldRefreshFailedAppStatusForPreviewOnlyBuildFailure(t *testing.T) {
 	app := &mortisev1alpha1.App{
 		Status: mortisev1alpha1.AppStatus{

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -830,6 +830,77 @@ func TestUpdateStatusCountsPreviewNotReadyWhenWorkloadExistsAfterBuildFailure(t 
 	}
 }
 
+func TestUpdateStatusRecoversAfterPreviewRemoval(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseFailed,
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "BuildFailed",
+				Message: "invalid reference format",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep).
+		WithObjects(app, productionDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, nil); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected app to recover to %q after preview removal, got %q", mortisev1alpha1.AppPhaseReady, fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected top-level BuildSucceeded to recover after preview removal, got %+v", cond)
+	}
+	if len(fresh.Status.Environments) != 1 || fresh.Status.Environments[0].Name != "production" {
+		t.Fatalf("expected stale preview env status to be removed, got %+v", fresh.Status.Environments)
+	}
+}
+
 func TestShouldRefreshFailedAppStatusForPreviewOnlyBuildFailure(t *testing.T) {
 	app := &mortisev1alpha1.App{
 		Status: mortisev1alpha1.AppStatus{
@@ -857,6 +928,35 @@ func TestShouldRefreshFailedAppStatusForPreviewOnlyBuildFailure(t *testing.T) {
 
 	if !shouldRefreshFailedAppStatus(app, resolvedEnvs, previewEnvNames) {
 		t.Fatal("expected failed app with preview-only build failure to refresh status")
+	}
+}
+
+func TestShouldRefreshFailedAppStatusForRemovedPreviewBuildFailure(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseFailed,
+			Conditions: []metav1.Condition{{
+				Type:   "BuildSucceeded",
+				Status: metav1.ConditionFalse,
+				Reason: "BuildFailed",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{Name: "production"},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}}
+
+	if !shouldRefreshFailedAppStatus(app, resolvedEnvs, nil) {
+		t.Fatal("expected failed app with removed preview build failure to refresh status")
 	}
 }
 

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -754,6 +754,72 @@ func TestUpdateStatusStillCountsPreviewRolloutFailureInTopLevelPhase(t *testing.
 	}
 }
 
+func TestShouldRefreshFailedAppStatusForPreviewOnlyBuildFailure(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseFailed,
+			Conditions: []metav1.Condition{{
+				Type:   "BuildSucceeded",
+				Status: metav1.ConditionFalse,
+				Reason: "BuildFailed",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{Name: "production"},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+
+	if !shouldRefreshFailedAppStatus(app, resolvedEnvs, previewEnvNames) {
+		t.Fatal("expected failed app with preview-only build failure to refresh status")
+	}
+}
+
+func TestShouldRefreshFailedAppStatusSkipsNonPreviewBuildFailure(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseFailed,
+			Conditions: []metav1.Condition{{
+				Type:   "BuildSucceeded",
+				Status: metav1.ConditionFalse,
+				Reason: "BuildFailed",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name: "production",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "production-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+				{
+					Name: "pr-6",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-failed",
+						Phase: mortisev1alpha1.BuildRunPhaseFailed,
+					},
+				},
+			},
+		},
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+
+	if shouldRefreshFailedAppStatus(app, resolvedEnvs, previewEnvNames) {
+		t.Fatal("expected failed app with non-preview build failure to keep failed latch")
+	}
+}
+
 func TestAllEnvBuildsCurrentForRevision_EnvBranchOverridesAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {

--- a/internal/controller/app_env_resolver.go
+++ b/internal/controller/app_env_resolver.go
@@ -103,3 +103,56 @@ func resolvedEnvNames(envs []mortisev1alpha1.Environment) map[string]struct{} {
 	}
 	return out
 }
+
+// resolvedPreviewEnvNames returns the subset of resolved env names that are
+// marked preview=true on the parent Project.
+func resolvedPreviewEnvNames(project *mortisev1alpha1.Project, resolvedEnvs []mortisev1alpha1.Environment) map[string]struct{} {
+	if project == nil || len(project.Spec.Environments) == 0 || len(resolvedEnvs) == 0 {
+		return nil
+	}
+
+	projectPreviewByName := make(map[string]struct{}, len(project.Spec.Environments))
+	for _, env := range project.Spec.Environments {
+		if env.Preview {
+			projectPreviewByName[env.Name] = struct{}{}
+		}
+	}
+	if len(projectPreviewByName) == 0 {
+		return nil
+	}
+
+	out := make(map[string]struct{})
+	for _, env := range resolvedEnvs {
+		if _, ok := projectPreviewByName[env.Name]; ok {
+			out[env.Name] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// buildFailureAggregationEnvNames returns the env names that should contribute
+// to app-global BuildSucceeded aggregation. When at least one non-preview env
+// exists, previews are excluded so a preview-only build failure does not mark
+// the top-level app as Degraded/Failed. Preview-only apps fall back to the
+// existing all-env aggregation.
+func buildFailureAggregationEnvNames(resolvedEnvs []mortisev1alpha1.Environment, previewEnvNames map[string]struct{}) map[string]struct{} {
+	if len(resolvedEnvs) == 0 {
+		return nil
+	}
+
+	nonPreview := make(map[string]struct{}, len(resolvedEnvs))
+	for _, env := range resolvedEnvs {
+		if _, isPreview := previewEnvNames[env.Name]; isPreview {
+			continue
+		}
+		nonPreview[env.Name] = struct{}{}
+	}
+	if len(nonPreview) > 0 {
+		return nonPreview
+	}
+
+	return resolvedEnvNames(resolvedEnvs)
+}

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -473,6 +474,73 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 	}
 	if es := envStatusFor(app, "production"); es == nil || es.LastBuiltImage != "registry.example.com/demo:new" {
 		t.Fatalf("expected env status updated from manual run, got %+v", es)
+	}
+}
+
+func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision": "same-sha",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:   mortisev1alpha1.SourceTypeGit,
+				Branch: "main",
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			CurrentBuildRunName: "manual-run",
+		},
+	}
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-run",
+			Namespace: app.Namespace,
+		},
+		Spec: appBuildRunSpec(app, "pr-6", "feature/preview-fail", "same-sha", "registry.example.com/mortise/demo:same-sh-pr-6", "registry.example.com/mortise/demo:same-sh-pr-6"),
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:         mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason: "BuildFailed",
+			FailureMessage:"invalid reference format",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, run).WithStatusSubresource(app).Build()
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		RegistryBackend: &fakeRegistryBackend{},
+	}
+
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "pr-6", "feature/preview-fail", "same-sha")
+	if err != nil {
+		t.Fatalf("reconcileEnvBuild: %v", err)
+	}
+	if image != "" {
+		t.Fatalf("expected no image on failed build, got %q", image)
+	}
+	if requeue {
+		t.Fatal("expected failed current run to avoid requeue")
+	}
+	if !statusDirty {
+		t.Fatal("expected failed buildrun projection to dirty status")
+	}
+	es := envStatusFor(app, "pr-6")
+	if es == nil || es.CurrentBuildRunRef == nil || es.CurrentBuildRunRef.Phase != mortisev1alpha1.BuildRunPhaseFailed {
+		t.Fatalf("expected failed buildrun ref to be projected into env status, got %+v", es)
+	}
+	cond := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected app build failure condition to be set, got %+v", cond)
 	}
 }
 

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -378,7 +378,18 @@ func (r *PreviewEnvironmentReconciler) copyAppEnvSecret(ctx context.Context, pro
 	var existing corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: secretName}, &existing)
 	if err == nil {
-		return nil
+		if len(existing.Data) > 0 {
+			return nil
+		}
+		existing.Labels = map[string]string{
+			constants.ProjectLabel:         projectName,
+			constants.AppNameLabel:         appName,
+			constants.EnvironmentLabel:     envName,
+			"app.kubernetes.io/managed-by": "mortise",
+		}
+		existing.Data = source.Data
+		existing.Annotations = copySourceAnnotations(source.Annotations)
+		return r.Update(ctx, &existing)
 	}
 	if !errors.IsNotFound(err) {
 		return err
@@ -788,10 +799,40 @@ func (r *PreviewEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		}
 		return reqs
 	})
+	enqueuePreviewsFromSecret := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
+
+		projectName := secret.Labels[constants.ProjectLabel]
+		envName := secret.Labels[constants.EnvironmentLabel]
+		if projectName == "" || envName == "" || !strings.HasPrefix(envName, "pr-") {
+			return nil
+		}
+
+		controlNs := constants.ControlNamespace(projectName)
+		var peList mortisev1alpha1.PreviewEnvironmentList
+		if err := mgr.GetClient().List(ctx, &peList, client.InNamespace(controlNs)); err != nil {
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(peList.Items))
+		for _, pe := range peList.Items {
+			if fmt.Sprintf("pr-%d", pe.Spec.PullRequest.Number) != envName {
+				continue
+			}
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace},
+			})
+		}
+		return reqs
+	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mortisev1alpha1.PreviewEnvironment{}).
 		Watches(&mortisev1alpha1.App{}, enqueuePreviewsFromApp).
+		Watches(&corev1.Secret{}, enqueuePreviewsFromSecret).
 		Named("previewenvironment").
 		Complete(r)
 }

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -33,7 +33,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/constants"
@@ -151,6 +153,12 @@ func (r *PreviewEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
+	if reason, msg, failed, err := r.previewBuildFailure(ctx, apps.Items, envName); err != nil {
+		return ctrl.Result{}, fmt.Errorf("detect preview build failure: %w", err)
+	} else if failed {
+		return ctrl.Result{}, r.setFailed(ctx, &pe, reason, msg)
+	}
+
 	// Set status to Ready.
 	return ctrl.Result{}, r.updateStatus(ctx, &pe, func(status *mortisev1alpha1.PreviewEnvironmentStatus) {
 		status.Phase = mortisev1alpha1.PreviewPhaseReady
@@ -163,6 +171,36 @@ func (r *PreviewEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 			LastTransitionTime: metav1.NewTime(r.clock().Now()),
 		})
 	})
+}
+
+func (r *PreviewEnvironmentReconciler) previewBuildFailure(ctx context.Context, apps []mortisev1alpha1.App, envName string) (reason, msg string, failed bool, err error) {
+	for i := range apps {
+		app := &apps[i]
+		es := envStatusFor(app, envName)
+		if es == nil || es.CurrentBuildRunRef == nil || es.CurrentBuildRunRef.Phase != mortisev1alpha1.BuildRunPhaseFailed {
+			continue
+		}
+
+		reason = "BuildFailed"
+		msg = fmt.Sprintf("preview build failed for app %q", app.Name)
+		if es.CurrentBuildRunRef.Name == "" {
+			return reason, msg, true, nil
+		}
+
+		var run mortisev1alpha1.BuildRun
+		if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: es.CurrentBuildRunRef.Name}, &run); err != nil {
+			if errors.IsNotFound(err) {
+				return reason, msg, true, nil
+			}
+			return "", "", false, err
+		}
+
+		return firstNonEmpty(run.Status.FailureReason, reason),
+			firstNonEmpty(run.Status.FailureMessage, msg),
+			true,
+			nil
+	}
+	return "", "", false, nil
 }
 
 // ensureProjectEnv adds a ProjectEnvironment entry to the Project spec if one
@@ -731,8 +769,29 @@ func (r *PreviewEnvironmentReconciler) reconcileProjectConvergence(ctx context.C
 }
 
 func (r *PreviewEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	enqueuePreviewsFromApp := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		app, ok := obj.(*mortisev1alpha1.App)
+		if !ok {
+			return nil
+		}
+
+		var peList mortisev1alpha1.PreviewEnvironmentList
+		if err := mgr.GetClient().List(ctx, &peList, client.InNamespace(app.Namespace)); err != nil {
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(peList.Items))
+		for _, pe := range peList.Items {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace},
+			})
+		}
+		return reqs
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mortisev1alpha1.PreviewEnvironment{}).
+		Watches(&mortisev1alpha1.App{}, enqueuePreviewsFromApp).
 		Named("previewenvironment").
 		Complete(r)
 }

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -123,6 +124,103 @@ func newPEReconciler() *PreviewEnvironmentReconciler {
 		Client: k8sClient,
 		Scheme: k8sClient.Scheme(),
 		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+}
+
+func TestPreviewEnvironmentReconcileMarksFailedWhenPreviewAppBuildFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+	pe := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-pr-7",
+			Namespace: constants.ControlNamespace(project.Name),
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef: project.Name,
+			SourceEnv:  "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{
+				Number: 7,
+				Branch: "feature/fail",
+				SHA:    "deadbeef",
+			},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-app",
+			Namespace: pe.Namespace,
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:   mortisev1alpha1.SourceTypeGit,
+				Repo:   "https://github.com/example/repo",
+				Branch: "main",
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "pr-7",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "buildrun-1",
+					Phase: mortisev1alpha1.BuildRunPhaseFailed,
+				},
+			}},
+		},
+	}
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buildrun-1",
+			Namespace: pe.Namespace,
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:          mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason:  "BuildFailed",
+			FailureMessage: "invalid reference format",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pe).
+		WithObjects(project, pe, app, run).
+		Build()
+	r := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: scheme,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace},
+	})
+	if err == nil || !strings.Contains(err.Error(), "BuildFailed") {
+		t.Fatalf("expected BuildFailed error, got %v", err)
+	}
+
+	var updated mortisev1alpha1.PreviewEnvironment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace}, &updated); err != nil {
+		t.Fatalf("get preview environment: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.PreviewPhaseFailed {
+		t.Fatalf("expected preview phase %q, got %q", mortisev1alpha1.PreviewPhaseFailed, updated.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Message != "invalid reference format" {
+		t.Fatalf("expected failed Ready condition with build failure message, got %+v", cond)
 	}
 }
 

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -224,6 +224,100 @@ func TestPreviewEnvironmentReconcileMarksFailedWhenPreviewAppBuildFails(t *testi
 	}
 }
 
+func TestPreviewEnvironmentReconcileHydratesEmptyPreviewAppSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+	controlNs := constants.ControlNamespace(project.Name)
+	pe := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-pr-7",
+			Namespace: controlNs,
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef: project.Name,
+			SourceEnv:  "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{
+				Number: 7,
+				Branch: "feature/fill-secret",
+				SHA:    "deadbeef",
+			},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-app",
+			Namespace: controlNs,
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type: mortisev1alpha1.SourceTypeGit,
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        envstore.AppEnvSecretName(app.Name),
+			Namespace:   constants.EnvNamespace(project.Name, "staging"),
+			Annotations: map[string]string{envstore.AnnotationGeneratedKeys: "DATABASE_URL"},
+		},
+		Data: map[string][]byte{"DATABASE_URL": []byte("postgres://source")},
+	}
+	previewSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envstore.AppEnvSecretName(app.Name),
+			Namespace: constants.EnvNamespace(project.Name, "pr-7"),
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pe).
+		WithObjects(project, pe, app, sourceSecret, previewSecret).
+		Build()
+	r := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: scheme,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile preview environment: %v", err)
+	}
+
+	var updated corev1.Secret
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name:      previewSecret.Name,
+		Namespace: previewSecret.Namespace,
+	}, &updated); err != nil {
+		t.Fatalf("get preview app secret: %v", err)
+	}
+	if got := string(updated.Data["DATABASE_URL"]); got != "postgres://source" {
+		t.Fatalf("expected preview app secret to be hydrated from source, got %q", got)
+	}
+	if updated.Annotations[envstore.AnnotationGeneratedKeys] != "DATABASE_URL" {
+		t.Fatalf("expected preview app secret annotations to be copied, got %+v", updated.Annotations)
+	}
+	if updated.Labels[constants.ProjectLabel] != project.Name || updated.Labels[constants.EnvironmentLabel] != "pr-7" || updated.Labels[constants.AppNameLabel] != app.Name {
+		t.Fatalf("expected preview app secret labels to be restored, got %+v", updated.Labels)
+	}
+}
+
 var _ = Describe("PreviewEnvironment Controller", func() {
 	Context("when the parent Project has project-level preview disabled", func() {
 		It("should set the PreviewEnvironment to Failed", func() {

--- a/test/helpers/gitea.go
+++ b/test/helpers/gitea.go
@@ -460,6 +460,16 @@ func CreateBranch(t *testing.T, baseURL, token, owner, repo, newBranch, fromBran
 func UpdateBranchFile(t *testing.T, baseURL, token, owner, repo, branch, path string) string {
 	t.Helper()
 
+	newContent := fmt.Sprintf("Webhook integration test update at %d rand=%d\n",
+		time.Now().UnixNano(), rand.Int())
+	return UpdateBranchFileContent(t, baseURL, token, owner, repo, branch, path, newContent)
+}
+
+// UpdateBranchFileContent rewrites the given file on the given branch to the
+// supplied content, producing a new commit and returning the new branch HEAD.
+func UpdateBranchFileContent(t *testing.T, baseURL, token, owner, repo, branch, path, content string) string {
+	t.Helper()
+
 	// Look up the file's current blob SHA on this branch; if it doesn't exist
 	// yet we'll create it in place of the update.
 	getURL := fmt.Sprintf("%s/api/v1/repos/%s/%s/contents/%s?ref=%s",
@@ -478,9 +488,7 @@ func UpdateBranchFile(t *testing.T, baseURL, token, owner, repo, branch, path st
 	}
 	resp.Body.Close()
 
-	newContent := fmt.Sprintf("Webhook integration test update at %d rand=%d\n",
-		time.Now().UnixNano(), rand.Int())
-	encoded := base64.StdEncoding.EncodeToString([]byte(newContent))
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
 	payload := map[string]any{
 		"message": fmt.Sprintf("integration test: update %s on %s", path, branch),
 		"content": encoded,

--- a/test/integration/preview_webhook_test.go
+++ b/test/integration/preview_webhook_test.go
@@ -18,6 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -357,6 +358,127 @@ func TestPreviewEnvironmentViaWebhook_PreviewDisabled(t *testing.T) {
 		for _, item := range all.Items {
 			t.Errorf("unexpected PreviewEnvironment %s/%s created with preview disabled", item.Namespace, item.Name)
 		}
+	}
+}
+
+// TestPreviewBuildFailureViaWebhookDoesNotDegradeTopLevelApp proves the real
+// issue-388 path end to end: a preview PR branch fails to build, the preview
+// keeps its failed local status, and the base app stays Ready because its
+// non-preview environments are still healthy.
+func TestPreviewBuildFailureViaWebhookDoesNotDegradeTopLevelApp(t *testing.T) {
+	t.Parallel()
+	projectName := "prev-wh-fail-" + randSuffix()
+	ns := createProjectForTest(t, projectName)
+
+	giteaLocalPort := helpers.PortForward(t, "mortise-test-deps", "gitea", 3000)
+	mortisePort := helpers.PortForward(t, "mortise-system", "mortise", 80)
+
+	giteaLocalURL := fmt.Sprintf("http://127.0.0.1:%d", giteaLocalPort)
+	giteaInClusterURL := "http://gitea.mortise-test-deps.svc:3000"
+	mortiseURL := fmt.Sprintf("http://127.0.0.1:%d", mortisePort)
+
+	repoName := "repo-prev-fail-" + randSuffix()
+	boot := (&helpers.GiteaBootstrap{
+		BaseURL:  giteaLocalURL,
+		Username: "mortise-test",
+		Password: "mortise-test-pw",
+	}).Ensure(t, giteaInClusterURL, "mortise-test", repoName,
+		map[string]string{
+			"Dockerfile": testDockerfile,
+			"README.md":  testReadme,
+		},
+	)
+
+	providerName := "gitea-prev-fail-" + randSuffix()
+	testEmail := "test@example.com"
+	stubSecret(t, "mortise-system", "prev-fail-webhook-"+providerName, map[string]string{
+		"secret": webhookSecret,
+	})
+	stubSecret(t, "mortise-system", "user-"+providerName+"-token-74657374406578616d706c652e636f6d", map[string]string{
+		"token": boot.Token,
+	})
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: providerName},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type:     mortisev1alpha1.GitProviderTypeGitea,
+			Host:     giteaInClusterURL,
+			ClientID: "test-client-id",
+			WebhookSecretRef: &mortisev1alpha1.SecretRef{
+				Namespace: "mortise-system", Name: "prev-fail-webhook-" + providerName, Key: "secret",
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), gp); err != nil {
+		t.Fatalf("create GitProvider: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), &mortisev1alpha1.GitProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: providerName},
+		})
+	})
+
+	app := helpers.LoadFixture(t, filepath.Join(fixturesDir(), "git-preview.yaml"))
+	app.Namespace = ns
+	app.Name = "prev-fail-app-" + randSuffix()
+	app.Spec.Source.Repo = boot.CloneURL
+	app.Spec.Source.ProviderRef = providerName
+	if app.Annotations == nil {
+		app.Annotations = map[string]string{}
+	}
+	app.Annotations["mortise.dev/revision"] = "main"
+	app.Annotations["mortise.dev/created-by"] = testEmail
+
+	enableProjectPreview(t, projectName, &mortisev1alpha1.PreviewConfig{
+		Enabled: true,
+	})
+
+	if err := k8sClient.Create(context.Background(), app); err != nil {
+		t.Fatalf("create App: %v", err)
+	}
+	helpers.WaitForAppReady(t, k8sClient, ns, app.Name, 5*time.Minute)
+
+	prBranch := "feature/preview-build-fail"
+	helpers.CreateBranch(t, giteaLocalURL, boot.Token, boot.Owner, boot.Name, prBranch, "main")
+	badDockerfile := "FROM invalid@@image\n"
+	headSHA := helpers.UpdateBranchFileContent(t, giteaLocalURL, boot.Token, boot.Owner, boot.Name, prBranch, "Dockerfile", badDockerfile)
+	pr := helpers.CreatePullRequest(t, giteaLocalURL, boot.Token, boot.Owner, boot.Name, prBranch, "main", "preview build failure test")
+
+	payload := giteaPRPayload("opened", pr.Number, prBranch, headSHA, boot.Owner, boot.Name)
+	postWebhook(t, mortiseURL, providerName, payload, http.StatusAccepted)
+
+	peName := fmt.Sprintf("preview-pr-%d", pr.Number)
+	waitForPreviewFailed(t, ns, peName, 5*time.Minute)
+
+	var pe mortisev1alpha1.PreviewEnvironment
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: peName, Namespace: ns}, &pe); err != nil {
+		t.Fatalf("get failed preview: %v", err)
+	}
+	if len(pe.Status.Conditions) == 0 {
+		t.Fatal("expected failed preview to carry a failure condition")
+	}
+
+	helpers.RequireEventually(t, 60*time.Second, func() bool {
+		var refreshed mortisev1alpha1.App
+		if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: app.Name, Namespace: ns}, &refreshed); err != nil {
+			return false
+		}
+		cond := meta.FindStatusCondition(refreshed.Status.Conditions, "BuildSucceeded")
+		return refreshed.Status.Phase == mortisev1alpha1.AppPhaseReady &&
+			cond != nil &&
+			cond.Status == metav1.ConditionTrue
+	})
+
+	var refreshed mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: app.Name, Namespace: ns}, &refreshed); err != nil {
+		t.Fatalf("get app after preview failure: %v", err)
+	}
+	if refreshed.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected top-level app phase Ready after preview build failure, got %q", refreshed.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(refreshed.Status.Conditions, "BuildSucceeded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected top-level BuildSucceeded=true after preview build failure, got %+v", cond)
 	}
 }
 


### PR DESCRIPTION
## Summary
- exclude preview environments from top-level app phase and build-failure aggregation when at least one non-preview environment exists
- keep preview-local failure state on per-environment status while masking preview-only failures out of the app-global `BuildSucceeded` condition
- add focused regression coverage for preview-only failures, non-preview failures, preview-only fallback, and recovery

## Root cause
The app controller aggregated phase and terminal build failure state across every resolved environment. A failed preview build could therefore set the app-global `BuildSucceeded` condition false and degrade the top-level app phase even when production and staging were still healthy.

## Validation
- `go test ./internal/controller -run 'Test(UpdateStatus(IgnoresPreviewBuildFailureWhenNonPreviewEnvIsHealthy|StillDegradesForNonPreviewBuildFailure|FallsBackToPreviewOnlyAggregationWhenNoNonPreviewEnvExists|StaysHealthyAfterPreviewFailureRecovers|MarksDegradedWhenLatestBuildFailsButPreviousImageStillServes|KeepsFailedWhenLatestBuildFailsAndNothingServes|ClearsDegradedAfterSuccessfulRecovery)|AllEnvBuildsCurrentForRevision_EnvBranchOverridesAnnotation|EnsureAppBuildRun(Create(sAndClearsRebuildMarkers|DistinctRunsForManualRebuildRequests)|ReusesCurrent(ManualRunAfterMarkersClear|TerminalRunBeforeStatusProjection)|DoesNotReuseCurrentRunWhenInputHashChanges)|ReconcileEnvBuild(ProjectsCurrentTerminalRunBeforeRevisionShortCircuit|DoesNotShortCircuitLastBuiltSHAWhenInputHashChanges))'`
- `go test ./internal/controller`
- `go test ./...`
- `make check-ui`
