### PR TITLE
fix: address preview crash and activity races

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -125,6 +125,10 @@ func (s *Server) Setup(w http.ResponseWriter, r *http.Request) {
 
 	if err := native.CreateUser(r.Context(), req.Email, req.Password, auth.RoleAdmin); err != nil {
 		_ = s.client.Delete(r.Context(), sentinel)
+		if k8serrors.IsAlreadyExists(err) {
+			writeJSON(w, http.StatusConflict, errorResponse{"user already exists"})
+			return
+		}
 		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
 	}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -49,7 +51,6 @@ func TestAuthStatusSetupRequired(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	ctx := context.Background()
 	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
-
 	authProvider := auth.NewNativeAuthProvider(k8sClient)
 	jwtHelper := auth.NewJWTHelper(k8sClient)
 	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
@@ -106,6 +107,44 @@ func TestSetupCreatesAdmin(t *testing.T) {
 	w = doRequestWithToken(h, http.MethodPost, "/api/auth/setup", body, "")
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409 on second setup, got %d", w.Code)
+	}
+}
+
+func TestSetupRejectsDuplicateUserWithoutLeakingSecretName(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+	_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "mortise-setup-complete", Namespace: "mortise-system"}})
+
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	if err := authProvider.CreateUser(ctx, "admin@example.com", "initialpass", auth.RoleAdmin); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	body := map[string]any{"email": "admin@example.com", "password": "initialpass"}
+	w := doRequestWithToken(h, http.MethodPost, "/api/auth/setup", body, "")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 on duplicate setup user, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "user-") || strings.Contains(w.Body.String(), "secret") {
+		t.Fatalf("expected sanitized duplicate-user error, got %s", w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "user already exists" {
+		t.Fatalf("expected sanitized duplicate-user error, got %#v", resp)
+	}
+
+	var sentinel corev1.ConfigMap
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "mortise-setup-complete", Namespace: "mortise-system"}, &sentinel); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected duplicate setup path to clean up sentinel, got err=%v configmap=%+v", err, sentinel)
 	}
 }
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -199,8 +199,6 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.recordActivity(r, project.Name, "create", "project", project.Name, "Created project "+project.Name, "")
-
 	writeJSON(w, http.StatusCreated, toProjectResponse(project, nil))
 }
 

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -41,6 +42,11 @@ func TestCreateProjectAsAdmin(t *testing.T) {
 	var project mortisev1alpha1.Project
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-saas"}, &project); err != nil {
 		t.Fatalf("project CRD not found after create: %v", err)
+	}
+
+	var activityCM corev1.ConfigMap
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "pj-my-saas", Name: "activity-my-saas"}, &activityCM); !errors.IsNotFound(err) {
+		t.Fatalf("expected API create to leave project activity ConfigMap to the controller, got err=%v configmap=%+v", err, activityCM)
 	}
 }
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/mortise-org/mortise/internal/auth"
@@ -117,6 +118,10 @@ func (s *Server) CreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := native.CreateUser(r.Context(), req.Email, req.Password, auth.Role(req.Role)); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeJSON(w, http.StatusConflict, errorResponse{"user already exists"})
+			return
+		}
 		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
 	}

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -2,7 +2,9 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/fake"
@@ -82,5 +84,30 @@ func TestDeleteUserAllowsDeletingAdminWhenAnotherAdminExists(t *testing.T) {
 	w := doRequestWithToken(h, http.MethodDelete, "/api/admin/users/admin1@example.com", nil, token)
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateUserRejectsDuplicateWithoutLeakingSecretName(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	w := doRequest(h, http.MethodPost, "/api/admin/users", map[string]any{
+		"email":    "test@example.com",
+		"password": "anotherpass1",
+		"role":     "admin",
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "user-") || strings.Contains(w.Body.String(), "secret") {
+		t.Fatalf("expected sanitized duplicate-user error, got %s", w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "user already exists" {
+		t.Fatalf("expected sanitized duplicate-user error, got %#v", resp)
 	}
 }

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2998,6 +2998,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			} else {
 				es.Phase = mortisev1alpha1.AppPhaseDeploying
 				crashCountsTowardTopLevel := envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames)
+				countsTowardTopLevelReadiness := !excludeFromTopLevelReadiness
 				if !isCron {
 					if crashMsg := r.checkPodCrashLoopInEnv(ctx, app, env.Name, envNs); crashMsg != "" {
 						es.Phase = mortisev1alpha1.AppPhaseCrashLooping
@@ -3008,9 +3009,12 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 						if crashCountsTowardTopLevel && firstCrashMsg == "" {
 							firstCrashMsg = crashMsg
 						}
+						if !crashCountsTowardTopLevel {
+							countsTowardTopLevelReadiness = false
+						}
 					}
 				}
-				if !excludeFromTopLevelReadiness {
+				if countsTowardTopLevelReadiness {
 					anyNotReady = true
 				}
 			}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2997,12 +2997,15 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 				}
 			} else {
 				es.Phase = mortisev1alpha1.AppPhaseDeploying
+				crashCountsTowardTopLevel := envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames)
 				if !isCron {
 					if crashMsg := r.checkPodCrashLoopInEnv(ctx, app, env.Name, envNs); crashMsg != "" {
 						es.Phase = mortisev1alpha1.AppPhaseCrashLooping
 						es.Message = crashMsg
-						anyCrash = true
-						if firstCrashMsg == "" {
+						if crashCountsTowardTopLevel {
+							anyCrash = true
+						}
+						if crashCountsTowardTopLevel && firstCrashMsg == "" {
 							firstCrashMsg = crashMsg
 						}
 					}

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -1064,6 +1064,167 @@ func TestUpdateStatusCountsPreviewNotReadyWhenWorkloadExistsAfterBuildFailure(t 
 	}
 }
 
+func TestUpdateStatusIgnoresPreviewCrashLoopForTopLevelHealth(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionTrue,
+				Reason:  "BuildComplete",
+				Message: "built registry.example/demo:prod digest=sha256:prod for production",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{
+					Name:           "production",
+					LastBuiltImage: "registry.example/demo:prod",
+				},
+				{
+					Name: "pr-6",
+				},
+			},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, app, "production")
+	previewDep := newReadyDeploymentForStatusTest(t, app, "pr-6")
+	previewDep.Status.ReadyReplicas = 0
+	previewDep.Status.AvailableReplicas = 0
+	previewDep.Status.UpdatedReplicas = 1
+	previewPod := newStatusTestPod(app, "pr-6", "preview-pod", []corev1.ContainerStatus{{
+		Name:         "app",
+		RestartCount: 3,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		},
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 137,
+				Reason:   "OOMKilled",
+			},
+		},
+	}}, nil)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, productionDep, previewDep).
+		WithObjects(app, productionDep, previewDep, previewPod).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+	if err := c.Status().Update(ctx, previewDep); err != nil {
+		t.Fatalf("seed preview deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
+		t.Fatalf("expected preview crash loop to keep top-level phase %q, got %q", mortisev1alpha1.AppPhaseDeploying, fresh.Status.Phase)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "PodHealthy"); cond != nil {
+		t.Fatalf("expected preview crash loop to not poison top-level PodHealthy, got %+v", cond)
+	}
+	previewStatus := envStatusFor(&fresh, "pr-6")
+	if previewStatus == nil || previewStatus.Phase != mortisev1alpha1.AppPhaseCrashLooping {
+		t.Fatalf("expected preview env to remain crash looping, got %+v", previewStatus)
+	}
+}
+
+func TestUpdateStatusPreviewOnlyCrashLoopStillSetsTopLevelHealth(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "pr-6"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionTrue,
+				Reason:  "BuildComplete",
+				Message: "built registry.example/demo:preview digest=sha256:preview for pr-6",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "pr-6",
+			}},
+		},
+	}
+	previewDep := newReadyDeploymentForStatusTest(t, app, "pr-6")
+	previewDep.Status.ReadyReplicas = 0
+	previewDep.Status.AvailableReplicas = 0
+	previewDep.Status.UpdatedReplicas = 1
+	previewPod := newStatusTestPod(app, "pr-6", "preview-pod", []corev1.ContainerStatus{{
+		Name:         "app",
+		RestartCount: 2,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		},
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+				Reason:   "Error",
+			},
+		},
+	}}, nil)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, previewDep).
+		WithObjects(app, previewDep, previewPod).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, previewDep); err != nil {
+		t.Fatalf("seed preview deployment status: %v", err)
+	}
+
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, app, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseCrashLooping {
+		t.Fatalf("expected preview-only crash loop to keep top-level phase %q, got %q", mortisev1alpha1.AppPhaseCrashLooping, fresh.Status.Phase)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "PodHealthy"); cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected preview-only crash loop to set PodHealthy false, got %+v", cond)
+	}
+}
+
 func TestUpdateStatusRecoversAfterPreviewRemoval(t *testing.T) {
 	ctx := context.Background()
 	scheme := newAppStatusTestScheme(t)

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -1140,8 +1140,8 @@ func TestUpdateStatusIgnoresPreviewCrashLoopForTopLevelHealth(t *testing.T) {
 	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
 		t.Fatalf("get app: %v", err)
 	}
-	if fresh.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
-		t.Fatalf("expected preview crash loop to keep top-level phase %q, got %q", mortisev1alpha1.AppPhaseDeploying, fresh.Status.Phase)
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("expected preview crash loop to keep top-level phase %q, got %q", mortisev1alpha1.AppPhaseReady, fresh.Status.Phase)
 	}
 	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "PodHealthy"); cond != nil {
 		t.Fatalf("expected preview crash loop to not poison top-level PodHealthy, got %+v", cond)


### PR DESCRIPTION
## Summary\n- stop preview crash loops from poisoning app-wide phase/health when a primary env is healthy\n- return sanitized duplicate-user conflicts instead of leaking internal secret naming\n- make the project controller the sole writer for project-create activity to avoid the activity ConfigMap race\n\n## Testing\n- go test ./internal/controller ./internal/api ./internal/activity\n\nCloses #408\nCloses #409\nCloses #410