### PR TITLE
fix preview/env races and build timer origin

### DIFF
--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -130,6 +130,17 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
+	existingSource := make(map[string]string, len(existing))
+	for _, e := range existing {
+		existingSource[e.Name] = e.Source
+	}
+	for _, v := range vars {
+		if src, ok := existingSource[v.Name]; ok && src != "" && src != "user" {
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
+				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", v.Name, src)})
+			return
+		}
+	}
 
 	// Start with non-user vars from the existing Secret.
 	var merged []envstore.Env

--- a/internal/api/env_handler_test.go
+++ b/internal/api/env_handler_test.go
@@ -327,6 +327,52 @@ func TestPatchEnvRejectsManagedVarOverwrite(t *testing.T) {
 	}
 }
 
+func TestPutEnvRejectsManagedVarOverwrite(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	ns := seedProject(t, k8sClient, "default")
+
+	ctx := context.Background()
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "put-bound-app", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.25.0"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	envNs := constants.EnvNamespace("default", "production")
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envNs}})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envstore.AppEnvSecretName("put-bound-app"),
+			Namespace: envNs,
+			Annotations: map[string]string{
+				"mortise.dev/binding-keys": "DB_URL",
+			},
+		},
+		Data: map[string][]byte{
+			"DB_URL":   []byte("postgres://localhost/db"),
+			"APP_PORT": []byte("3000"),
+		},
+	}
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		t.Fatalf("seed env secret: %v", err)
+	}
+
+	w := doRequest(h, http.MethodPut, "/api/projects/default/apps/put-bound-app/env?environment=production", []map[string]string{
+		{"name": "DB_URL", "value": "postgres://evil/db"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when overwriting binding var via PUT, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestPatchEnvRejectsManagedVarUnset(t *testing.T) {
 	k8sClient := setupEnvtest(t)
 	srv := newAdminServer(t, k8sClient)

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -444,8 +444,7 @@ func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	project.Spec.Environments = append(project.Spec.Environments[:idx], project.Spec.Environments[idx+1:]...)
-	if err := s.client.Update(r.Context(), project); err != nil {
+	if err := s.deleteProjectEnvironmentSpec(r.Context(), project.Name, envName); err != nil {
 		if apierrors.IsForbidden(err) {
 			writeJSON(w, http.StatusConflict, errorResponse{err.Error()})
 			return
@@ -530,15 +529,11 @@ func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	project.Spec.Environments = append(project.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
-		Name:         req.Name,
-		DisplayOrder: req.DisplayOrder,
-	})
 	if err := s.ensureProjectEnvNamespace(r.Context(), project, req.Name, false); err != nil {
 		writeError(w, r, err)
 		return
 	}
-	if err := s.client.Update(r.Context(), project); err != nil {
+	if err := s.cloneProjectEnvironmentSpec(r.Context(), project.Name, req); err != nil {
 		_ = s.deleteProjectEnvNamespace(r.Context(), project, req.Name)
 		writeError(w, r, err)
 		return
@@ -565,6 +560,40 @@ func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request)
 		Name:         req.Name,
 		DisplayOrder: req.DisplayOrder,
 		Health:       EnvHealthUnknown,
+	})
+}
+
+func (s *Server) deleteProjectEnvironmentSpec(ctx context.Context, projectName, envName string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current mortisev1alpha1.Project
+		if err := s.client.Get(ctx, types.NamespacedName{Name: projectName}, &current); err != nil {
+			return err
+		}
+		idx := indexOfEnv(&current, envName)
+		if idx < 0 {
+			return apierrors.NewNotFound(schema.GroupResource{Group: mortisev1alpha1.GroupVersion.Group, Resource: "projects"}, projectName)
+		}
+		current.Spec.Environments = append(current.Spec.Environments[:idx], current.Spec.Environments[idx+1:]...)
+		return s.client.Update(ctx, &current)
+	})
+}
+
+func (s *Server) cloneProjectEnvironmentSpec(ctx context.Context, projectName string, req cloneProjectEnvRequest) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current mortisev1alpha1.Project
+		if err := s.client.Get(ctx, types.NamespacedName{Name: projectName}, &current); err != nil {
+			return err
+		}
+		for _, existing := range current.Spec.Environments {
+			if existing.Name == req.Name {
+				return apierrors.NewAlreadyExists(schema.GroupResource{Group: mortisev1alpha1.GroupVersion.Group, Resource: "projectenvironments"}, req.Name)
+			}
+		}
+		current.Spec.Environments = append(current.Spec.Environments, mortisev1alpha1.ProjectEnvironment{
+			Name:         req.Name,
+			DisplayOrder: req.DisplayOrder,
+		})
+		return s.client.Update(ctx, &current)
 	})
 }
 

