### PR TITLE
fix: converge dangling binding references

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2345,26 +2345,9 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		}
 	}
 	if len(env.Bindings) > 0 && len(bindingEnvs) == 0 {
-		currentExisting, err := store.Get(ctx, envNs, app.Name)
-		if err != nil {
-			return fmt.Errorf("read existing env vars before binding cleanup: %w", err)
-		}
-		bindingOnly := len(currentExisting) > 0
-		for _, existingEnv := range currentExisting {
-			if existingEnv.Source != "binding" {
-				bindingOnly = false
-				break
-			}
-		}
-		if bindingOnly {
-			if err := r.Client.Delete(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      envstore.AppEnvSecretName(app.Name),
-					Namespace: envNs,
-				},
-			}); err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("delete empty binding-only env secret: %w", err)
-			}
+		if deleted, err := r.deleteBindingOnlyEnvSecret(ctx, envNs, app.Name); err != nil {
+			return fmt.Errorf("delete empty binding-only env secret: %w", err)
+		} else if deleted {
 			return nil
 		}
 	}
@@ -2372,6 +2355,52 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		return nil
 	}
 	return store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels)
+}
+
+func (r *AppReconciler) deleteBindingOnlyEnvSecret(ctx context.Context, envNs, appName string) (bool, error) {
+	secretKey := types.NamespacedName{
+		Name:      envstore.AppEnvSecretName(appName),
+		Namespace: envNs,
+	}
+
+	deleted := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var secret corev1.Secret
+		if err := r.Client.Get(ctx, secretKey, &secret); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		existing := envstore.SecretToEnvs(&secret)
+		if len(existing) == 0 {
+			return nil
+		}
+		for _, env := range existing {
+			if env.Source != "binding" {
+				return nil
+			}
+		}
+
+		uid := secret.UID
+		resourceVersion := secret.ResourceVersion
+		if err := r.Client.Delete(ctx, &secret, client.Preconditions{
+			UID:             &uid,
+			ResourceVersion: &resourceVersion,
+		}); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		deleted = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return deleted, nil
 }
 
 func (r *AppReconciler) readLastSpecEnv(ctx context.Context, ns, appName string) map[string]string {

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -144,6 +144,9 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// that enumerates them and deletes by label.
 	if !app.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(&app, appFinalizer) {
+			if err := r.pruneBindingsToDeletedApp(ctx, &app); err != nil {
+				return ctrl.Result{}, fmt.Errorf("prune dangling bindings: %w", err)
+			}
 			if err := r.gcAppAcrossEnvs(ctx, &app); err != nil {
 				return ctrl.Result{}, fmt.Errorf("gc app across envs: %w", err)
 			}
@@ -424,6 +427,80 @@ func (r *AppReconciler) removeAppFinalizerWithRetry(ctx context.Context, key typ
 		controllerutil.RemoveFinalizer(&fresh, appFinalizer)
 		return r.Update(ctx, &fresh)
 	})
+}
+
+func (r *AppReconciler) pruneBindingsToDeletedApp(ctx context.Context, deletedApp *mortisev1alpha1.App) error {
+	if deletedApp == nil || deletedApp.Name == "" || deletedApp.Namespace == "" {
+		return nil
+	}
+
+	var apps mortisev1alpha1.AppList
+	if err := r.List(ctx, &apps, client.InNamespace(deletedApp.Namespace)); err != nil {
+		return err
+	}
+
+	for i := range apps.Items {
+		consumer := &apps.Items[i]
+		if consumer.Name == deletedApp.Name || !consumer.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		changed := false
+		for envIdx := range consumer.Spec.Environments {
+			env := &consumer.Spec.Environments[envIdx]
+			if len(env.Bindings) == 0 {
+				continue
+			}
+			filtered := env.Bindings[:0]
+			for _, binding := range env.Bindings {
+				if binding.Ref == deletedApp.Name {
+					changed = true
+					continue
+				}
+				filtered = append(filtered, binding)
+			}
+			env.Bindings = filtered
+		}
+		if !changed {
+			continue
+		}
+
+		key := types.NamespacedName{Name: consumer.Name, Namespace: consumer.Namespace}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var fresh mortisev1alpha1.App
+			if err := r.Get(ctx, key, &fresh); err != nil {
+				return err
+			}
+			if !fresh.DeletionTimestamp.IsZero() {
+				return nil
+			}
+
+			updated := false
+			for envIdx := range fresh.Spec.Environments {
+				env := &fresh.Spec.Environments[envIdx]
+				if len(env.Bindings) == 0 {
+					continue
+				}
+				filtered := env.Bindings[:0]
+				for _, binding := range env.Bindings {
+					if binding.Ref == deletedApp.Name {
+						updated = true
+						continue
+					}
+					filtered = append(filtered, binding)
+				}
+				env.Bindings = filtered
+			}
+			if !updated {
+				return nil
+			}
+			return r.Update(ctx, &fresh)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // reconcileGitSource handles the build-from-source path for source.type=git apps
@@ -2265,6 +2342,30 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 				Value:  bv.Value,
 				Source: "binding",
 			})
