### PR TITLE
[codex] Fix preview build SHA identity and tag safety

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -170,13 +170,22 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("fetch parent project: %w", err)
 	}
 	var resolvedEnvs []mortisev1alpha1.Environment
+	var previewEnvNames map[string]struct{}
+	var previewBuildIdentities map[string]previewBuildIdentity
 	if project != nil {
 		resolvedEnvs = resolveEnvs(project, &app)
+		previewEnvNames = resolvedPreviewEnvNames(project, resolvedEnvs)
+	}
+	if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && len(previewEnvNames) > 0 {
+		previewBuildIdentities, err = r.previewBuildIdentitiesByEnv(ctx, app.Namespace, previewEnvNames)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("resolve preview build identities: %w", err)
+		}
 	}
 
 	switch app.Spec.Source.Type {
 	case mortisev1alpha1.SourceTypeGit:
-		if r.BuildClient != nil && !r.allEnvBuildsCurrentForRevision(&app, resolvedEnvs) {
+		if r.BuildClient != nil && !r.allEnvBuildsCurrentForRevision(&app, resolvedEnvs, previewBuildIdentities) {
 			result, proceed, err := r.prepareGitSource(ctx, &app)
 			if !proceed || err != nil {
 				if syncErr := r.reconcileResolvedEnvSecrets(ctx, &app, resolvedEnvs); syncErr != nil {
@@ -236,7 +245,8 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		// Resolve the container image for this env.
 		var image string
 		if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && r.BuildClient != nil {
-			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, env.Name, env.Branch)
+			buildIdentity := resolveEnvBuildIdentity(&app, *env, previewBuildIdentities)
+			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, env.Name, buildIdentity.branch, buildIdentity.revision)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile buildrun for env %s: %w", env.Name, err)
 			}
@@ -511,19 +521,106 @@ func (r *AppReconciler) DeletePreviewEnvironment(ctx context.Context, pe *mortis
 	return r.Delete(ctx, pe)
 }
 
+type previewBuildIdentity struct {
+	branch   string
+	revision string
+}
+
+type envBuildIdentity struct {
+	branch   string
+	revision string
+}
+
+func resolvedPreviewEnvNames(project *mortisev1alpha1.Project, resolvedEnvs []mortisev1alpha1.Environment) map[string]struct{} {
+	if project == nil || len(project.Spec.Environments) == 0 || len(resolvedEnvs) == 0 {
+		return nil
+	}
+
+	projectPreviewByName := make(map[string]struct{}, len(project.Spec.Environments))
+	for _, env := range project.Spec.Environments {
+		if env.Preview {
+			projectPreviewByName[env.Name] = struct{}{}
+		}
+	}
+	if len(projectPreviewByName) == 0 {
+		return nil
+	}
+
+	out := make(map[string]struct{})
+	for _, env := range resolvedEnvs {
+		if _, ok := projectPreviewByName[env.Name]; ok {
+			out[env.Name] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (r *AppReconciler) previewBuildIdentitiesByEnv(ctx context.Context, namespace string, previewEnvNames map[string]struct{}) (map[string]previewBuildIdentity, error) {
+	if len(previewEnvNames) == 0 {
+		return nil, nil
+	}
+
+	previewEnvs, err := r.ListPreviewEnvironments(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	identities := make(map[string]previewBuildIdentity, len(previewEnvs))
+	for _, pe := range previewEnvs {
+		if !pe.DeletionTimestamp.IsZero() {
+			continue
+		}
+		envName := fmt.Sprintf("pr-%d", pe.Spec.PullRequest.Number)
+		if _, ok := previewEnvNames[envName]; !ok {
+			continue
+		}
+		identities[envName] = previewBuildIdentity{
+			branch:   pe.Spec.PullRequest.Branch,
+			revision: pe.Spec.PullRequest.SHA,
+		}
+	}
+	if len(identities) == 0 {
+		return nil, nil
+	}
+	return identities, nil
+}
+
+func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Environment, previewBuildIdentities map[string]previewBuildIdentity) envBuildIdentity {
+	identity := envBuildIdentity{branch: env.Branch}
+	if preview, ok := previewBuildIdentities[env.Name]; ok {
+		identity.branch = firstNonEmpty(preview.branch, identity.branch)
+		identity.revision = preview.revision
+	}
+	if identity.revision == "" {
+		identity.revision = app.Annotations["mortise.dev/revision"]
+		if identity.branch != "" {
+			identity.revision = identity.branch
+		} else if identity.revision == "" {
+			identity.revision = app.Spec.Source.Branch
+		}
+	}
+	identity.branch = firstNonEmpty(identity.branch, app.Spec.Source.Branch)
+	identity.branch = firstNonEmpty(identity.branch, "main")
+	identity.revision = firstNonEmpty(identity.revision, "main")
+	return identity
+}
+
 // reconcileEnvBuild handles per-environment builds for git-source apps. Returns
 // the image to use for this env's deployment, or "" if a build is still in
 // flight (caller should skip deployment and requeue). statusDirty is true when
 // applyEnvBuildSuccess mutated app.Status and the caller must flush.
-func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, envName, envBranch string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
+func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
 
-	revision := app.Annotations["mortise.dev/revision"]
-	if envBranch != "" {
-		revision = envBranch
-	} else if revision == "" {
-		revision = app.Spec.Source.Branch
+	branch = firstNonEmpty(branch, app.Spec.Source.Branch)
+	revision = firstNonEmpty(revision, app.Annotations["mortise.dev/revision"])
+	if revision == "" {
+		revision = branch
 	}
+	branch = firstNonEmpty(branch, "main")
 	if revision == "" {
 		revision = "main"
 	}
@@ -538,7 +635,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		log.Error(err, "pull target failed", "env", envName)
 		return "", false, false, false, nil
 	}
-	desiredRunSpec := appBuildRunSpec(app, envName, revision, imageRef.Full, pullRef.Full)
+	desiredRunSpec := appBuildRunSpec(app, envName, branch, revision, imageRef.Full, pullRef.Full)
 
 	// Short-circuit: skip rebuild if we already built this revision for this env
 	// with the same effective build inputs.
@@ -584,7 +681,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 	}
 
-	run, err := r.ensureAppBuildRun(ctx, app, envName, revision, imageRef.Full, pullRef.Full)
+	run, err := r.ensureAppBuildRun(ctx, app, envName, branch, revision, imageRef.Full, pullRef.Full)
 	if err != nil {
 		log.Error(err, "ensure buildrun failed", "env", envName)
 		return "", false, false, false, err
@@ -734,9 +831,38 @@ func shortTag(revision string) string {
 	return revision
 }
 
+func sanitizeImageTagPart(v string) string {
+	if v == "" {
+		return "build"
+	}
+
+	var b strings.Builder
+	b.Grow(len(v))
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+
+	out := strings.TrimLeft(b.String(), ".-")
+	if out == "" {
+		return "build"
+	}
+	return out
+}
+
 // envImageTag produces a per-environment image tag: "sha-envname".
 func envImageTag(revision, envName string) string {
-	return shortTag(revision) + "-" + envName
+	return sanitizeImageTagPart(shortTag(revision)) + "-" + sanitizeImageTagPart(envName)
 }
 
 // envStatusFor returns the EnvironmentStatus for envName, or nil.
@@ -769,20 +895,12 @@ func (r *AppReconciler) currentImageForEnv(app *mortisev1alpha1.App, envName str
 // allEnvBuildsCurrentForRevision returns true only when every resolved
 // environment already has a per-env build matching the current revision.
 // Used to skip prepareGitSource (auth + clone) when no new builds are needed.
-func (r *AppReconciler) allEnvBuildsCurrentForRevision(app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment) bool {
+func (r *AppReconciler) allEnvBuildsCurrentForRevision(app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment, previewBuildIdentities map[string]previewBuildIdentity) bool {
 	if len(envs) == 0 {
 		return false
 	}
 	for _, env := range envs {
-		revision := app.Annotations["mortise.dev/revision"]
-		if env.Branch != "" {
-			revision = env.Branch
-		} else if revision == "" {
-			revision = app.Spec.Source.Branch
-		}
-		if revision == "" {
-			revision = "main"
-		}
+		revision := resolveEnvBuildIdentity(app, env, previewBuildIdentities).revision
 		es := envStatusFor(app, env.Name)
 		if es == nil || es.LastBuiltSHA != revision || es.LastBuiltImage == "" {
 			return false
@@ -3528,6 +3646,28 @@ func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			Namespace: br.Namespace,
 		}}}
 	})
+	enqueueAppsFromPreviewEnvironment := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		pe, ok := obj.(*mortisev1alpha1.PreviewEnvironment)
+		if !ok || pe.Namespace == "" {
+			return nil
+		}
+
+		var apps mortisev1alpha1.AppList
+		if err := r.List(ctx, &apps, client.InNamespace(pe.Namespace)); err != nil {
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(apps.Items))
+		for i := range apps.Items {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      apps.Items[i].Name,
+					Namespace: apps.Items[i].Namespace,
+				},
+			})
+		}
+		return reqs
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mortisev1alpha1.App{}).
 		Watches(&appsv1.Deployment{}, enqueueAppFromManagedResource).
@@ -3538,6 +3678,7 @@ func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.ServiceAccount{}, enqueueAppFromManagedResource).
 		Watches(&networkingv1.Ingress{}, enqueueAppFromManagedResource).
 		Watches(&mortisev1alpha1.BuildRun{}, enqueueAppFromBuildRun).
+		Watches(&mortisev1alpha1.PreviewEnvironment{}, enqueueAppsFromPreviewEnvironment).
 		Named("app").
 		Complete(r)
 }

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -474,15 +474,66 @@ func TestAllEnvBuildsCurrentForRevision_EnvBranchOverridesAnnotation(t *testing.
 	envs := []mortisev1alpha1.Environment{{Name: "staging", Branch: "feature/x"}}
 
 	// With the env branch matching LastBuiltSHA, should return true.
-	if !r.allEnvBuildsCurrentForRevision(app, envs) {
+	if !r.allEnvBuildsCurrentForRevision(app, envs, nil) {
 		t.Fatal("expected allEnvBuildsCurrentForRevision=true when env branch matches LastBuiltSHA")
 	}
 
 	// If LastBuiltSHA matches the annotation instead of the env branch, should return false
 	// (env branch must win over annotation).
 	app.Status.Environments[0].LastBuiltSHA = "abc123"
-	if r.allEnvBuildsCurrentForRevision(app, envs) {
+	if r.allEnvBuildsCurrentForRevision(app, envs, nil) {
 		t.Fatal("expected allEnvBuildsCurrentForRevision=false when LastBuiltSHA matches annotation but not env branch")
+	}
+}
+
+func TestAllEnvBuildsCurrentForRevision_PreviewUsesSHAInsteadOfBranch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision": "base-sha",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:   mortisev1alpha1.SourceTypeGit,
+				Branch: "main",
+			},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "pr-7", Branch: "feature/preview-slash"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name:           "pr-7",
+				LastBuiltSHA:   "sha-preview-v1",
+				LastBuiltImage: "registry/demo:sha-prev-pr-7",
+			}},
+		},
+	}
+
+	r := &AppReconciler{Scheme: scheme}
+	envs := []mortisev1alpha1.Environment{{Name: "pr-7", Branch: "feature/preview-slash"}}
+	previewBuildIdentities := map[string]previewBuildIdentity{
+		"pr-7": {
+			branch:   "feature/preview-slash",
+			revision: "sha-preview-v1",
+		},
+	}
+
+	if !r.allEnvBuildsCurrentForRevision(app, envs, previewBuildIdentities) {
+		t.Fatal("expected preview env to use immutable SHA identity")
+	}
+
+	app.Status.Environments[0].LastBuiltSHA = "feature/preview-slash"
+	if r.allEnvBuildsCurrentForRevision(app, envs, previewBuildIdentities) {
+		t.Fatal("expected preview env branch to not count as current build identity")
 	}
 }
 