--- a/internal/api/rollback.go
+++ b/internal/api/rollback.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
@@ -63,8 +65,6 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, err)
 		return
 	}
-	envNs := constants.EnvNamespace(projectName, req.Environment)
-
 	// Find the environment status.
 	var envStatus *mortisev1alpha1.EnvironmentStatus
 	for i := range app.Status.Environments {
@@ -88,19 +88,7 @@ func (s *Server) Rollback(w http.ResponseWriter, r *http.Request) {
 		rollbackImage = target.Digest
 	}
 
-	depName := constants.DeploymentName(appName)
-	var dep appsv1.Deployment
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: envNs}, &dep); err != nil {
-		writeError(w, r, err)
-		return
-	}
-	if len(dep.Spec.Template.Spec.Containers) == 0 {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{fmt.Sprintf("deployment %s has no containers", depName)})
-		return
-	}
-
-	dep.Spec.Template.Spec.Containers[0].Image = rollbackImage
-	if err := s.client.Update(r.Context(), &dep); err != nil {
+	if err := s.rollbackDeployment(r.Context(), projectName, appName, req.Environment, rollbackImage); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -205,20 +193,7 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		promoteImage = fromStatus.CurrentDigest
 	}
 
-	depName := constants.DeploymentName(appName)
-	toEnvNs := constants.EnvNamespace(projectName, req.To)
-	var dep appsv1.Deployment
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: depName, Namespace: toEnvNs}, &dep); err != nil {
-		writeError(w, r, err)
-		return
-	}
-	if len(dep.Spec.Template.Spec.Containers) == 0 {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{fmt.Sprintf("deployment %s has no containers", depName)})
-		return
-	}
-
-	dep.Spec.Template.Spec.Containers[0].Image = promoteImage
-	if err := s.client.Update(r.Context(), &dep); err != nil {
+	if err := s.promoteDeployment(r.Context(), projectName, appName, req.To, promoteImage); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -248,7 +223,7 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 	toStatus.CurrentDigest = fromStatus.CurrentDigest
 	toStatus.DeployHistory = append(toStatus.DeployHistory, record)
 
-	if err := s.client.Status().Update(r.Context(), &app); err != nil {
+	if err := s.recordPromotedDeploy(r.Context(), ns, appName, req.From, req.To); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -260,5 +235,82 @@ func (s *Server) Promote(w http.ResponseWriter, r *http.Request) {
 		"from":   req.From,
 		"to":     req.To,
 		"image":  promoteImage,
+	})
+}
+
+func (s *Server) rollbackDeployment(ctx context.Context, projectName, appName, envName, image string) error {
+	depName := constants.DeploymentName(appName)
+	envNs := constants.EnvNamespace(projectName, envName)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var dep appsv1.Deployment
+		if err := s.client.Get(ctx, types.NamespacedName{Name: depName, Namespace: envNs}, &dep); err != nil {
+			return err
+		}
+		if len(dep.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("deployment %s has no containers", depName)
+		}
+		dep.Spec.Template.Spec.Containers[0].Image = image
+		return s.client.Update(ctx, &dep)
+	})
+}
+
+func (s *Server) promoteDeployment(ctx context.Context, projectName, appName, envName, image string) error {
+	depName := constants.DeploymentName(appName)
+	envNs := constants.EnvNamespace(projectName, envName)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var dep appsv1.Deployment
+		if err := s.client.Get(ctx, types.NamespacedName{Name: depName, Namespace: envNs}, &dep); err != nil {
+			return err
+		}
+		if len(dep.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("deployment %s has no containers", depName)
+		}
+		dep.Spec.Template.Spec.Containers[0].Image = image
+		return s.client.Update(ctx, &dep)
+	})
+}
+
+func (s *Server) recordPromotedDeploy(ctx context.Context, ns, appName, fromEnv, toEnv string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var app mortisev1alpha1.App
+		if err := s.client.Get(ctx, types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+			return err
+		}
+
+		var fromStatus *mortisev1alpha1.EnvironmentStatus
+		for i := range app.Status.Environments {
+			if app.Status.Environments[i].Name == fromEnv {
+				fromStatus = &app.Status.Environments[i]
+				break
+			}
+		}
+		if fromStatus == nil {
+			return fmt.Errorf("source environment %q not found in app status", fromEnv)
+		}
+
+		record := mortisev1alpha1.DeployRecord{
+			Image:     fromStatus.CurrentImage,
+			Digest:    fromStatus.CurrentDigest,
+			Timestamp: metav1.Now(),
+		}
+
+		var toStatus *mortisev1alpha1.EnvironmentStatus
+		for i := range app.Status.Environments {
+			if app.Status.Environments[i].Name == toEnv {
+				toStatus = &app.Status.Environments[i]
+				break
+			}
+		}
+		if toStatus == nil {
+			app.Status.Environments = append(app.Status.Environments, mortisev1alpha1.EnvironmentStatus{
+				Name: toEnv,
+			})
+			toStatus = &app.Status.Environments[len(app.Status.Environments)-1]
+		}
+		toStatus.CurrentImage = fromStatus.CurrentImage
+		toStatus.CurrentDigest = fromStatus.CurrentDigest
+		toStatus.DeployHistory = append(toStatus.DeployHistory, record)
+
+		return s.client.Status().Update(ctx, &app)
 	})
 }

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -891,6 +891,7 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		app.Status.DetectedPort = detectedPort
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
+	meta.RemoveStatusCondition(&app.Status.Conditions, "BuildStarted")
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildSucceeded",
 		Status:             metav1.ConditionTrue,
