### PR TITLE
Polish settings UI for passwords and namespaces

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -91,8 +91,7 @@
 					{#if project.description}
 						<p class="mt-2 text-xs text-gray-500 line-clamp-2">{project.description}</p>
 					{/if}
-					<div class="mt-3 flex items-center justify-between text-xs text-gray-500">
-						<span class="font-mono">{project.namespace}</span>
+					<div class="mt-3 flex items-center justify-end text-xs text-gray-500">
 						<span>{project.appCount} app{project.appCount === 1 ? '' : 's'}</span>
 					</div>
 				</a>

--- a/ui/src/routes/projects/[project]/settings/+page.svelte
+++ b/ui/src/routes/projects/[project]/settings/+page.svelte
@@ -379,6 +379,17 @@
           <p class="mt-1 text-xs text-gray-500">Names cannot be changed after creation.</p>
         </div>
         <div>
+          <label class={labelCls} for="proj-namespace">Namespace</label>
+          <input
+            id="proj-namespace"
+            type="text"
+            value={project?.namespace ?? ''}
+            disabled
+            class="w-full cursor-not-allowed rounded-md border border-surface-600 bg-surface-700 px-3 py-2 font-mono text-sm text-gray-400"
+          />
+          <p class="mt-1 text-xs text-gray-500">Backing Kubernetes namespace for this project.</p>
+        </div>
+        <div>
           <label class={labelCls} for="proj-desc">Description</label>
           <input id="proj-desc" type="text" bind:value={editDesc} placeholder="Optional description" class={inputCls} />
         </div>

--- a/ui/src/routes/settings/+page.svelte
+++ b/ui/src/routes/settings/+page.svelte
@@ -939,15 +939,16 @@
 							class="w-full rounded-md border border-surface-600 bg-surface-900 px-3 py-2 text-sm text-white placeholder-gray-500 outline-none focus:border-accent" />
 					</div>
 					<div>
-						<label class="block text-xs text-gray-500 mb-1" for="new-user-password">Password (auto-generated)</label>
+						<label class="block text-xs text-gray-500 mb-1" for="new-user-password">Initial password</label>
 						<div class="flex gap-2">
-							<input id="new-user-password" type="text" bind:value={newUserPassword} readonly
-								class="flex-1 rounded-md border border-surface-600 bg-surface-900 px-3 py-2 text-sm text-white font-mono outline-none" />
+							<input id="new-user-password" type="text" bind:value={newUserPassword} autocomplete="new-password"
+								class="flex-1 rounded-md border border-surface-600 bg-surface-900 px-3 py-2 text-sm text-white font-mono outline-none focus:border-accent" />
 							<button type="button" onclick={() => { newUserPassword = generatePassword(); }}
 								class="rounded-md border border-surface-600 px-2.5 py-1.5 text-xs text-gray-400 hover:bg-surface-600 hover:text-white">
 								Regenerate
 							</button>
 						</div>
+						<p class="mt-1 text-xs text-gray-500">You can edit the generated password before creating the user.</p>
 					</div>
 					<div>
 						<label class="block text-xs text-gray-500 mb-1" for="new-user-role">Role</label>
@@ -959,7 +960,7 @@
 						</select>
 					</div>
 					<div class="flex gap-2">
-						<button type="button" onclick={handleCreateUser} disabled={creatingUser || !newUserEmail.trim()}
+						<button type="button" onclick={handleCreateUser} disabled={creatingUser || !newUserEmail.trim() || !newUserPassword.trim()}
 							class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50">
 							{creatingUser ? 'Creating...' : 'Create user'}
 						</button>

--- a/ui/tests/e2e/platform-settings-actions.spec.ts
+++ b/ui/tests/e2e/platform-settings-actions.spec.ts
@@ -275,4 +275,35 @@ test.describe('platform settings actions', () => {
 			})
 			.catch(() => {});
 	});
