### PR TITLE
Fix env-local buildrun status projection

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -622,33 +622,36 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	// Short-circuit: skip rebuild if we already built this revision for this env
 	// with the same effective build inputs.
 	es := envStatusFor(app, envName)
-	if currentRunName := currentBuildRunNameForEnv(app, envName); currentRunName != "" {
-		var current mortisev1alpha1.BuildRun
-		if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: currentRunName}, &current); err != nil {
-			if !errors.IsNotFound(err) {
-				return "", false, false, false, err
-			}
-		} else if buildRunMatchesAppSpec(&current, app, envName, desiredRunSpec) {
-			projectAppBuildRunStatus(app, envName, &current)
-			switch current.Status.Phase {
-			case mortisev1alpha1.BuildRunPhaseSucceeded:
-				r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
-				return current.Status.Image, false, true, false, nil
-			case mortisev1alpha1.BuildRunPhaseFailed:
-				if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
+	if !hasPendingRebuildRequest(app) {
+		currentRunName := currentBuildRunNameForEnv(app, envName)
+		if currentRunName != "" {
+			var current mortisev1alpha1.BuildRun
+			if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: currentRunName}, &current); err != nil {
+				if !errors.IsNotFound(err) {
 					return "", false, false, false, err
 				}
-				return "", false, true, false, nil
-			default:
-				app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
-				meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-					Type:               "BuildStarted",
-					Status:             metav1.ConditionTrue,
-					Reason:             "BuildInProgress",
-					Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
-					LastTransitionTime: metav1.NewTime(r.clock().Now()),
-				})
-				return "", true, true, false, nil
+			} else if buildRunMatchesAppSpec(&current, app, envName, desiredRunSpec) {
+				projectAppBuildRunStatus(app, envName, &current)
+				switch current.Status.Phase {
+				case mortisev1alpha1.BuildRunPhaseSucceeded:
+					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
+					return current.Status.Image, false, true, false, nil
+				case mortisev1alpha1.BuildRunPhaseFailed:
+					if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
+						return "", false, false, false, err
+					}
+					return "", false, true, false, nil
+				default:
+					app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
+					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+						Type:               "BuildStarted",
+						Status:             metav1.ConditionTrue,
+						Reason:             "BuildInProgress",
+						Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
+						LastTransitionTime: metav1.NewTime(r.clock().Now()),
+					})
+					return "", true, true, false, nil
+				}
 			}
 		}
 	}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -219,6 +219,11 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	needsRequeue := false
 	buildStatusDirty := false
 	clearNoCache := false
+	projectionEnvOrder := make([]string, 0, len(resolvedEnvs))
+	for _, env := range resolvedEnvs {
+		projectionEnvOrder = append(projectionEnvOrder, env.Name)
+	}
+
 	for i := range resolvedEnvs {
 		env := &resolvedEnvs[i]
 		envNs, err := appEnvNs(&app, env.Name)
@@ -246,7 +251,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		var image string
 		if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && r.BuildClient != nil {
 			buildIdentity := resolveEnvBuildIdentity(&app, *env, previewBuildIdentities)
-			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, env.Name, buildIdentity.branch, buildIdentity.revision)
+			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, env.Name, buildIdentity.branch, buildIdentity.revision)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile buildrun for env %s: %w", env.Name, err)
 			}
@@ -589,7 +594,7 @@ func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Envir
 // the image to use for this env's deployment, or "" if a build is still in
 // flight (caller should skip deployment and requeue). statusDirty is true when
 // applyEnvBuildSuccess mutated app.Status and the caller must flush.
-func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
+func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
 
 	branch = firstNonEmpty(branch, app.Spec.Source.Branch)
@@ -617,9 +622,9 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	// Short-circuit: skip rebuild if we already built this revision for this env
 	// with the same effective build inputs.
 	es := envStatusFor(app, envName)