@@ -1276,6 +1277,7 @@ func (r *AppReconciler) setFailedCondition(ctx context.Context, app *mortisev1al
 	transitionTime := metav1.NewTime(r.clock().Now())
 	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
 		status.Phase = mortisev1alpha1.AppPhaseFailed
+		meta.RemoveStatusCondition(&status.Conditions, "BuildStarted")
 		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 			Type:               "BuildSucceeded",
 			Status:             metav1.ConditionFalse,
@@ -1287,6 +1289,7 @@ func (r *AppReconciler) setFailedCondition(ctx context.Context, app *mortisev1al
 		log.Error(err, "update failed status")
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseFailed
+	meta.RemoveStatusCondition(&app.Status.Conditions, "BuildStarted")
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildSucceeded",
 		Status:             metav1.ConditionFalse,
@@ -1300,6 +1303,7 @@ func (r *AppReconciler) setFailedCondition(ctx context.Context, app *mortisev1al
 func (r *AppReconciler) setBuildFailureCondition(ctx context.Context, app *mortisev1alpha1.App, reason, msg string) error {
 	transitionTime := metav1.NewTime(r.clock().Now())
 	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+		meta.RemoveStatusCondition(&status.Conditions, "BuildStarted")
 		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 			Type:               "BuildSucceeded",
 			Status:             metav1.ConditionFalse,
@@ -1310,6 +1314,7 @@ func (r *AppReconciler) setBuildFailureCondition(ctx context.Context, app *morti
 	}); err != nil {
 		return err
 	}
+	meta.RemoveStatusCondition(&app.Status.Conditions, "BuildStarted")
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildSucceeded",
 		Status:             metav1.ConditionFalse,

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -716,6 +716,73 @@ func TestUpdateStatusClearsDegradedAfterSuccessfulRecovery(t *testing.T) {
 	}
 }
 
+func TestApplyEnvBuildSuccessClearsBuildStartedCondition(t *testing.T) {
+	r := &AppReconciler{Clock: clocktesting.NewFakeClock(time.Unix(1_700_000_000, 0))}
+	app := &mortisev1alpha1.App{
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "BuildStarted",
+					Status:             metav1.ConditionTrue,
+					Reason:             "BuildInProgress",
+					Message:            "building revision oldsha for production",
+					LastTransitionTime: metav1.NewTime(time.Unix(1_600_000_000, 0)),
+				},
+			},
+		},
+	}
+
+	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "newsha", "registry.example/demo:new", "sha256:new", 8080)
+
+	if cond := meta.FindStatusCondition(app.Status.Conditions, "BuildStarted"); cond != nil {
+		t.Fatalf("expected BuildStarted to be cleared after build success, got %+v", cond)
+	}
+	if cond := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded"); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected BuildSucceeded=True after build success, got %+v", cond)
+	}
+}
+
+func TestSetBuildFailureConditionClearsBuildStartedCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "pj-default-project"},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "BuildStarted",
+					Status:             metav1.ConditionTrue,
+					Reason:             "BuildInProgress",
+					Message:            "building revision oldsha for production",
+					LastTransitionTime: metav1.NewTime(time.Unix(1_600_000_000, 0)),
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(app).
+		WithObjects(app).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme, Clock: clocktesting.NewFakeClock(time.Unix(1_700_000_000, 0))}
+
+	if err := r.setBuildFailureCondition(ctx, app, "BuildFailed", "docker build failed"); err != nil {
+		t.Fatalf("setBuildFailureCondition: %v", err)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildStarted"); cond != nil {
+		t.Fatalf("expected BuildStarted to be cleared after build failure, got %+v", cond)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, "BuildSucceeded"); cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected BuildSucceeded=False after build failure, got %+v", cond)
+	}
+}
+
 func TestUpdateStatusMasksPreviewOnlyBuildFailureWhilePreviewStillServes(t *testing.T) {
 	ctx := context.Background()
 	scheme := newAppStatusTestScheme(t)

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -50,6 +50,16 @@ const previewFinalizer = "mortise.dev/preview-finalizer"
 // no matching open PR (e.g. because the forge API hasn't propagated yet)
 // would race against the creator.
 const convergenceGracePeriod = 15 * time.Minute
+const previewNamespaceReadyRequeue = 2 * time.Second
+
+type previewNamespaceNotReadyError struct {
+	project string
+	env     string
+}
+
+func (e *previewNamespaceNotReadyError) Error() string {
+	return fmt.Sprintf("preview namespace %q for project %q not ready", constants.EnvNamespace(e.project, e.env), e.project)
+}
 
 // PreviewEnvironmentReconciler coordinates preview environments as a thin layer:
 // it adds/removes a ProjectEnvironment entry on the parent Project and clones
@@ -126,7 +136,6 @@ func (r *PreviewEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err := r.ensureProjectEnv(ctx, projectName, envName); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensure project env: %w", err)
 	}
-
 	controlNs := constants.ControlNamespace(projectName)
 
 	var apps mortisev1alpha1.AppList
@@ -144,11 +153,19 @@ func (r *PreviewEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Copy shared-env and per-app env Secrets from source env namespace to preview namespace.
 	if err := r.copySharedEnvSecret(ctx, projectName, sourceEnv, envName); err != nil {
+		if _, ok := err.(*previewNamespaceNotReadyError); ok {
+			log.Info("preview namespace not ready yet, waiting for project controller", "project", projectName, "env", envName)
+			return ctrl.Result{RequeueAfter: previewNamespaceReadyRequeue}, nil
+		}
 		log.Error(err, "copy shared-env secret")
 		return ctrl.Result{}, err
 	}
 	for i := range apps.Items {
 		if err := r.copyAppEnvSecret(ctx, projectName, sourceEnv, envName, apps.Items[i].Name); err != nil {
+			if _, ok := err.(*previewNamespaceNotReadyError); ok {
+				log.Info("preview namespace not ready yet, waiting for project controller", "project", projectName, "env", envName)
+				return ctrl.Result{RequeueAfter: previewNamespaceReadyRequeue}, nil
+			}
 			log.Error(err, "copy app env secret", "app", apps.Items[i].Name)
 			return ctrl.Result{}, err
 		}
@@ -334,6 +351,9 @@ func (r *PreviewEnvironmentReconciler) copySharedEnvSecret(ctx context.Context, 
 	if err != nil {
 		return err
 	}
+	if err := r.ensurePreviewNamespaceReady(ctx, targetNs, projectName, envName); err != nil {
+		return err
+	}
 
 	var existing corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: envstore.SharedEnvName}, &existing)
@@ -379,6 +399,9 @@ func (r *PreviewEnvironmentReconciler) copyAppEnvSecret(ctx context.Context, pro
 	if err != nil {
 		return err
 	}
+	if err := r.ensurePreviewNamespaceReady(ctx, targetNs, projectName, envName); err != nil {
+		return err
+	}
 
 	var existing corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: secretName}, &existing)
@@ -415,6 +438,17 @@ func (r *PreviewEnvironmentReconciler) copyAppEnvSecret(ctx context.Context, pro
 		Data: source.Data,
 	}
 	if err := r.Create(ctx, copied); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *PreviewEnvironmentReconciler) ensurePreviewNamespaceReady(ctx context.Context, targetNs, projectName, envName string) error {
+	var ns corev1.Namespace
+	if err := r.Get(ctx, types.NamespacedName{Name: targetNs}, &ns); err != nil {
+		if errors.IsNotFound(err) {
+			return &previewNamespaceNotReadyError{project: projectName, env: envName}
+		}
 		return err
 	}
 	return nil
@@ -734,6 +768,7 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 
 	// Delete PE CRs for PRs that are no longer open. Skip recently-created
 	// PEs to avoid racing with webhooks or in-flight reconciles.
+	var deleteErr error
 	for peName, pe := range existingByPR {
 		if openPEs[peName] {
 			continue
@@ -750,12 +785,16 @@ func (r *PreviewEnvironmentReconciler) ConvergeProjectPreviews(ctx context.Conte
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return fmt.Errorf("delete stale PE %q: %w", peName, err)
+			log.Error(err, "convergence: failed to delete stale PE, skipping", "project", project.Name, "pe", peName)
+			if deleteErr == nil {
+				deleteErr = fmt.Errorf("delete stale PE %q: %w", peName, err)
+			}
+			continue
 		}
 		log.Info("convergence: deleted PE for closed PR", "project", project.Name, "pe", peName)
 	}
 
-	return nil
+	return deleteErr
 }
 
 func (r *PreviewEnvironmentReconciler) protectRepoPreviewEnvironments(protectedPEs map[string]bool, existingByPR map[string]*mortisev1alpha1.PreviewEnvironment, repo string, multiRepo bool) {

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -45,6 +45,19 @@ import (
 	"github.com/mortise-org/mortise/internal/git"
 )
 
+type deleteErrorClient struct {
+	client.Client
+	target types.NamespacedName
+	err    error
+}
+
+func (c *deleteErrorClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if obj.GetNamespace() == c.target.Namespace && obj.GetName() == c.target.Name {
+		return c.err
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
 // helper: create a test Project and its control namespace (`pj-{name}`). The
 // PreviewEnvironment CRD lives in the control namespace; preview workloads
 // reconcile into `pj-{name}-pr-{num}` which the controller creates on demand.
@@ -392,11 +405,16 @@ func TestPreviewEnvironmentReconcileHydratesEmptyPreviewAppSecret(t *testing.T) 
 			Namespace: constants.EnvNamespace(project.Name, "pr-7"),
 		},
 	}
+	previewNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.EnvNamespace(project.Name, "pr-7"),
+		},
+	}
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(pe).
-		WithObjects(project, pe, app, sourceSecret, previewSecret).
+		WithObjects(project, pe, app, sourceSecret, previewSecret, previewNamespace).
 		Build()
 	r := &PreviewEnvironmentReconciler{
 		Client: c,
@@ -770,6 +788,70 @@ var _ = Describe("PreviewEnvironment Controller", func() {
 			var updated mortisev1alpha1.PreviewEnvironment
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pe.Name, Namespace: ns}, &updated)).To(Succeed())
 			Expect(updated.Status.Phase).To(Equal(mortisev1alpha1.PreviewPhaseReady))
