### PR TITLE
fix: surface crash loops during redeploy

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2979,6 +2979,26 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			newRestart := restartedAt != "" && restartedAt != es.LastProcessedRestartedAt
 
 			excludeFromTopLevelReadiness := envExcludedFromTopLevelReadinessAggregation(es, previewEnvNames, buildAggregationEnvNames, workloadPresent)
+			crashCountsTowardTopLevel := envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames)
+
+			applyCrashLoopState := func() bool {
+				if isCron {
+					return false
+				}
+				crashMsg := r.checkPodCrashLoopInEnv(ctx, app, env.Name, envNs)
+				if crashMsg == "" {
+					return false
+				}
+				es.Phase = mortisev1alpha1.AppPhaseCrashLooping
+				es.Message = crashMsg
+				if crashCountsTowardTopLevel {
+					anyCrash = true
+					if firstCrashMsg == "" {
+						firstCrashMsg = crashMsg
+					}
+				}
+				return true
+			}
 
 			if ready && !newRestart {
 				if restartedAt != "" {
@@ -2991,28 +3011,19 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 					es.Phase = mortisev1alpha1.AppPhaseReady
 				} else {
 					es.Phase = mortisev1alpha1.AppPhaseDeploying
-					if !excludeFromTopLevelReadiness {
+					countsTowardTopLevelReadiness := !excludeFromTopLevelReadiness
+					if applyCrashLoopState() && !crashCountsTowardTopLevel {
+						countsTowardTopLevelReadiness = false
+					}
+					if countsTowardTopLevelReadiness {
 						anyNotReady = true
 					}
 				}
 			} else {
 				es.Phase = mortisev1alpha1.AppPhaseDeploying
-				crashCountsTowardTopLevel := envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames)
 				countsTowardTopLevelReadiness := !excludeFromTopLevelReadiness
-				if !isCron {
-					if crashMsg := r.checkPodCrashLoopInEnv(ctx, app, env.Name, envNs); crashMsg != "" {
-						es.Phase = mortisev1alpha1.AppPhaseCrashLooping
-						es.Message = crashMsg
-						if crashCountsTowardTopLevel {
-							anyCrash = true
-						}
-						if crashCountsTowardTopLevel && firstCrashMsg == "" {
-							firstCrashMsg = crashMsg
-						}
-						if !crashCountsTowardTopLevel {
-							countsTowardTopLevelReadiness = false
-						}
-					}
+				if applyCrashLoopState() && !crashCountsTowardTopLevel {
+					countsTowardTopLevelReadiness = false
 				}
 				if countsTowardTopLevelReadiness {
 					anyNotReady = true

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -1225,6 +1225,90 @@ func TestUpdateStatusPreviewOnlyCrashLoopStillSetsTopLevelHealth(t *testing.T) {
 	}
 }
 
+func TestUpdateStatusDetectsCrashLoopWhileRedeployLatchIsActive(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage},
+			Environments: []mortisev1alpha1.Environment{
+				{Name: "production"},
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:    "BuildSucceeded",
+				Status:  metav1.ConditionTrue,
+				Reason:  "BuildComplete",
+				Message: "built registry.example/demo:prod digest=sha256:prod for production",
+			}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name:                     "production",
+				LastBuiltImage:           "registry.example/demo:prod",
+				LastProcessedRestartedAt: "",
+			}},
+		},
+	}
+	dep := newReadyDeploymentForStatusTest(t, app, "production")
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations["mortise.dev/restartedAt"] = "1700000000000"
+	dep.Status.ReadyReplicas = 0
+	dep.Status.AvailableReplicas = 0
+	dep.Status.UpdatedReplicas = 1
+	prodPod := newStatusTestPod(app, "production", "prod-pod", []corev1.ContainerStatus{{
+		Name:         "app",
+		RestartCount: 200,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		},
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+				Reason:   "Error",
+			},
+		},
+	}}, nil)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app, dep).
+		WithObjects(app, dep, prodPod).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+	if err := c.Status().Update(ctx, dep); err != nil {
+		t.Fatalf("seed deployment status: %v", err)
+	}
+
+	if err := r.updateStatus(ctx, app, []mortisev1alpha1.Environment{{Name: "production"}}, nil); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseCrashLooping {
+		t.Fatalf("expected redeploy crash loop to set top-level phase %q, got %q", mortisev1alpha1.AppPhaseCrashLooping, fresh.Status.Phase)
+	}
+	envStatus := envStatusFor(&fresh, "production")
+	if envStatus == nil || envStatus.Phase != mortisev1alpha1.AppPhaseCrashLooping {
+		t.Fatalf("expected production env to be crash looping, got %+v", envStatus)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "PodHealthy"); cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected redeploy crash loop to set PodHealthy false, got %+v", cond)
+	}
+	if envStatus != nil && envStatus.LastProcessedRestartedAt != "" {
+		t.Fatalf("expected crash detection to preserve restart latch until rollout succeeds, got %q", envStatus.LastProcessedRestartedAt)
+	}
+}
+
 func TestUpdateStatusRecoversAfterPreviewRemoval(t *testing.T) {
 	ctx := context.Background()
 	scheme := newAppStatusTestScheme(t)


### PR DESCRIPTION
## Summary\n- run crash-loop detection while the redeploy restart latch is active\n- keep preview crash aggregation semantics unchanged while surfacing real crash loops after manual restart\n- add a regression test for crash-looping pods during an incomplete redeploy\n\n## Testing\n- go test ./internal/controller\n\nCloses #412