-	if app.Status.CurrentBuildRunName != "" {
+	if currentRunName := currentBuildRunNameForEnv(app, envName); currentRunName != "" {
 		var current mortisev1alpha1.BuildRun
-		if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: app.Status.CurrentBuildRunName}, &current); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: currentRunName}, &current); err != nil {
 			if !errors.IsNotFound(err) {
 				return "", false, false, false, err
 			}
@@ -627,7 +632,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 			projectAppBuildRunStatus(app, envName, &current)
 			switch current.Status.Phase {
 			case mortisev1alpha1.BuildRunPhaseSucceeded:
-				r.applyEnvBuildSuccess(ctx, app, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
+				r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
 				return current.Status.Image, false, true, false, nil
 			case mortisev1alpha1.BuildRunPhaseFailed:
 				if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
@@ -667,7 +672,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	projectAppBuildRunStatus(app, envName, run)
 	switch run.Status.Phase {
 	case mortisev1alpha1.BuildRunPhaseSucceeded:
-		r.applyEnvBuildSuccess(ctx, app, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
+		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
 		return run.Status.Image, false, true, false, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
 		if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
@@ -688,7 +693,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 }
 
 // applyEnvBuildSuccess records the successful build for a specific environment.
-func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, envName, revision, image, digest string, detectedPort int32) {
+func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32) {
 	// Update per-env status.
 	found := false
 	for i := range app.Status.Environments {
@@ -707,10 +712,11 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		})
 	}
 
-	// Keep app-level fields updated for backward compat.
-	app.Status.LastBuiltSHA = revision
-	app.Status.LastBuiltImage = image
-	app.Status.DetectedPort = detectedPort
+	if projectedEnvName(app.Status.Environments, projectionEnvOrder) == envName {
+		app.Status.LastBuiltSHA = revision
+		app.Status.LastBuiltImage = image
+		app.Status.DetectedPort = detectedPort
+	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildSucceeded",
@@ -852,6 +858,89 @@ func envStatusFor(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.Env
 	return nil
 }
 
+func projectedEnvName(envStatuses []mortisev1alpha1.EnvironmentStatus, projectionEnvOrder []string) string {
+	if len(envStatuses) == 0 {
+		return ""
+	}
+
+	statusByName := make(map[string]mortisev1alpha1.EnvironmentStatus, len(envStatuses))
+	extras := make([]string, 0, len(envStatuses))
+	for _, es := range envStatuses {
+		statusByName[es.Name] = es
+		extras = append(extras, es.Name)
+	}
+
+	seen := make(map[string]struct{}, len(projectionEnvOrder))
+	orderedNames := make([]string, 0, len(projectionEnvOrder)+len(extras))
+	for _, envName := range projectionEnvOrder {
+		if _, ok := statusByName[envName]; !ok {
+			continue
+		}
+		orderedNames = append(orderedNames, envName)
+		seen[envName] = struct{}{}
+	}
+
+	sort.Strings(extras)
+	for _, envName := range extras {
+		if _, ok := seen[envName]; ok {
+			continue
+		}
+		orderedNames = append(orderedNames, envName)
+	}
+
+	for _, envName := range orderedNames {
+		es := statusByName[envName]
+		if es.LastBuiltImage != "" {
+			return envName
+		}
+	}
+	return ""
+}
+
+func projectedBuildRunName(es mortisev1alpha1.EnvironmentStatus) string {
+	if es.CurrentBuildRunRef != nil && es.CurrentBuildRunRef.Phase == mortisev1alpha1.BuildRunPhaseSucceeded {
+		return es.CurrentBuildRunRef.Name
+	}
+	if es.LastSuccessfulBuildRunRef != nil {
+		return es.LastSuccessfulBuildRunRef.Name
+	}
+	return ""
+}
+
+func (r *AppReconciler) projectAppBuildMetadata(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string) error {
+	app.Status.LastBuiltSHA = ""
+	app.Status.LastBuiltImage = ""
+	app.Status.DetectedPort = 0
+
+	envName := projectedEnvName(app.Status.Environments, projectionEnvOrder)
+	if envName == "" {
+		return nil
+	}
+
+	es := envStatusFor(app, envName)
+	if es == nil {
+		return nil
+	}
+
+	app.Status.LastBuiltSHA = es.LastBuiltSHA
+	app.Status.LastBuiltImage = es.LastBuiltImage
+
+	runName := projectedBuildRunName(*es)
+	if runName == "" {
+		return nil
+	}
+
+	var run mortisev1alpha1.BuildRun
+	if err := r.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: runName}, &run); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	app.Status.DetectedPort = run.Status.DetectedPort
+	return nil
+}
+
 func envSelectedForBuildFailureAggregation(envName string, aggregationEnvNames map[string]struct{}) bool {
 	if len(aggregationEnvNames) == 0 {
 		return false
@@ -900,7 +989,7 @@ func excludedEnvHasTerminalBuildFailure(envStatuses []mortisev1alpha1.Environmen
 	return false
 }
 
-func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment, previewEnvNames map[string]struct{}) bool {
+func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, _ []mortisev1alpha1.Environment, _ map[string]struct{}) bool {
 	if app.Status.Phase != mortisev1alpha1.AppPhaseFailed {
 		return false
 	}
@@ -910,16 +999,12 @@ func shouldRefreshFailedAppStatus(app *mortisev1alpha1.App, resolvedEnvs []morti
 		return false
 	}
 
-	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
-	if len(buildAggregationEnvNames) == 0 {
-		return false
+	for _, es := range app.Status.Environments {
+		if es.CurrentBuildRunRef != nil && isTerminalBuildFailurePhase(es.CurrentBuildRunRef.Phase) {
+			return true
+		}
 	}
-
-	if selectedEnvHasTerminalBuildFailure(app.Status.Environments, buildAggregationEnvNames) {
-		return false
-	}
-
-	return excludedEnvHasTerminalBuildFailure(app.Status.Environments, buildAggregationEnvNames)
+	return false
 }
 
 // currentImageForEnv returns the image currently deployed for the given
@@ -2799,6 +2884,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		}
 
 		envStatuses := make([]mortisev1alpha1.EnvironmentStatus, 0, len(resolvedEnvs))
+		projectionEnvOrder := make([]string, 0, len(resolvedEnvs))
 		buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
 
 		isCron := app.Spec.Kind == mortisev1alpha1.AppKindCron
@@ -2808,6 +2894,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		firstCrashMsg := ""
 
 		for _, env := range resolvedEnvs {
+			projectionEnvOrder = append(projectionEnvOrder, env.Name)
 			autoDomain := ""
 			if app.Spec.Network.Public {
 				autoDomain = r.autoDefaultDomain(ctx, app, env.Name)
@@ -2995,6 +3082,9 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 
 		fresh.Status.Phase = phase
 		fresh.Status.Environments = envStatuses
+		if err := r.projectAppBuildMetadata(ctx, &fresh, projectionEnvOrder); err != nil {
+			return err
+		}
 		fresh.Status.CurrentBuildRunName, fresh.Status.LastBuildRunName = aggregateAppBuildRunNames(envStatuses)
 		return r.Status().Update(ctx, &fresh)
 	})

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -367,6 +367,104 @@ func TestUpdateStatusRecomputesTopLevelBuildRunNamesFromTerminalEnvRef(t *testin
 	}
 }
 
+func TestUpdateStatusProjectsTopLevelBuildMetadataFromResolvedEnvOrder(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:  mortisev1alpha1.SourceTypeImage,
+				Image: "nginx:1.27",
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "preview"}, {Name: "production"}},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			LastBuiltSHA:   "poisoned-sha",
+			LastBuiltImage: "registry.example/demo:preview",
+			DetectedPort:   3000,
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "preview",
+					LastBuiltSHA:   "preview-sha",
+					LastBuiltImage: "registry.example/demo:preview",
+					LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "preview-run",
+						Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+					},
+				},
+				{
+					Name:           "production",
+					LastBuiltSHA:   "prod-sha",
+					LastBuiltImage: "registry.example/demo:prod",
+					LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "prod-run",
+						Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+					},
+				},
+			},
+		},
+	}
+	productionRun := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prod-run",
+			Namespace: app.Namespace,
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:        mortisev1alpha1.BuildRunPhaseSucceeded,
+			DetectedPort: 8081,
+		},
+	}
+	previewRun := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-run",
+			Namespace: app.Namespace,
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:        mortisev1alpha1.BuildRunPhaseSucceeded,
+			DetectedPort: 3000,
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+	previewDep := newReadyDeploymentForStatusTest(t, app, "preview")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep, previewDep).
+		WithObjects(app, productionRun, previewRun, productionDep, previewDep).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+	if err := c.Status().Update(ctx, previewDep); err != nil {
+		t.Fatalf("seed preview deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "preview"}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, nil); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.LastBuiltSHA != "prod-sha" {
+		t.Fatalf("expected projected SHA from production, got %q", fresh.Status.LastBuiltSHA)
+	}
+	if fresh.Status.LastBuiltImage != "registry.example/demo:prod" {
+		t.Fatalf("expected projected image from production, got %q", fresh.Status.LastBuiltImage)
+	}
+	if fresh.Status.DetectedPort != 8081 {
+		t.Fatalf("expected projected detected port from production, got %d", fresh.Status.DetectedPort)
+	}
+}
+
 func TestUpdateStatusMarksDegradedWhenLatestBuildFailsButPreviousImageStillServes(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
@@ -1166,7 +1264,7 @@ func TestShouldRefreshFailedAppStatusForRemovedPreviewBuildFailure(t *testing.T)
 	}
 }
 