+		})
+
+		It("should requeue until the preview namespace is ready", func() {
+			ctx := context.Background()
+			project, ns := createPreviewTestProject(ctx, true)
+			project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}}
+			project.Status.EnvNamespaces = map[string]string{
+				"staging": constants.EnvNamespace(project.Name, "staging"),
+			}
+			Expect(k8sClient.Update(ctx, project)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, project)).To(Succeed())
+
+			createPreviewApp(ctx, "wait-app", ns, &mortisev1alpha1.Environment{Name: "staging"})
+
+			sourceEnvNs := constants.EnvNamespace(project.Name, "staging")
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: sourceEnvNs},
+			})).To(Succeed())
+
+			sharedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      envstore.SharedEnvName,
+					Namespace: sourceEnvNs,
+				},
+				Data: map[string][]byte{
+					"FEATURE_FLAG": []byte("true"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, sharedSecret)).To(Succeed())
+
+			pe := createPreviewEnv(ctx, "wait-app-preview-pr-22", ns, project.Name, 22, "sha22", "feat")
+
+			reconciler := newPEReconciler()
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(previewNamespaceReadyRequeue))
+
+			previewNs := constants.EnvNamespace(project.Name, "pr-22")
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: previewNs},
+			})).To(Succeed())
+
+			var refreshed mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: project.Name}, &refreshed)).To(Succeed())
+			if refreshed.Status.EnvNamespaces == nil {
+				refreshed.Status.EnvNamespaces = map[string]string{}
+			}
+			refreshed.Status.EnvNamespaces["pr-22"] = previewNs
+			Expect(k8sClient.Status().Update(ctx, &refreshed)).To(Succeed())
+
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			var copied corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.SharedEnvName,
+				Namespace: previewNs,
+			}, &copied)).To(Succeed())
+			Expect(copied.Data).To(HaveKeyWithValue("FEATURE_FLAG", []byte("true")))
 		})
 
 		It("should succeed even when no apps exist in the project", func() {
@@ -1614,6 +1696,118 @@ func TestConvergeProjectPreviews_DeletesStale(t *testing.T) {
 	}
 	if !prNums[7] {
 		t.Errorf("PE for PR #7 should be created")
+	}
+}
+
+func TestConvergeProjectPreviews_ContinuesAfterStaleDeleteError(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	projectName := "converge-delete-continue"
+	nsName := constants.ControlNamespace(projectName)
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: nsName},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://github.com/org/repo",
+				Branch:      "main",
+				ProviderRef: "github-converge-delete",
+			},
+		},
+	}
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-converge-delete"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			Host: "https://github.com",
+		},
+	}
+	pm := &mortisev1alpha1.ProjectMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "member", Namespace: nsName},
+		Spec: mortisev1alpha1.ProjectMemberSpec{
+			Email: "dev@example.com",
+			Role:  "owner",
+		},
+	}
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      git.UserTokenSecretName("github-converge-delete", "dev@example.com"),
+			Namespace: git.TokenSecretNamespace,
+		},
+		Data: map[string][]byte{"token": []byte("fake-token")},
+	}
+
+	oldEnough := metav1.NewTime(time.Now().Add(-convergenceGracePeriod - time.Minute))
+	stuckPE := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{Name: "preview-pr-5", Namespace: nsName, CreationTimestamp: oldEnough},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef:  projectName,
+			SourceEnv:   "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{Number: 5, Branch: "old", SHA: "old"},
+		},
+	}
+	otherStale := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{Name: "preview-pr-6", Namespace: nsName, CreationTimestamp: oldEnough},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef:  projectName,
+			SourceEnv:   "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{Number: 6, Branch: "old2", SHA: "old2"},
+		},
+	}
+
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(project, app, gp, pm, tokenSecret, stuckPE, otherStale).Build()
+	c := &deleteErrorClient{
+		Client: base,
+		target: types.NamespacedName{Name: stuckPE.Name, Namespace: stuckPE.Namespace},
+		err:    fmt.Errorf("forced delete failure"),
+	}
+
+	mock := &mockGitAPI{
+		openPRs: []git.PullRequestSnapshot{
+			{Number: 7, Branch: "new-feat", SHA: "ccc"},
+		},
+	}
+	reconciler := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: s,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+		GitAPIFactory: func(gp *mortisev1alpha1.GitProvider, token, secret string) (git.GitAPI, error) {
+			return mock, nil
+		},
+	}
+
+	err := reconciler.ConvergeProjectPreviews(ctx, project)
+	if err == nil || !strings.Contains(err.Error(), stuckPE.Name) {
+		t.Fatalf("expected returned delete error for stuck PE, got %v", err)
+	}
+
+	var peList mortisev1alpha1.PreviewEnvironmentList
+	if err := base.List(ctx, &peList, client.InNamespace(nsName)); err != nil {
+		t.Fatalf("list PEs: %v", err)
+	}
+
+	gotNames := map[string]bool{}
+	for _, pe := range peList.Items {
+		if pe.DeletionTimestamp.IsZero() {
+			gotNames[pe.Name] = true
+		}
+	}
+	if !gotNames[stuckPE.Name] {
+		t.Fatalf("expected stuck PE to remain present")
+	}
+	if gotNames[otherStale.Name] {
+		t.Fatalf("expected second stale PE to be deleted despite first delete failure")
+	}
+	if !gotNames["preview-pr-7"] {
+		t.Fatalf("expected new PE for PR #7 to be created despite stale delete failure")
 	}
 }
 

