### PR TITLE
[codex] Fix preview namespace teardown and BuildRun retention

### DIFF
--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,7 @@ const (
 	buildRunPollInterval        = 15 * time.Second
 	buildRunTrackerLossGrace    = 5 * time.Second
 	maxBuildRunRecoveryAttempts = 2
+	buildRunHistoryLimit        = 10
 )
 
 // BuildRunReconciler reconciles durable BuildRun objects.
@@ -75,6 +77,9 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if isBuildRunTerminal(&br) {
+		if err := r.gcBuildRunHistory(ctx, &br); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -124,6 +129,9 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 			if err := r.projectTerminalBuildRunStatus(ctx, &br); err != nil {
+				return ctrl.Result{}, err
+			}
+			if err := r.gcBuildRunHistory(ctx, &br); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -404,6 +412,136 @@ func (r *BuildRunReconciler) projectTerminalBuildRunStatus(ctx context.Context, 
 	default:
 		return nil
 	}
+}
+
+func (r *BuildRunReconciler) gcBuildRunHistory(ctx context.Context, br *mortisev1alpha1.BuildRun) error {
+	if br == nil ||
+		br.Spec.TargetRef.Kind != mortisev1alpha1.BuildRunTargetAppEnvironment ||
+		br.Spec.TargetRef.Name == "" ||
+		br.Spec.Environment == "" {
+		return nil
+	}
+
+	var runs mortisev1alpha1.BuildRunList
+	if err := r.List(ctx, &runs,
+		client.InNamespace(br.Namespace),
+		client.MatchingLabels{
+			buildRunTargetKindLabel:  strings.ToLower(mortisev1alpha1.BuildRunTargetAppEnvironment),
+			buildRunTargetNameLabel:  br.Spec.TargetRef.Name,
+			buildRunEnvironmentLabel: br.Spec.Environment,
+		},
+	); err != nil {
+		return err
+	}
+
+	protected, err := r.protectedBuildRunNames(ctx, br)
+	if err != nil {
+		return err
+	}
+
+	sort.SliceStable(runs.Items, func(i, j int) bool {
+		ti := buildRunRetentionSortTime(&runs.Items[i])
+		tj := buildRunRetentionSortTime(&runs.Items[j])
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return runs.Items[i].Name < runs.Items[j].Name
+	})
+
+	keptTerminal := 0
+	for i := range runs.Items {
+		run := &runs.Items[i]
+		if !isBuildRunTerminal(run) {
+			continue
+		}
+		if _, ok := protected[run.Name]; ok {
+			continue
+		}
+		if keptTerminal < buildRunHistoryLimit {
+			keptTerminal++
+			continue
+		}
+		if err := r.deleteRetiredBuildRun(ctx, run); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *BuildRunReconciler) protectedBuildRunNames(ctx context.Context, br *mortisev1alpha1.BuildRun) (map[string]struct{}, error) {
+	protected := map[string]struct{}{}
+	if br == nil || br.Spec.TargetRef.Name == "" {
+		return protected, nil
+	}
+
+	var app mortisev1alpha1.App
+	if err := r.Get(ctx, types.NamespacedName{Name: br.Spec.TargetRef.Name, Namespace: br.Namespace}, &app); err != nil {
+		if errors.IsNotFound(err) {
+			return protected, nil
+		}
+		return nil, err
+	}
+
+	if app.Status.CurrentBuildRunName != "" {
+		protected[app.Status.CurrentBuildRunName] = struct{}{}
+	}
+	if app.Status.LastBuildRunName != "" {
+		protected[app.Status.LastBuildRunName] = struct{}{}
+	}
+	for _, env := range app.Status.Environments {
+		if env.CurrentBuildRunRef != nil && env.CurrentBuildRunRef.Name != "" {
+			protected[env.CurrentBuildRunRef.Name] = struct{}{}
+		}
+		if env.LastSuccessfulBuildRunRef != nil && env.LastSuccessfulBuildRunRef.Name != "" {
+			protected[env.LastSuccessfulBuildRunRef.Name] = struct{}{}
+		}
+	}
+	return protected, nil
+}
+
+func (r *BuildRunReconciler) deleteRetiredBuildRun(ctx context.Context, br *mortisev1alpha1.BuildRun) error {
+	if br == nil {
+		return nil
+	}
+
+	logNames := map[string]struct{}{
+		buildRunLogConfigMapName(br.Name): {},
+	}
+	if br.Status.LogRef != nil && br.Status.LogRef.Name != "" {
+		logNames[br.Status.LogRef.Name] = struct{}{}
+	}
+	for name := range logNames {
+		if err := r.Delete(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: br.Namespace,
+			},
+		}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := r.Delete(ctx, br); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func buildRunRetentionSortTime(run *mortisev1alpha1.BuildRun) time.Time {
+	if run == nil {
+		return time.Time{}
+	}
+	if run.Status.CompletedAt != nil {
+		return run.Status.CompletedAt.Time
+	}
+	if run.Status.FinishedAt != nil {
+		return run.Status.FinishedAt.Time
+	}
+	if run.Status.StartedAt != nil {
+		return run.Status.StartedAt.Time
+	}
+	return run.CreationTimestamp.Time
 }
 
 func upsertConfigMap(ctx context.Context, c client.Client, desired *corev1.ConfigMap) error {

--- a/internal/controller/buildrun_gc_test.go
+++ b/internal/controller/buildrun_gc_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestGCBuildRunHistoryKeepsRecentAndProtectedRuns(t *testing.T) {
+	scheme := newBuildRunGCScheme(t)
+	namespace := "pj-demo"
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: namespace},
+		Status: mortisev1alpha1.AppStatus{
+			LastBuildRunName: "run-13",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name:                      "production",
+				LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{Name: "run-01", Phase: mortisev1alpha1.BuildRunPhaseSucceeded},
+				CurrentBuildRunRef:        &mortisev1alpha1.BuildRunReference{Name: "run-13", Phase: mortisev1alpha1.BuildRunPhaseSucceeded},
+			}},
+		},
+	}
+
+	objects := []client.Object{app}
+	for i := 1; i <= 13; i++ {
+		name := fmt.Sprintf("run-%02d", i)
+		run := testTerminalBuildRun(name, namespace, "demo", "production", time.Unix(int64(i), 0))
+		objects = append(objects, run, testBuildRunLogConfigMap(run))
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &BuildRunReconciler{Client: c, Scheme: scheme}
+
+	current := &mortisev1alpha1.BuildRun{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "run-13", Namespace: namespace}, current); err != nil {
+		t.Fatalf("get current buildrun: %v", err)
+	}
+	if err := r.gcBuildRunHistory(context.Background(), current); err != nil {
+		t.Fatalf("gc buildrun history: %v", err)
+	}
+
+	var runs mortisev1alpha1.BuildRunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("list buildruns: %v", err)
+	}
+	if len(runs.Items) != 12 {
+		t.Fatalf("expected 12 buildruns after retention, got %d", len(runs.Items))
+	}
+	assertBuildRunPresent(t, runs.Items, "run-01")
+	assertBuildRunMissing(t, runs.Items, "run-02")
+
+	var deletedLog corev1.ConfigMap
+	if err := c.Get(context.Background(), client.ObjectKey{Name: buildRunLogConfigMapName("run-02"), Namespace: namespace}, &deletedLog); err == nil {
+		t.Fatalf("expected deleted durable log configmap for run-02")
+	}
+}
+
+func TestGCBuildRunHistorySkipsPendingAndRunningAndIgnoresUnrelatedRuns(t *testing.T) {
+	scheme := newBuildRunGCScheme(t)
+	namespace := "pj-demo"
+
+	objects := []client.Object{}
+	for i := 1; i <= 11; i++ {
+		name := fmt.Sprintf("run-%02d", i)
+		run := testTerminalBuildRun(name, namespace, "demo", "production", time.Unix(int64(i), 0))
+		objects = append(objects, run, testBuildRunLogConfigMap(run))
+	}
+	pending := testBuildRunWithPhase("run-pending", namespace, "demo", "production", mortisev1alpha1.BuildRunPhasePending, time.Unix(20, 0))
+	running := testBuildRunWithPhase("run-running", namespace, "demo", "production", mortisev1alpha1.BuildRunPhaseRunning, time.Unix(21, 0))
+	otherEnv := testTerminalBuildRun("run-staging", namespace, "demo", "staging", time.Unix(22, 0))
+	otherApp := testTerminalBuildRun("run-other-app", namespace, "other", "production", time.Unix(23, 0))
+	objects = append(objects, pending, running, otherEnv, otherApp)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &BuildRunReconciler{Client: c, Scheme: scheme}
+
+	current := &mortisev1alpha1.BuildRun{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "run-11", Namespace: namespace}, current); err != nil {
+		t.Fatalf("get current buildrun: %v", err)
+	}
+	if err := r.gcBuildRunHistory(context.Background(), current); err != nil {
+		t.Fatalf("gc buildrun history: %v", err)
+	}
+
+	var runs mortisev1alpha1.BuildRunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("list buildruns: %v", err)
+	}
+	assertBuildRunMissing(t, runs.Items, "run-01")
+	assertBuildRunPresent(t, runs.Items, "run-pending")
+	assertBuildRunPresent(t, runs.Items, "run-running")
+	assertBuildRunPresent(t, runs.Items, "run-staging")
+	assertBuildRunPresent(t, runs.Items, "run-other-app")
+}
+
+func TestGCBuildRunHistoryPrunesWhenAppIsMissing(t *testing.T) {
+	scheme := newBuildRunGCScheme(t)
+	namespace := "pj-demo"
+
+	objects := []client.Object{}
+	for i := 1; i <= 11; i++ {
+		name := fmt.Sprintf("run-%02d", i)
+		run := testTerminalBuildRun(name, namespace, "demo", "production", time.Unix(int64(i), 0))
+		objects = append(objects, run, testBuildRunLogConfigMap(run))
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &BuildRunReconciler{Client: c, Scheme: scheme}
+
+	current := &mortisev1alpha1.BuildRun{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "run-11", Namespace: namespace}, current); err != nil {
+		t.Fatalf("get current buildrun: %v", err)
+	}
+	if err := r.gcBuildRunHistory(context.Background(), current); err != nil {
+		t.Fatalf("gc buildrun history without app: %v", err)
+	}
+
+	var runs mortisev1alpha1.BuildRunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("list buildruns: %v", err)
+	}
+	if len(runs.Items) != 10 {
+		t.Fatalf("expected 10 buildruns after retention without app, got %d", len(runs.Items))
+	}
+	assertBuildRunMissing(t, runs.Items, "run-01")
+}
+
+func newBuildRunGCScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return scheme
+}
+
+func testTerminalBuildRun(name, namespace, appName, env string, ts time.Time) *mortisev1alpha1.BuildRun {
+	return testBuildRunWithPhase(name, namespace, appName, env, mortisev1alpha1.BuildRunPhaseSucceeded, ts)
+}
+
+func testBuildRunWithPhase(name, namespace, appName, env string, phase mortisev1alpha1.BuildRunPhase, ts time.Time) *mortisev1alpha1.BuildRun {
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(ts),
+		},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind: mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name: appName,
+			},
+			AppName:     appName,
+			Environment: env,
+			Revision:    name,
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase: phase,
+		},
+	}
+	if phase == mortisev1alpha1.BuildRunPhaseSucceeded || phase == mortisev1alpha1.BuildRunPhaseFailed {
+		completed := metav1.NewTime(ts)
+		run.Status.CompletedAt = &completed
+		run.Status.LogRef = &corev1.LocalObjectReference{Name: buildRunLogConfigMapName(name)}
+	}
+	run.Labels = buildRunLabels(run)
+	return run
+}
+
+func testBuildRunLogConfigMap(run *mortisev1alpha1.BuildRun) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      buildRunLogConfigMapName(run.Name),
+			Namespace: run.Namespace,
+		},
+	}
+}
+
+func assertBuildRunPresent(t *testing.T, runs []mortisev1alpha1.BuildRun, name string) {
+	t.Helper()
+	for _, run := range runs {
+		if run.Name == name {
+			return
+		}
+	}
+	t.Fatalf("expected buildrun %q to be present", name)
+}
+
+func assertBuildRunMissing(t *testing.T, runs []mortisev1alpha1.BuildRun, name string) {
+	t.Helper()
+	for _, run := range runs {
+		if run.Name == name {
+			t.Fatalf("expected buildrun %q to be deleted", name)
+		}
+	}
+}