-func TestShouldRefreshFailedAppStatusSkipsNonPreviewBuildFailure(t *testing.T) {
+func TestShouldRefreshFailedAppStatusForSelectedEnvBuildFailure(t *testing.T) {
 	app := &mortisev1alpha1.App{
 		Status: mortisev1alpha1.AppStatus{
 			Phase: mortisev1alpha1.AppPhaseFailed,
@@ -1197,8 +1295,29 @@ func TestShouldRefreshFailedAppStatusSkipsNonPreviewBuildFailure(t *testing.T) {
 	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
 	previewEnvNames := map[string]struct{}{"pr-6": {}}
 
-	if shouldRefreshFailedAppStatus(app, resolvedEnvs, previewEnvNames) {
-		t.Fatal("expected failed app with non-preview build failure to keep failed latch")
+	if !shouldRefreshFailedAppStatus(app, resolvedEnvs, previewEnvNames) {
+		t.Fatal("expected failed app with env-backed build failure to refresh status")
+	}
+}
+
+func TestShouldRefreshFailedAppStatusSkipsAppGlobalBuildFailure(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseFailed,
+			Conditions: []metav1.Condition{{
+				Type:   "BuildSucceeded",
+				Status: metav1.ConditionFalse,
+				Reason: "BuildFailed",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+	}
+
+	if shouldRefreshFailedAppStatus(app, []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}, map[string]struct{}{"pr-6": {}}) {
+		t.Fatal("expected app-global build failure to keep failed latch")
 	}
 }
 

--- a/internal/controller/buildrun_support.go
+++ b/internal/controller/buildrun_support.go
@@ -188,6 +188,14 @@ func projectAppBuildRunStatus(app *mortisev1alpha1.App, envName string, run *mor
 	}
 }
 
+func currentBuildRunNameForEnv(app *mortisev1alpha1.App, envName string) string {
+	es := envStatusFor(app, envName)
+	if es == nil || es.CurrentBuildRunRef == nil {
+		return ""
+	}
+	return es.CurrentBuildRunRef.Name
+}
+
 func aggregateAppBuildRunNames(envs []mortisev1alpha1.EnvironmentStatus) (current, last string) {
 	for _, es := range envs {
 		if es.CurrentBuildRunRef == nil {
@@ -293,14 +301,17 @@ func buildRunMatchesAppSpec(run *mortisev1alpha1.BuildRun, app *mortisev1alpha1.
 
 func (r *AppReconciler) ensureAppBuildRun(ctx context.Context, app *mortisev1alpha1.App, envName, branch, revision, pushTarget, pullTarget string) (*mortisev1alpha1.BuildRun, error) {
 	spec := appBuildRunSpec(app, envName, branch, revision, pushTarget, pullTarget)
-	if !hasPendingRebuildRequest(app) && app.Status.CurrentBuildRunName != "" {
-		var current mortisev1alpha1.BuildRun
-		if err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Status.CurrentBuildRunName}, &current); err == nil {
-			if buildRunMatchesAppSpec(&current, app, envName, spec) {
-				return &current, nil
+	if !hasPendingRebuildRequest(app) {
+		currentRunName := currentBuildRunNameForEnv(app, envName)
+		if currentRunName != "" {
+			var current mortisev1alpha1.BuildRun
+			if err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: currentRunName}, &current); err == nil {
+				if buildRunMatchesAppSpec(&current, app, envName, spec) {
+					return &current, nil
+				}
+			} else if !errors.IsNotFound(err) {
+				return nil, err
 			}
-		} else if !errors.IsNotFound(err) {
-			return nil, err
 		}
 	}
 	name := buildRunName("app", app.Name, envName, revision, spec.InputHash, spec.RequestID)

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -567,6 +567,93 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 	}
 }
 
+func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision":              "same-sha",
+				rebuildRequestedAtAnnotation:        "req-1",
+				rebuildNoCacheRequestedAtAnnotation: "req-1",
+				"mortise.dev/git-token-owner":       "owner@example.com",
+				"mortise.dev/no-cache-build":        "true",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://example.com/repo.git",
+				Branch:      "main",
+				ProviderRef: "github",
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			CurrentBuildRunName: "manual-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name:           "production",
+				LastBuiltSHA:   "same-sha",
+				LastBuiltImage: "registry.example.com/demo:old",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "manual-run",
+					Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+				},
+				LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "manual-run",
+					Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+				},
+			}},
+		},
+	}
+	previousRun := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-run",
+			Namespace: app.Namespace,
+		},
+		Spec: appBuildRunSpec(&mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        app.Name,
+				Namespace:   app.Namespace,
+				Annotations: map[string]string{"mortise.dev/revision": "same-sha", "mortise.dev/git-token-owner": "owner@example.com"},
+			},
+			Spec: app.Spec,
+		}, "production", "main", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production"),
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+			Image: "registry.example.com/demo:old",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, previousRun).Build()
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		RegistryBackend: &fakeRegistryBackend{},
+	}
+
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	if err != nil {
+		t.Fatalf("reconcileEnvBuild: %v", err)
+	}
+	if image != "" {
+		t.Fatalf("expected manual rebuild to create a fresh buildrun, got image %q", image)
+	}
+	if !requeue {
+		t.Fatal("expected manual rebuild to requeue on fresh buildrun")
+	}
+	if !statusDirty {
+		t.Fatal("expected manual rebuild to dirty status")
+	}
+	if app.Status.CurrentBuildRunName == "manual-run" {
+		t.Fatal("expected manual rebuild to replace the previous terminal run")
+	}
+}
+
 func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -77,6 +77,68 @@ func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
 	}
 }
 