--- a/ui/src/lib/components/AppDrawer.svelte
+++ b/ui/src/lib/components/AppDrawer.svelte
@@ -132,22 +132,34 @@
 	// Build timer — synced to BuildStarted condition timestamp from k8s.
 	let buildElapsed = $state('');
 	let buildTimerHandle: ReturnType<typeof setInterval> | null = null;
+	let activeBuildStart = $state<number | null>(null);
+
+	function buildStartTime(): number | null {
+		const cond = liveApp?.status?.conditions?.find(c => c.type === 'BuildStarted' && c.status === 'True');
+		if (!cond?.lastTransitionTime) return null;
+		const start = new Date(cond.lastTransitionTime).getTime();
+		return Number.isNaN(start) ? null : start;
+	}
 
 	$effect(() => {
-		if (isBuilding && !buildTimerHandle) {
-			const cond = liveApp?.status?.conditions?.find(c => c.type === 'BuildStarted' && c.status === 'True');
-			const start = cond?.lastTransitionTime ? new Date(cond.lastTransitionTime).getTime() : Date.now();
+		const start = isBuilding ? (buildStartTime() ?? Date.now()) : null;
+		if (start !== activeBuildStart) {
+			if (buildTimerHandle) {
+				clearInterval(buildTimerHandle);
+				buildTimerHandle = null;
+			}
+			activeBuildStart = start;
+			if (start === null) {
+				buildElapsed = '';
+				return;
+			}
 			const tick = () => {
-				const s = Math.floor((Date.now() - start) / 1000);
+				const s = Math.max(0, Math.floor((Date.now() - start) / 1000));
 				const m = Math.floor(s / 60);
 				buildElapsed = m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
 			};
 			tick();
 			buildTimerHandle = setInterval(tick, 1000);
-		} else if (!isBuilding && buildTimerHandle) {
-			clearInterval(buildTimerHandle);
-			buildTimerHandle = null;
-			buildElapsed = '';
 		}
 	});
 

--- a/ui/src/lib/components/AppNode.svelte
+++ b/ui/src/lib/components/AppNode.svelte
@@ -59,17 +59,18 @@
 	// Build timer - synced to the BuildStarted condition timestamp from k8s.
 	let buildElapsed = $state('');
 	let timerHandle: ReturnType<typeof setInterval> | null = null;
+	let activeBuildStart = $state<number | null>(null);
 
 	function buildStartTime(): number | null {
 		const cond = app.status?.conditions?.find(c => c.type === 'BuildStarted' && c.status === 'True');
 		if (!cond?.lastTransitionTime) return null;
-		return new Date(cond.lastTransitionTime).getTime();
+		const start = new Date(cond.lastTransitionTime).getTime();
+		return Number.isNaN(start) ? null : start;
 	}
 
-	function startBuildTimer() {
-		const start = buildStartTime() ?? Date.now();
+	function startBuildTimer(start: number) {
 		const tick = () => {
-			const s = Math.floor((Date.now() - start) / 1000);
+			const s = Math.max(0, Math.floor((Date.now() - start) / 1000));
 			const m = Math.floor(s / 60);
 			buildElapsed = m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
 		};
@@ -78,12 +79,18 @@
 	}
 
 	$effect(() => {
-		if (phase === 'Building' && !timerHandle) {
-			startBuildTimer();
-		} else if (phase !== 'Building' && timerHandle) {
-			clearInterval(timerHandle);
-			timerHandle = null;
-			buildElapsed = '';
+		const start = phase === 'Building' ? (buildStartTime() ?? Date.now()) : null;
+		if (start !== activeBuildStart) {
+			if (timerHandle) {
+				clearInterval(timerHandle);
+				timerHandle = null;
+			}
+			activeBuildStart = start;
+			if (start !== null) {
+				startBuildTimer(start);
+			} else {
+				buildElapsed = '';
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary
- fix stale build timer anchors by clearing and re-anchoring BuildStarted across backend and UI build states
- wait for preview namespaces only when secret hydration actually needs the target namespace, and keep convergence processing after one stale preview delete error
- add retry-on-conflict to the remaining read-modify-write API paths and make PutEnv reject managed var overwrites

## Testing
- go test ./internal/controller ./internal/api
- make check-ui

Closes #421
Closes #422
Closes #423
Closes #424