@@ -3765,6 +3816,7 @@ var _ = Describe("App Controller — git source", func() {
 				Spec: appBuildRunSpec(
 					app,
 					"production",
+					"main",
 					"same-sha",
 					"registry.example.com/mortise/git-shortcircuit:same-sh-production",
 					"registry.example.com/mortise/git-shortcircuit:same-sh-production",

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -3042,6 +3042,10 @@ func (f *fakeGitClient) Clone(_ context.Context, _, _, _ string, _ git.GitCreden
 	return f.err
 }
 
+func (f *fakeGitClient) CheckoutRevision(_ context.Context, _, _ string) error {
+	return f.err
+}
+
 func (f *fakeGitClient) Fetch(_ context.Context, _, _ string) error {
 	return f.err
 }

--- a/internal/controller/build_runner.go
+++ b/internal/controller/build_runner.go
@@ -91,6 +91,13 @@ func runBuild(
 		return
 	}
 	log.Info("cloned repo", "repo", p.repo, "branch", p.branch)
+	if p.revision != "" && p.revision != p.branch {
+		if err := gitClient.CheckoutRevision(ctx, cloneDir, p.revision); err != nil {
+			t.setFailed(fmt.Sprintf("CheckoutRevisionFailed: %v", err))
+			return
+		}
+		log.Info("checked out revision", "revision", p.revision)
+	}
 
 	dockerfileDir := cloneDir
 	if p.path != "" {

--- a/internal/controller/build_runner_test.go
+++ b/internal/controller/build_runner_test.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/build"
+	"github.com/mortise-org/mortise/internal/git"
+	"github.com/mortise-org/mortise/internal/registry"
+)
+
+func TestRunBuildChecksOutRequestedRevision(t *testing.T) {
+	repoDir, branch, firstRevision := createBuildRunnerRepo(t)
+	buildClient := &capturingBuildClient{t: t}
+	tracker := &buildTracker{revision: firstRevision, phase: buildPhaseRunning}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runBuild(ctx, cancel, tracker, buildParams{
+		appName:   "demo",
+		namespace: "default",
+		repo:      repoDir,
+		branch:    branch,
+		revision:  firstRevision,
+		imageRef: registry.ImageRef{
+			Full: "registry.example.com/demo:build",
+		},
+		pullImageRef: registry.ImageRef{
+			Full:     "registry.example.com/demo:build",
+			Registry: "registry.example.com",
+			Path:     "demo",
+		},
+		buildContext: mortisev1alpha1.BuildContextRoot,
+	}, git.NewGoGitClient(), buildClient, buildRunnerOptions{})
+
+	phase, _, _, _, errMsg, _ := tracker.snapshot()
+	if phase != buildPhaseSucceeded {
+		t.Fatalf("build phase = %s, err = %q", phase, errMsg)
+	}
+	if buildClient.version != "old\n" {
+		t.Fatalf("built version = %q, want %q", buildClient.version, "old\n")
+	}
+}
+
+type capturingBuildClient struct {
+	t       *testing.T
+	version string
+}
+
+func (c *capturingBuildClient) Submit(_ context.Context, req build.BuildRequest) (<-chan build.BuildEvent, error) {
+	c.t.Helper()
+	contents, err := os.ReadFile(filepath.Join(req.SourceDir, "version.txt"))
+	if err != nil {
+		c.t.Fatalf("ReadFile(version.txt) error = %v", err)
+	}
+	c.version = string(contents)
+
+	ch := make(chan build.BuildEvent, 1)
+	ch <- build.BuildEvent{Type: build.EventSuccess, Digest: "sha256:test"}
+	close(ch)
+	return ch, nil
+}
+
+func createBuildRunnerRepo(t *testing.T) (repoDir, branch, firstRevision string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	repo, err := gogit.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree() error = %v", err)
+	}
+	createBuildRunnerCommit(t, wt, repoDir, "seed.txt", "seed\n", "seed")
+
+	branch = "feature/preview-slash"
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Create: true,
+		Branch: plumbing.NewBranchReferenceName(branch),
+	}); err != nil {
+		t.Fatalf("Checkout(create branch) error = %v", err)
+	}
+
+	firstRevision = createBuildRunnerCommit(t, wt, repoDir, "version.txt", "old\n", "first")
+	createBuildRunnerCommit(t, wt, repoDir, "version.txt", "new\n", "second")
+	return repoDir, branch, firstRevision
+}
+
+func createBuildRunnerCommit(t *testing.T, wt *gogit.Worktree, repoDir, path, contents, message string) string {
+	t.Helper()
+
+	fullPath := filepath.Join(repoDir, path)
+	if err := os.WriteFile(fullPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+	if _, err := wt.Add(path); err != nil {
+		t.Fatalf("Add(%s) error = %v", path, err)
+	}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@example.com",
+			When:  time.Unix(1, 0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Commit(%s) error = %v", message, err)
+	}
+	return hash.String()
+}

--- a/internal/controller/buildrun_support.go
+++ b/internal/controller/buildrun_support.go
@@ -225,7 +225,7 @@ func buildRunTokenSecretRef(providerName, email string) *mortisev1alpha1.SecretR
 	}
 }
 
