### PR TITLE
fix: self-heal dangling bindings

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -172,6 +172,9 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("fetch parent project: %w", err)
 	}
+	if _, err := r.pruneMissingBindingsForConsumer(ctx, &app); err != nil {
+		return ctrl.Result{}, fmt.Errorf("prune missing bindings: %w", err)
+	}
 	var resolvedEnvs []mortisev1alpha1.Environment
 	var previewEnvNames map[string]struct{}
 	var previewBuildIdentities map[string]previewBuildIdentity
@@ -501,6 +504,96 @@ func (r *AppReconciler) pruneBindingsToDeletedApp(ctx context.Context, deletedAp
 	}
 
 	return nil
+}
+
+func (r *AppReconciler) pruneMissingBindingsForConsumer(ctx context.Context, app *mortisev1alpha1.App) (bool, error) {
+	if app == nil || app.Name == "" || app.Namespace == "" {
+		return false, nil
+	}
+
+	key := types.NamespacedName{Name: app.Name, Namespace: app.Namespace}
+	var updated *mortisev1alpha1.App
+	pruned := false
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := r.Get(ctx, key, &fresh); err != nil {
+			return err
+		}
+		changed, err := r.removeDanglingBindings(ctx, &fresh)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			updated = fresh.DeepCopy()
+			return nil
+		}
+		if err := r.Update(ctx, &fresh); err != nil {
+			return err
+		}
+		pruned = true
+		updated = fresh.DeepCopy()
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	if updated != nil {
+		*app = *updated
+	}
+	return pruned, nil
+}
+
+func (r *AppReconciler) removeDanglingBindings(ctx context.Context, app *mortisev1alpha1.App) (bool, error) {
+	if app == nil || app.Namespace == "" {
+		return false, nil
+	}
+
+	refs := make(map[string]struct{})
+	for _, env := range app.Spec.Environments {
+		for _, binding := range env.Bindings {
+			if binding.Ref != "" {
+				refs[binding.Ref] = struct{}{}
+			}
+		}
+	}
+	if len(refs) == 0 {
+		return false, nil
+	}
+
+	missing := make(map[string]struct{})
+	for ref := range refs {
+		var boundApp mortisev1alpha1.App
+		if err := r.Get(ctx, types.NamespacedName{Name: ref, Namespace: app.Namespace}, &boundApp); err != nil {
+			if errors.IsNotFound(err) {
+				missing[ref] = struct{}{}
+				continue
+			}
+			return false, err
+		}
+		if !boundApp.DeletionTimestamp.IsZero() {
+			missing[ref] = struct{}{}
+		}
+	}
+	if len(missing) == 0 {
+		return false, nil
+	}
+
+	changed := false
+	for envIdx := range app.Spec.Environments {
+		env := &app.Spec.Environments[envIdx]
+		if len(env.Bindings) == 0 {
+			continue
+		}
+		filtered := env.Bindings[:0]
+		for _, binding := range env.Bindings {
+			if _, gone := missing[binding.Ref]; gone {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, binding)
+		}
+		env.Bindings = filtered
+	}
+	return changed, nil
 }
 
 // reconcileGitSource handles the build-from-source path for source.type=git apps
@@ -2344,7 +2437,7 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 			})
 		}
 	}
-	if len(env.Bindings) > 0 && len(bindingEnvs) == 0 {
+	if len(bindingEnvs) == 0 {
 		if deleted, err := r.deleteBindingOnlyEnvSecret(ctx, envNs, app.Name); err != nil {
 			return fmt.Errorf("delete empty binding-only env secret: %w", err)
 		} else if deleted {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -7277,6 +7277,11 @@ var _ = Describe("App Controller — git source", func() {
 			for k := range envData {
 				Expect(k).NotTo(HavePrefix("DOES_NOT_EXIST_"), "no binding vars should exist for missing app")
 			}
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fresh)).To(Succeed())
+			Expect(fresh.Spec.Environments).To(HaveLen(1))
+			Expect(fresh.Spec.Environments[0].Bindings).To(BeEmpty(), "consumer reconcile should self-heal dangling binding refs")
 		})
 
 		It("clears stale binding vars when bound app is deleted between reconciles", func() {

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -12,7 +12,6 @@ package envstore
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -393,7 +392,7 @@ update:
 		return &corev1.Secret{}
 	}, func(existing *corev1.Secret) (bool, error) {
 		changed := false
-		if !reflect.DeepEqual(existing.Data, desired.Data) {
+		if !secretDataEqual(existing.Data, desired.Data) {
 			existing.Data = desired.Data
 			changed = true
 		}
@@ -534,6 +533,22 @@ func removeKeyFromAnnotations(secret *corev1.Secret, key string) {
 			}
 		}
 	}
+}
+
+func secretDataEqual(existing, desired map[string][]byte) bool {
+	if len(existing) == 0 && len(desired) == 0 {
+		return true
+	}
+	if len(existing) != len(desired) {
+		return false
+	}
+	for key, desiredValue := range desired {
+		existingValue, ok := existing[key]
+		if !ok || string(existingValue) != string(desiredValue) {
+			return false
+		}
+	}
+	return true
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/internal/envstore/envstore_test.go
+++ b/internal/envstore/envstore_test.go
@@ -15,6 +15,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
+type countingClient struct {
+	client.Client
+	updateCalls int
+}
+
+func (c *countingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updateCalls++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
 func TestAppEnvSecretName(t *testing.T) {
 	tests := []struct {
 		app  string
@@ -250,5 +260,25 @@ func TestUpdateWithConflictRetryStopsWhenUnchanged(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestReplaceSourceSkipsEmptySecretDataNilVsEmptyChurn(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	existing := buildSecret("ns", AppEnvSecretName("app"), nil, nil)
+	existing.Data = nil
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	c := &countingClient{Client: base}
+
+	store := &Store{Client: c}
+	if err := store.ReplaceSource(context.Background(), "ns", "app", "binding", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if c.updateCalls != 0 {
+		t.Fatalf("expected no update for logically empty secret data, got %d update calls", c.updateCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- fix empty app env Secret churn when Kubernetes returns nil Data for zero-key Secrets
- self-heal dangling binding refs during consumer reconcile, including stale refs that predate #417
- keep binding-only Secret cleanup working in the same reconcile after stale bindings are pruned

## Testing
- go test ./internal/envstore ./internal/controller

Closes #418
Closes #419