+
+	test('admin can set an explicit password when creating a user via settings UI', async ({ page, request }) => {
+		const memberEmail = `e2e-custompass-${randomSuffix()}@test.local`;
+		const explicitPassword = `Chosen-${randomSuffix()}-pass123`;
+
+		await injectToken(page, adminToken);
+		await page.goto('/settings');
+		await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible({ timeout: 10_000 });
+
+		await page.getByRole('button', { name: 'Add User', exact: true }).click();
+		await page.getByLabel('Username').fill(memberEmail);
+		await page.getByLabel('Initial password').fill(explicitPassword);
+		await page.getByRole('button', { name: 'Create user', exact: true }).click();
+
+		await expect(page.getByText('User created. Copy the password now', { exact: false })).toBeVisible({
+			timeout: 10_000
+		});
+		await expect(page.getByText(explicitPassword, { exact: true })).toBeVisible();
+
+		const loginRes = await request.post('/api/auth/login', {
+			data: { email: memberEmail, password: explicitPassword }
+		});
+		expect(loginRes.ok()).toBeTruthy();
+
+		await request
+			.delete(`/api/admin/users/${encodeURIComponent(memberEmail)}`, {
+				headers: { Authorization: `Bearer ${adminToken}` },
+				failOnStatusCode: false
+			})
+			.catch(() => {});
+	});
 });

--- a/ui/tests/e2e/project-settings.spec.ts
+++ b/ui/tests/e2e/project-settings.spec.ts
@@ -47,9 +47,14 @@ test.describe('project settings', () => {
 		});
 
 		// Project name (read-only).
-		const nameInput = page.locator('input[disabled]');
+		const nameInput = page.locator('#proj-name');
 		await expect(nameInput).toBeVisible();
 		await expect(nameInput).toHaveValue(projectName);
+
+		// Backing namespace is shown in Project Settings instead of the dashboard card.
+		const namespaceInput = page.locator('#proj-namespace');
+		await expect(namespaceInput).toBeVisible();
+		await expect(namespaceInput).toHaveValue(`pj-${projectName}`);
 
 		// Description input.
 		const descInput = page.locator('input[placeholder="Optional description"]');

--- a/ui/tests/e2e/projects.spec.ts
+++ b/ui/tests/e2e/projects.spec.ts
@@ -151,6 +151,25 @@ test.describe('projects', () => {
 		await expect(page.getByRole('button', { name: 'Delete project' })).toBeVisible();
 	});
 
+	test('dashboard hides namespace while project settings general shows it', async ({ page, request }) => {
+		const name = `e2e-ns-${randomSuffix()}`;
+		projectsToCleanup.push(name);
+		await createProjectViaAPI(request, adminToken, name, 'Namespace placement test');
+
+		await injectToken(page, adminToken);
+		await page.goto('/');
+
+		const card = page.locator('a').filter({ hasText: name });
+		await expect(card).toBeVisible({ timeout: 10_000 });
+		await expect(card.getByText(`pj-${name}`, { exact: true })).toHaveCount(0);
+
+		await page.goto(`/projects/${name}/settings`);
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
+			timeout: 10_000
+		});
+		await expect(page.getByLabel('Namespace')).toHaveValue(`pj-${name}`);
+	});
+
 	test('delete project via project settings UI', async ({ page, request }) => {
 		const name = `e2e-del-${randomSuffix()}`;
 		await createProjectViaAPI(request, adminToken, name);


### PR DESCRIPTION
## Summary
- allow admins to edit the initial password when creating a user while keeping password generation convenience
- remove backing namespace from dashboard project cards and surface it in Project Settings -> General instead
- add Playwright coverage for explicit-password user creation and the namespace relocation

## Local validation
- cd ui && npm run check
- cd ui && MORTISE_BASE_URL=http://127.0.0.1:8080 MORTISE_ADMIN_EMAIL=admin@local MORTISE_ADMIN_PASSWORD=admin123 npm run test:e2e -- ui/tests/e2e/platform-settings-actions.spec.ts ui/tests/e2e/projects.spec.ts ui/tests/e2e/project-settings.spec.ts (blocked locally: ECONNREFUSED 127.0.0.1:8080)