+func TestEnsureAppBuildRunDoesNotReuseAnotherEnvsCurrentRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/git-token-owner": "owner@example.com",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://example.com/repo.git",
+				Branch:      "main",
+				ProviderRef: "github",
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			CurrentBuildRunName: "production-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name: "production",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "production-run",
+						Phase: mortisev1alpha1.BuildRunPhaseRunning,
+					},
+				},
+			},
+		},
+	}
+
+	productionRun := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "production-run",
+			Namespace: app.Namespace,
+		},
+		Spec: appBuildRunSpec(app, "production", "main", "abc1234567890", "registry/push:prod", "registry/pull:prod"),
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase: mortisev1alpha1.BuildRunPhaseRunning,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, productionRun).Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	run, err := r.ensureAppBuildRun(context.Background(), app, "staging", "main", "abc1234567890", "registry/push:staging", "registry/pull:staging")
+	if err != nil {
+		t.Fatalf("ensure buildrun: %v", err)
+	}
+	if run.Name == productionRun.Name {
+		t.Fatalf("expected staging buildrun not to reuse production run %q", run.Name)
+	}
+	if run.Spec.Environment != "staging" {
+		t.Fatalf("expected staging buildrun, got %q", run.Spec.Environment)
+	}
+}
+
 func TestParseImageRefSplitsRegistryPathAndTag(t *testing.T) {
 	ref := parseImageRef("registry.example.com/team/app:sha-prod")
 	if ref.Registry != "registry.example.com" {
@@ -235,6 +297,13 @@ func TestEnsureAppBuildRunReusesCurrentManualRunAfterMarkersClear(t *testing.T) 
 		},
 		Status: mortisev1alpha1.AppStatus{
 			CurrentBuildRunName: "manual-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "production",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "manual-run",
+					Phase: mortisev1alpha1.BuildRunPhaseRunning,
+				},
+			}},
 		},
 		Spec: mortisev1alpha1.AppSpec{
 			Source: mortisev1alpha1.AppSource{
@@ -296,6 +365,13 @@ func TestEnsureAppBuildRunReusesCurrentTerminalRunBeforeStatusProjection(t *test
 		},
 		Status: mortisev1alpha1.AppStatus{
 			CurrentBuildRunName: "manual-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "production",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "manual-run",
+					Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+				},
+			}},
 		},
 		Spec: mortisev1alpha1.AppSpec{
 			Source: mortisev1alpha1.AppSource{
@@ -358,6 +434,13 @@ func TestEnsureAppBuildRunDoesNotReuseCurrentRunWhenInputHashChanges(t *testing.
 		},
 		Status: mortisev1alpha1.AppStatus{
 			CurrentBuildRunName: "current-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "production",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "current-run",
+					Phase: mortisev1alpha1.BuildRunPhaseRunning,
+				},
+			}},
 		},
 		Spec: mortisev1alpha1.AppSpec{
 			Source: mortisev1alpha1.AppSource{
@@ -427,6 +510,10 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 					Name:           "production",
 					LastBuiltSHA:   "same-sha",
 					LastBuiltImage: "registry.example.com/demo:old",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "manual-run",
+						Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+					},
 				},
 			},
 		},