-func appBuildRunSpec(app *mortisev1alpha1.App, envName, revision, pushTarget, pullTarget string) mortisev1alpha1.BuildRunSpec {
+func appBuildRunSpec(app *mortisev1alpha1.App, envName, branch, revision, pushTarget, pullTarget string) mortisev1alpha1.BuildRunSpec {
 	noCache := false
 	requestID := app.Annotations[rebuildRequestedAtAnnotation]
 	if requestID == "" {
@@ -252,7 +252,7 @@ func appBuildRunSpec(app *mortisev1alpha1.App, envName, revision, pushTarget, pu
 		CreatedBy:      app.Annotations["mortise.dev/created-by"],
 		TokenOwner:     app.Annotations["mortise.dev/git-token-owner"],
 		Repo:           app.Spec.Source.Repo,
-		Branch:         firstNonEmpty(app.Spec.Source.Branch, "main"),
+		Branch:         firstNonEmpty(branch, "main"),
 		Revision:       revision,
 		SourcePath:     app.Spec.Source.Path,
 		Path:           app.Spec.Source.Path,
@@ -290,8 +290,8 @@ func buildRunMatchesAppSpec(run *mortisev1alpha1.BuildRun, app *mortisev1alpha1.
 		buildRunSelectionHash(run.Spec) == buildRunSelectionHash(spec)
 }
 
-func (r *AppReconciler) ensureAppBuildRun(ctx context.Context, app *mortisev1alpha1.App, envName, revision, pushTarget, pullTarget string) (*mortisev1alpha1.BuildRun, error) {
-	spec := appBuildRunSpec(app, envName, revision, pushTarget, pullTarget)
+func (r *AppReconciler) ensureAppBuildRun(ctx context.Context, app *mortisev1alpha1.App, envName, branch, revision, pushTarget, pullTarget string) (*mortisev1alpha1.BuildRun, error) {
+	spec := appBuildRunSpec(app, envName, branch, revision, pushTarget, pullTarget)
 	if !hasPendingRebuildRequest(app) && app.Status.CurrentBuildRunName != "" {
 		var current mortisev1alpha1.BuildRun
 		if err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Status.CurrentBuildRunName}, &current); err == nil {

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -46,7 +46,7 @@ func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	run, err := r.ensureAppBuildRun(context.Background(), app, "production", "abc1234567890", "registry/push:tag", "registry/pull:tag")
+	run, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "abc1234567890", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("ensure buildrun: %v", err)
 	}
@@ -58,6 +58,9 @@ func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
 	}
 	if run.Spec.Revision != "abc1234567890" {
 		t.Fatalf("expected revision persisted, got %q", run.Spec.Revision)
+	}
+	if run.Spec.Branch != "main" {
+		t.Fatalf("expected branch persisted, got %q", run.Spec.Branch)
 	}
 	if run.Spec.TokenSecretRef == nil {
 		t.Fatal("expected token secret ref")
@@ -80,6 +83,37 @@ func TestParseImageRefSplitsRegistryPathAndTag(t *testing.T) {
 	}
 	if ref.Tag != "sha-prod" {
 		t.Fatalf("tag = %q", ref.Tag)
+	}
+}
+
+func TestAppBuildRunSpecSeparatesPreviewBranchAndRevision(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://example.com/repo.git",
+				Branch:      "main",
+				ProviderRef: "github",
+			},
+		},
+	}
+
+	spec := appBuildRunSpec(app, "pr-12", "feature/preview-slash", "abcdef1234567890", "registry/push:tag", "registry/pull:tag")
+	if spec.Branch != "feature/preview-slash" {
+		t.Fatalf("branch = %q", spec.Branch)
+	}
+	if spec.Revision != "abcdef1234567890" {
+		t.Fatalf("revision = %q", spec.Revision)
+	}
+}
+
+func TestEnvImageTagSanitizesInvalidOCICharacters(t *testing.T) {
+	if got := envImageTag("fix/stripe-payment-element", "pr-6"); got != "fix-str-pr-6" {
+		t.Fatalf("envImageTag = %q", got)
 	}
 }
 
@@ -157,7 +191,7 @@ func TestEnsureAppBuildRunCreatesDistinctRunsForManualRebuildRequests(t *testing
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	first, err := r.ensureAppBuildRun(context.Background(), app, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	first, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("first ensure buildrun: %v", err)
 	}
@@ -166,7 +200,7 @@ func TestEnsureAppBuildRunCreatesDistinctRunsForManualRebuildRequests(t *testing
 	}
 
 	app.Annotations[rebuildNoCacheRequestedAtAnnotation] = "req-2"
-	second, err := r.ensureAppBuildRun(context.Background(), app, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	second, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("second ensure buildrun: %v", err)
 	}
@@ -210,7 +244,7 @@ func TestEnsureAppBuildRunReusesCurrentManualRunAfterMarkersClear(t *testing.T) 
 	manualApp := app.DeepCopy()
 	manualApp.Annotations[rebuildRequestedAtAnnotation] = "req-1"
 	manualApp.Annotations[rebuildNoCacheRequestedAtAnnotation] = "req-1"
-	manualSpec := appBuildRunSpec(manualApp, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	manualSpec := appBuildRunSpec(manualApp, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	run := &mortisev1alpha1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "manual-run",
@@ -225,7 +259,7 @@ func TestEnsureAppBuildRunReusesCurrentManualRunAfterMarkersClear(t *testing.T) 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, run).Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("ensure buildrun: %v", err)
 	}
@@ -271,7 +305,7 @@ func TestEnsureAppBuildRunReusesCurrentTerminalRunBeforeStatusProjection(t *test
 	manualApp := app.DeepCopy()
 	manualApp.Annotations[rebuildRequestedAtAnnotation] = "req-1"
 	manualApp.Annotations[rebuildNoCacheRequestedAtAnnotation] = "req-1"
-	manualSpec := appBuildRunSpec(manualApp, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	manualSpec := appBuildRunSpec(manualApp, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	run := &mortisev1alpha1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "manual-run",
@@ -287,7 +321,7 @@ func TestEnsureAppBuildRunReusesCurrentTerminalRunBeforeStatusProjection(t *test
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, run).Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("ensure buildrun: %v", err)
 	}
@@ -334,7 +368,7 @@ func TestEnsureAppBuildRunDoesNotReuseCurrentRunWhenInputHashChanges(t *testing.
 		},
 	}
 	currentApp := app.DeepCopy()
-	currentSpec := appBuildRunSpec(currentApp, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	currentSpec := appBuildRunSpec(currentApp, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	run := &mortisev1alpha1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "current-run",
@@ -351,7 +385,7 @@ func TestEnsureAppBuildRunDoesNotReuseCurrentRunWhenInputHashChanges(t *testing.
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, run).Build()
 	r := &AppReconciler{Client: c, Scheme: scheme}
 
-	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "same-sha", "registry/push:tag", "registry/pull:tag")
+	got, err := r.ensureAppBuildRun(context.Background(), app, "production", "main", "same-sha", "registry/push:tag", "registry/pull:tag")
 	if err != nil {
 		t.Fatalf("ensure buildrun: %v", err)
 	}
@@ -396,7 +430,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 	manualApp := app.DeepCopy()
 	manualApp.Annotations[rebuildRequestedAtAnnotation] = "req-1"
 	manualApp.Annotations[rebuildNoCacheRequestedAtAnnotation] = "req-1"
-	manualSpec := appBuildRunSpec(manualApp, "production", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production")
+	manualSpec := appBuildRunSpec(manualApp, "production", "main", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production")
 	run := &mortisev1alpha1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "manual-run",
@@ -418,7 +452,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -488,7 +522,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 			Name:      "last-run",
 			Namespace: app.Namespace,
 		},
-		Spec: appBuildRunSpec(lastApp, "production", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production"),
+		Spec: appBuildRunSpec(lastApp, "production", "main", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production"),
 		Status: mortisev1alpha1.BuildRunStatus{
 			Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
 			Image: "registry.example.com/demo:old",
@@ -502,7 +536,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -5,5 +5,6 @@ import "context"
 // GitClient handles git protocol operations. Single implementation shared across all forges.
 type GitClient interface {
 	Clone(ctx context.Context, repo, ref, dest string, creds GitCredentials) error
+	CheckoutRevision(ctx context.Context, dir, revision string) error
 	Fetch(ctx context.Context, dir, ref string) error
 }

--- a/internal/git/gogit_client.go
+++ b/internal/git/gogit_client.go
@@ -26,7 +26,6 @@ func (c *GoGitClient) Clone(ctx context.Context, repo, ref, dest string, creds G
 		URL:           repo,
 		ReferenceName: plumbing.NewBranchReferenceName(ref),
 		SingleBranch:  true,
-		Depth:         1,
 	}
 	if creds.Token != "" {
 		opts.Auth = &http.BasicAuth{
@@ -37,6 +36,26 @@ func (c *GoGitClient) Clone(ctx context.Context, repo, ref, dest string, creds G
 	_, err := gogit.PlainClone(dest, false, opts)
 	if err != nil {
 		return fmt.Errorf("clone %s@%s: %w", repo, ref, err)
+	}
+	return nil
+}
+
+func (c *GoGitClient) CheckoutRevision(ctx context.Context, dir, revision string) error {
+	_ = ctx
+	r, err := gogit.PlainOpen(dir)
+	if err != nil {
+		return fmt.Errorf("open repo %s: %w", dir, err)
+	}
+	hash, err := r.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		return fmt.Errorf("resolve revision %s: %w", revision, err)
+	}
+	wt, err := r.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree: %w", err)
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{Hash: *hash, Force: true}); err != nil {
+		return fmt.Errorf("checkout revision %s: %w", revision, err)
 	}
 	return nil
 }

--- a/internal/git/gogit_client_test.go
+++ b/internal/git/gogit_client_test.go
@@ -1,0 +1,84 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestGoGitClientCheckoutRevisionAfterClone(t *testing.T) {
+	sourceDir, branch, firstRevision := createTestBranchRepo(t)
+	cloneDir := t.TempDir()
+
+	client := NewGoGitClient()
+	if err := client.Clone(context.Background(), sourceDir, branch, cloneDir, GitCredentials{}); err != nil {
+		t.Fatalf("Clone() error = %v", err)
+	}
+	if err := client.CheckoutRevision(context.Background(), cloneDir, firstRevision); err != nil {
+		t.Fatalf("CheckoutRevision() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(cloneDir, "version.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "old\n" {
+		t.Fatalf("version.txt = %q, want %q", string(got), "old\n")
+	}
+}
+
+func createTestBranchRepo(t *testing.T) (repoDir, branch, firstRevision string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	repo, err := gogit.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree() error = %v", err)
+	}
+	writeCommit(t, wt, repoDir, "seed.txt", "seed\n", "seed")
+
+	branch = "feature/preview-slash"
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Create: true,
+		Branch: plumbing.NewBranchReferenceName(branch),
+	}); err != nil {
+		t.Fatalf("Checkout(create branch) error = %v", err)
+	}
+
+	firstRevision = writeCommit(t, wt, repoDir, "version.txt", "old\n", "first")
+	writeCommit(t, wt, repoDir, "version.txt", "new\n", "second")
+	return repoDir, branch, firstRevision
+}
+
+func writeCommit(t *testing.T, wt *gogit.Worktree, repoDir, path, contents, message string) string {
+	t.Helper()
+
+	fullPath := filepath.Join(repoDir, path)
+	if err := os.WriteFile(fullPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+	if _, err := wt.Add(path); err != nil {
+		t.Fatalf("Add(%s) error = %v", path, err)
+	}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@example.com",
+			When:  time.Unix(1, 0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Commit(%s) error = %v", message, err)
+	}
+	return hash.String()
+}

--- a/test/integration/preview_webhook_test.go
+++ b/test/integration/preview_webhook_test.go
@@ -196,6 +196,7 @@ func TestPreviewEnvironmentViaWebhook(t *testing.T) {
 	if img := dep.Spec.Template.Spec.Containers[0].Image; img == "" {
 		t.Error("preview Deployment container image is empty")
 	}
+	waitForAppEnvBuiltSHA(t, ns, app.Name, fmt.Sprintf("pr-%d", prNumber), headSHA, 3*time.Minute)
 
 	// --- Step 2: synchronize — push a new commit to the PR branch and fire
 	// a synchronize webhook. The handler should update the existing PE's SHA.
@@ -219,6 +220,7 @@ func TestPreviewEnvironmentViaWebhook(t *testing.T) {
 
 	// Wait for rebuild: status should cycle back to Ready under the new SHA.
 	waitForPreviewReady(t, ns, peName, 3*time.Minute)
+	waitForAppEnvBuiltSHA(t, ns, app.Name, fmt.Sprintf("pr-%d", prNumber), newSHA, 3*time.Minute)
 
 	// --- Step 3: closed — fire the close webhook. The handler should delete
 	// the PE, and the controller should garbage-collect owned resources.
@@ -383,6 +385,24 @@ func giteaPRPayload(action string, number int, branch, sha, owner, repo string) 
 		panic(fmt.Sprintf("marshal PR payload: %v", err)) // fixture data; not test-facing
 	}
 	return b
+}
+
+func waitForAppEnvBuiltSHA(t *testing.T, namespace, appName, envName, sha string, timeout time.Duration) {
+	t.Helper()
+	helpers.RequireEventually(t, timeout, func() bool {
+		var app mortisev1alpha1.App
+		if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name: appName, Namespace: namespace,
+		}, &app); err != nil {
+			return false
+		}
+		for _, env := range app.Status.Environments {
+			if env.Name == envName && env.LastBuiltSHA == sha {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 // postWebhook POSTs the payload to the Mortise webhook endpoint with a correct


### PR DESCRIPTION
## Summary
- use preview PR SHA as the preview build revision/identity while keeping the PR branch for checkout
- sanitize preview image tag parts so slash-containing branch names cannot produce invalid OCI refs
- requeue apps on PreviewEnvironment updates and add regression coverage for same-branch/new-SHA rebuilds

## Validation
- `go test ./internal/controller -run 'Test(AllEnvBuildsCurrentForRevision|EnsureAppBuildRun|AppBuildRunSpec|EnvImageTag|ReconcileEnvBuild)'`
- `go test ./internal/controller`
- `go test -tags=integration ./test/integration -run TestPreviewEnvironmentViaWebhook -count=1` *(blocked locally by stale dev cluster before code path execution; see notes)*

## Notes
The local integration environment had an unhealthy `mortise` deployment (`ErrImageNeverPull` on a stale dev image tag), so the preview webhook integration harness failed before exercising the updated controller path. CI should provide the full cluster-backed signal.

Closes #387.
