### PR TITLE
[codex] Fix preview environment selection highlight

### DIFF
--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -67,7 +67,13 @@
 	const currentEnv = $derived.by<string>(() => {
 		if (!activeProject) return '';
 		const stored = store.currentEnv(activeProject);
-		if (stored && projectEnvs.some((e) => e.name === stored)) return stored;
+		if (stored) {
+			const isProjectEnv = projectEnvs.some((e) => e.name === stored);
+			const isPreviewEnv = (store.previewEnvs[activeProject] ?? []).some(
+				(p) => (p.environmentName || p.name) === stored
+			);
+			if (isProjectEnv || isPreviewEnv) return stored;
+		}
 		return projectEnvs[0]?.name ?? stored ?? '';
 	});
 


### PR DESCRIPTION
## Summary

Fix the project navbar environment switcher so PR preview environments stay visually selected when they are the active environment.

## Root cause

The layout-level `currentEnv` derived state only treated declared project environments as valid. When the stored environment was a preview environment, the UI fell back to the first regular environment for rendering, so the preview was active in state and the URL but not shown as selected.

## What changed

- accept preview environment names as valid current environment values in the top-level layout
- preserve existing fallback behavior only when the stored environment matches neither a regular environment nor a preview environment

## Validation

- `npm run check` in `ui`