@@ -456,7 +543,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -502,6 +589,13 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		},
 		Status: mortisev1alpha1.AppStatus{
 			CurrentBuildRunName: "manual-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "pr-6",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "manual-run",
+					Phase: mortisev1alpha1.BuildRunPhaseFailed,
+				},
+			}},
 		},
 	}
 	run := &mortisev1alpha1.BuildRun{
@@ -524,7 +618,7 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "pr-6", "feature/preview-fail", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, "pr-6", "feature/preview-fail", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -544,6 +638,82 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 	cond := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded")
 	if cond == nil || cond.Status != metav1.ConditionFalse {
 		t.Fatalf("expected app build failure condition to be set, got %+v", cond)
+	}
+}
+
+func TestReconcileEnvBuildDoesNotReuseAnotherEnvsCurrentRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision":        "same-sha",
+				"mortise.dev/git-token-owner": "owner@example.com",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://example.com/repo.git",
+				Branch:      "main",
+				ProviderRef: "github",
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			CurrentBuildRunName: "production-run",
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name: "production",
+					CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+						Name:  "production-run",
+						Phase: mortisev1alpha1.BuildRunPhaseRunning,
+					},
+				},
+			},
+		},
+	}
+	productionRun := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "production-run",
+			Namespace: app.Namespace,
+		},
+		Spec: appBuildRunSpec(app, "production", "main", "same-sha", "registry.example.com/mortise/demo:same-sh-production", "registry.example.com/mortise/demo:same-sh-production"),
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase: mortisev1alpha1.BuildRunPhaseRunning,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, productionRun).Build()
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		RegistryBackend: &fakeRegistryBackend{},
+	}
+
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, "staging", "main", "same-sha")
+	if err != nil {
+		t.Fatalf("reconcileEnvBuild: %v", err)
+	}
+	if image != "" {
+		t.Fatalf("expected staging build to stay in flight, got %q", image)
+	}
+	if !requeue {
+		t.Fatal("expected staging buildrun creation to requeue")
+	}
+	if !statusDirty {
+		t.Fatal("expected status dirty after staging buildrun creation")
+	}
+	if app.Status.CurrentBuildRunName == "production-run" {
+		t.Fatal("expected staging buildrun to replace app-level current name during projection")
+	}
+	stagingStatus := envStatusFor(app, "staging")
+	if stagingStatus == nil || stagingStatus.CurrentBuildRunRef == nil || stagingStatus.CurrentBuildRunRef.Name == "production-run" {
+		t.Fatalf("expected staging env to get its own buildrun ref, got %+v", stagingStatus)
 	}
 }
 