+		}
+	}
+	if len(env.Bindings) > 0 && len(bindingEnvs) == 0 {
+		currentExisting, err := store.Get(ctx, envNs, app.Name)
+		if err != nil {
+			return fmt.Errorf("read existing env vars before binding cleanup: %w", err)
+		}
+		bindingOnly := len(currentExisting) > 0
+		for _, existingEnv := range currentExisting {
+			if existingEnv.Source != "binding" {
+				bindingOnly = false
+				break
+			}
+		}
+		if bindingOnly {
+			if err := r.Client.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      envstore.AppEnvSecretName(app.Name),
+					Namespace: envNs,
+				},
+			}); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("delete empty binding-only env secret: %w", err)
+			}
+			return nil
 		}
 	}
 	if len(existing) == 0 && len(toMerge) == 0 && len(bindingEnvs) == 0 {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -7359,10 +7359,7 @@ var _ = Describe("App Controller — git source", func() {
 			})
 			Expect(err).NotTo(HaveOccurred(), "reconcile should succeed after bound app deleted")
 			envData = readAppEnvSecret(ctx, apiName, envNsProduction)
-			Expect(envData).NotTo(HaveKey("STALE_DB_HOST"), "stale binding vars should be cleared")
-			Expect(envData).NotTo(HaveKey("STALE_DB_PORT"), "stale binding vars should be cleared")
-			Expect(envData).NotTo(HaveKey("STALE_DB_USERNAME"), "stale credential vars should be cleared")
-			Expect(envData).NotTo(HaveKey("STALE_DB_PASSWORD"), "stale credential vars should be cleared")
+			Expect(envData).To(BeNil(), "empty app-env Secret should be removed after last binding disappears")
 		})
 
 		It("preserves valid bindings when one of multiple bound apps is deleted", func() {
@@ -7453,6 +7450,77 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(envData).NotTo(HaveKey("SURV_DB_HOST"), "deleted binding vars should be cleared")
 			Expect(envData).NotTo(HaveKey("SURV_DB_PORT"), "deleted binding vars should be cleared")
 			Expect(envData).NotTo(HaveKey("SURV_DB_PASSWORD"), "deleted credential vars should be cleared")
+		})
+
+		It("prunes dangling binding refs from consumers when a bound app is deleted", func() {
+			dbName := "prune-db"
+			cacheName := "prune-cache"
+			apiName := "prune-api"
+
+			dbApp := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: dbName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "postgres:16"},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+					}},
+				},
+			}
+			cacheApp := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: cacheName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "redis:7"},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+					}},
+				},
+			}
+			consumer := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: apiName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+					Network: mortisev1alpha1.NetworkConfig{Public: false},
+					Environments: []mortisev1alpha1.Environment{{
+						Name:     "production",
+						Replicas: ptr.To[int32](1),
+						Bindings: []mortisev1alpha1.Binding{
+							{Ref: dbName},
+							{Ref: cacheName},
+						},
+					}},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, dbApp)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cacheApp)).To(Succeed())
+			Expect(k8sClient.Create(ctx, consumer)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, cacheApp) }()
+			defer func() { _ = k8sClient.Delete(ctx, consumer) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			// Ensure the provider app has its finalizer before deletion.
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dbName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, dbApp)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dbName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: apiName, Namespace: namespace}, &fresh)).To(Succeed())
+			Expect(fresh.Spec.Environments).To(HaveLen(1))
+			Expect(fresh.Spec.Environments[0].Bindings).To(HaveLen(1))
+			Expect(fresh.Spec.Environments[0].Bindings[0].Ref).To(Equal(cacheName))
 		})
 
 		It("skips binding when bound app is disabled in the target env", func() {


### PR DESCRIPTION
## Summary\n- prune binding refs from consumer apps when the bound app is deleted\n- delete binding-only app env secrets when the last bound app disappears so the controller converges instead of looping on a watched empty secret\n- add regression coverage for stale binding cleanup and bound-app deletion pruning\n\n## Testing\n- go test ./internal/controller\n\nCloses #416