--- a/internal/controller/buildrun_support.go
+++ b/internal/controller/buildrun_support.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/git"
@@ -317,6 +318,9 @@ func (r *AppReconciler) ensureAppBuildRun(ctx context.Context, app *mortisev1alp
 			Namespace: app.Namespace,
 		},
 		Spec: spec,
+	}
+	if err := controllerutil.SetControllerReference(app, &run, r.Scheme); err != nil {
+		return nil, err
 	}
 	for k, v := range appLabels(app, envName) {
 		if run.Labels == nil {

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -66,6 +66,9 @@ func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
 	if run.Spec.TokenSecretRef == nil {
 		t.Fatal("expected token secret ref")
 	}
+	if len(run.OwnerReferences) != 1 || run.OwnerReferences[0].Kind != "App" || run.OwnerReferences[0].Name != app.Name {
+		t.Fatalf("expected buildrun owner App/%s, got %+v", app.Name, run.OwnerReferences)
+	}
 	if got := app.Annotations[rebuildRequestedAtAnnotation]; got != "" {
 		t.Fatalf("expected rebuild request marker cleared, got %q", got)
 	}
@@ -508,9 +511,9 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		},
 		Spec: appBuildRunSpec(app, "pr-6", "feature/preview-fail", "same-sha", "registry.example.com/mortise/demo:same-sh-pr-6", "registry.example.com/mortise/demo:same-sh-pr-6"),
 		Status: mortisev1alpha1.BuildRunStatus{
-			Phase:         mortisev1alpha1.BuildRunPhaseFailed,
-			FailureReason: "BuildFailed",
-			FailureMessage:"invalid reference format",
+			Phase:          mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason:  "BuildFailed",
+			FailureMessage: "invalid reference format",
 		},
 	}
 

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -66,6 +66,7 @@ type PreviewEnvironmentReconciler struct {
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=previewenvironments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=projects,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=apps,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;delete
 
 func (r *PreviewEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -440,10 +441,9 @@ func copySourceAnnotations(src map[string]string) map[string]string {
 	return out
 }
 
-// cleanupPreview removes the preview env entry from the Project and strips
-// per-app env overrides for the preview env name. Copied Secrets in the preview
-// namespace are not explicitly deleted — the Project controller garbage-collects
-// the entire env namespace when the env entry is removed.
+// cleanupPreview removes the preview env entry from the Project, strips
+// per-app env overrides for the preview env name, and requests deletion of
+// the preview namespace before the PE finalizer is removed.
 func (r *PreviewEnvironmentReconciler) cleanupPreview(ctx context.Context, pe *mortisev1alpha1.PreviewEnvironment, projectName, envName string) error {
 	if err := r.removeProjectEnv(ctx, projectName, envName); err != nil {
 		return err
@@ -459,7 +459,49 @@ func (r *PreviewEnvironmentReconciler) cleanupPreview(ctx context.Context, pe *m
 			return err
 		}
 	}
+
+	return r.deletePreviewNamespace(ctx, projectName, envName)
+}
+
+func (r *PreviewEnvironmentReconciler) deletePreviewNamespace(ctx context.Context, projectName, envName string) error {
+	previewNS := types.NamespacedName{Name: constants.EnvNamespace(projectName, envName)}
+
+	var ns corev1.Namespace
+	if err := r.Get(ctx, previewNS, &ns); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !previewNamespaceOwnedByProject(&ns, projectName) {
+		return fmt.Errorf("refusing to delete namespace %q: not clearly managed by project %q", previewNS.Name, projectName)
+	}
+	if !ns.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	if err := r.Delete(ctx, &ns); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
 	return nil
+}
+
+func previewNamespaceOwnedByProject(ns *corev1.Namespace, projectName string) bool {
+	if ns == nil {
+		return false
+	}
+	if ns.Labels["app.kubernetes.io/managed-by"] == "mortise" &&
+		ns.Labels[constants.ProjectLabel] == projectName {
+		return true
+	}
+	for _, ref := range ns.OwnerReferences {
+		if ref.APIVersion == mortisev1alpha1.GroupVersion.String() &&
+			ref.Kind == "Project" &&
+			ref.Name == projectName {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *PreviewEnvironmentReconciler) removeProjectEnv(ctx context.Context, projectName, envName string) error {

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
@@ -959,6 +960,16 @@ var _ = Describe("PreviewEnvironment Controller", func() {
 			project, ns := createPreviewTestProject(ctx, true)
 			project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
 			Expect(k8sClient.Update(ctx, project)).To(Succeed())
+			previewNsName := constants.PreviewNamespace(project.Name, 99)
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: previewNsName,
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "mortise",
+						constants.ProjectLabel:         project.Name,
+					},
+				},
+			})).To(Succeed())
 
 			staging := &mortisev1alpha1.Environment{
 				Name: "staging",
@@ -1022,6 +1033,14 @@ var _ = Describe("PreviewEnvironment Controller", func() {
 				appEnvNames[i] = e.Name
 			}
 			Expect(appEnvNames).NotTo(ContainElement("pr-99"))
+
+			var previewNs corev1.Namespace
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: previewNsName}, &previewNs)
+			if err == nil {
+				Expect(previewNs.DeletionTimestamp).NotTo(BeNil())
+			} else {
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
 		})
 
 		It("should handle deletion gracefully when the Project is already gone", func() {
@@ -1051,6 +1070,42 @@ var _ = Describe("PreviewEnvironment Controller", func() {
 				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: ns},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should refuse to delete a preview namespace it cannot attribute to the project", func() {
+			ctx := context.Background()
+			project, ns := createPreviewTestProject(ctx, true)
+			project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
+			Expect(k8sClient.Update(ctx, project)).To(Succeed())
+
+			createPreviewApp(ctx, "foreign-ns-app", ns, &mortisev1alpha1.Environment{Name: "staging"})
+
+			pe := createPreviewEnv(ctx, "foreign-preview-pr-17", ns, project.Name, 17, "sha17", "feat")
+			foreignNsName := constants.PreviewNamespace(project.Name, 17)
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: foreignNsName},
+			})).To(Succeed())
+
+			reconciler := newPEReconciler()
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, pe)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: ns},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("refusing to delete namespace"))
+
+			var stuck mortisev1alpha1.PreviewEnvironment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pe.Name, Namespace: ns}, &stuck)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(&stuck, previewFinalizer)).To(BeTrue())
+
+			var foreignNs corev1.Namespace
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: foreignNsName}, &foreignNs)).To(Succeed())
 		})
 	})
 })