@@ -607,7 +777,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -665,6 +835,43 @@ func TestProjectAppBuildRunStatusProjectsRefs(t *testing.T) {
 	}
 	if es.LastSuccessfulBuildRunRef == nil || es.LastSuccessfulBuildRunRef.Name != "buildrun-1" {
 		t.Fatalf("expected last successful buildrun ref, got %+v", es.LastSuccessfulBuildRunRef)
+	}
+}
+
+func TestApplyEnvBuildSuccessDoesNotOverwriteProjectedMetadataWithLaterEnv(t *testing.T) {
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltSHA:   "prod-sha",
+					LastBuiltImage: "registry.example.com/demo:prod",
+				},
+				{
+					Name: "preview",
+				},
+			},
+			LastBuiltSHA:   "prod-sha",
+			LastBuiltImage: "registry.example.com/demo:prod",
+			DetectedPort:   8081,
+		},
+	}
+
+	r := &AppReconciler{}
+	r.applyEnvBuildSuccess(context.Background(), app, []string{"production", "preview"}, "preview", "preview-sha", "registry.example.com/demo:preview", "sha256:preview", 3000)
+
+	if app.Status.LastBuiltSHA != "prod-sha" {
+		t.Fatalf("expected projected SHA to stay on production, got %q", app.Status.LastBuiltSHA)
+	}
+	if app.Status.LastBuiltImage != "registry.example.com/demo:prod" {
+		t.Fatalf("expected projected image to stay on production, got %q", app.Status.LastBuiltImage)
+	}
+	if app.Status.DetectedPort != 8081 {
+		t.Fatalf("expected projected port to stay on production, got %d", app.Status.DetectedPort)
+	}
+	previewStatus := envStatusFor(app, "preview")
+	if previewStatus == nil || previewStatus.LastBuiltImage != "registry.example.com/demo:preview" {
+		t.Fatalf("expected preview env build recorded, got %+v", previewStatus)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop env reconcile/buildrun ensure paths from consulting the app-global current buildrun name
- reaggregate env-backed failed apps through updateStatus and project top-level build metadata deterministically from env order
- add focused regressions for cross-env buildrun isolation, failed-app recovery, and deterministic metadata/port projection

## Testing
- go test ./internal/controller -run 'Test(EnsureAppBuildRunReusesCurrentManualRunAfterMarkersClear|EnsureAppBuildRunReusesCurrentTerminalRunBeforeStatusProjection|EnsureAppBuildRunDoesNotReuseCurrentRunWhenInputHashChanges|ReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit|ReconcileEnvBuildProjectsFailedCurrentRunIntoStatus|EnsureAppBuildRunDoesNotReuseAnotherEnvsCurrentRun|ReconcileEnvBuildDoesNotReuseAnotherEnvsCurrentRun|ApplyEnvBuildSuccessDoesNotOverwriteProjectedMetadataWithLaterEnv|UpdateStatusProjectsTopLevelBuildMetadataFromResolvedEnvOrder|ShouldRefreshFailedAppStatusForSelectedEnvBuildFailure|ShouldRefreshFailedAppStatusSkipsAppGlobalBuildFailure)$'
- go test ./internal/controller