--- a/test/integration/preview_test.go
+++ b/test/integration/preview_test.go
@@ -221,6 +221,10 @@ func TestPreviewEnvironmentLifecycle(t *testing.T) {
 		}, &networkingv1.Ingress{})
 		return errors.IsNotFound(err)
 	})
+	helpers.RequireEventually(t, 2*time.Minute, func() bool {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: previewNs}, &corev1.Namespace{})
+		return errors.IsNotFound(err)
+	})
 
 	// Project namespace must still exist.
 	var nsObj corev1.Namespace

--- a/test/integration/preview_webhook_test.go
+++ b/test/integration/preview_webhook_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -241,6 +242,11 @@ func TestPreviewEnvironmentViaWebhook(t *testing.T) {
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Name: previewResourceName, Namespace: previewNs,
 		}, &d)
+		return errors.IsNotFound(err)
+	})
+	helpers.RequireEventually(t, 2*time.Minute, func() bool {
+		var gone corev1.Namespace
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: previewNs}, &gone)
 		return errors.IsNotFound(err)
 	})
 }


### PR DESCRIPTION
## Summary
- explicitly delete preview namespaces during PreviewEnvironment finalization
- retain only the newest terminal BuildRuns per app/environment while preserving referenced runs
- delete durable per-run build log ConfigMaps when retiring old BuildRuns

## Issues
- closes #395
- closes #396

## Testing
- go test ./internal/controller/...
- attempted: go test -v -tags integration -count=1 -timeout 40m ./test/integration/... -run '^(TestPreviewEnvironmentLifecycle|TestPreviewEnvironmentViaWebhook)$' (timed out before preview assertions; both stalled on initial base-app readiness, so local result was non-diagnostic for this patch)
