### PR TITLE
[codex] Fix env-specific build state display

### DIFF
--- a/ui/src/lib/components/AppDrawer.svelte
+++ b/ui/src/lib/components/AppDrawer.svelte
@@ -34,14 +34,8 @@
 	const envStatusEntry = $derived(liveApp?.status?.environments?.find((e) => e.name === selectedEnv));
 	const envSpecEntry = $derived(liveApp?.spec.environments?.find((e) => e.name === selectedEnv));
 	const envEnabled = $derived(envSpecEntry?.enabled !== false);
-	// Building is app-aggregate (one build serves all envs); everything else
-	// derives from per-env EnvironmentStatus.phase.
 	const envPhase = $derived.by<string | null>(() => {
-		const agg = liveApp?.status?.phase ?? null;
-		if (agg === 'Building') return 'Building';
-		if (agg === 'Failed') return 'Failed';
-		if (agg === 'Degraded' && envStatusEntry?.phase === 'Ready') return 'Degraded';
-		return envStatusEntry?.phase ?? agg;
+		return envStatusEntry?.phase ?? liveApp?.status?.phase ?? null;
 	});
 
 	let reloading = $state(false);
@@ -49,7 +43,7 @@
 
 	let lastAutoSwitchPhase = $state<string | null>(null);
 	$effect(() => {
-		const phase = liveApp?.status?.phase ?? null;
+		const phase = envPhase;
 		if ((phase === 'Building' || phase === 'Degraded' || phase === 'Failed') && phase !== lastAutoSwitchPhase) {
 			if (liveApp!.spec.source.type !== 'image') {
 				lastAutoSwitchPhase = phase;
@@ -84,7 +78,7 @@
 
 	// Clear optimistic override once the real polled phase catches up.
 	$effect(() => {
-		if (optimisticPhase && liveApp?.status?.phase === optimisticPhase) {
+		if (optimisticPhase && envPhase === optimisticPhase) {
 			optimisticPhase = null;
 		}
 	});
@@ -96,7 +90,7 @@
 	async function doRebuild() {
 		if (!liveApp) return;
 		errorMsg = '';
-		const prevPhase = liveApp.status?.phase;
+		const prevPhase = envPhase;
 		applyOptimisticPhase('Building');
 		reloading = true;
 		try {
@@ -114,7 +108,7 @@
 		const envName = selectedEnv || liveApp.spec.environments?.[0]?.name;
 		if (!envName) return;
 		errorMsg = '';
-		const prevPhase = liveApp.status?.phase;
+		const prevPhase = envPhase;
 		applyOptimisticPhase('Deploying');
 		reloading = true;
 		try {

--- a/ui/src/lib/components/AppDrawer.svelte
+++ b/ui/src/lib/components/AppDrawer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
+	import { resolveAppEnvironment } from '$lib/types';
 	import type { App, BuildLogsResponse, Pod } from '$lib/types';
 	import { X, GitBranch, Container, Cloud, ExternalLink, Rocket } from 'lucide-svelte';
 	import DeploymentsTab from './drawer/DeploymentsTab.svelte';
@@ -30,7 +31,9 @@
 
 	// Navbar is the single source of truth for env selection. Tabs read the
 	// current env from the store; the drawer does not own env state.
-	const selectedEnv = $derived(store.currentEnv(project) ?? '');
+	const selectedEnv = $derived(
+		liveApp ? resolveAppEnvironment(liveApp, store.currentEnv(project)) : (store.currentEnv(project) ?? '')
+	);
 	const envStatusEntry = $derived(liveApp?.status?.environments?.find((e) => e.name === selectedEnv));
 	const envSpecEntry = $derived(liveApp?.spec.environments?.find((e) => e.name === selectedEnv));
 	const envEnabled = $derived(envSpecEntry?.enabled !== false);

--- a/ui/src/lib/components/AppNode.svelte
+++ b/ui/src/lib/components/AppNode.svelte
@@ -20,13 +20,9 @@
 	const envEntry = $derived(app.spec.environments?.find((e) => e.name === envName));
 	const envStatusEntry = $derived(app.status?.environments?.find((e) => e.name === envName));
 	const enabled = $derived(envEntry?.enabled !== false);
-	// Building is app-aggregate (one build serves all envs); everything else is
-	// per-env from EnvironmentStatus.phase.
 	const phase = $derived.by<AppPhase | undefined>(() => {
-		if (app.status?.phase === 'Building') return 'Building';
-		if (app.status?.phase === 'Failed') return 'Failed';
-		if (app.status?.phase === 'Degraded' && envStatusEntry?.phase === 'Ready') return 'Degraded';
-		return envStatusEntry?.phase ?? app.status?.phase;
+		if (envStatusEntry?.phase) return envStatusEntry.phase;
+		return app.status?.phase;
 	});
 	const isExternal = $derived(app.spec.source.type === 'external' as string);
 	const isPrivate = $derived(app.spec.network?.public === false);

--- a/ui/src/lib/components/drawer/DeployLogsTab.svelte
+++ b/ui/src/lib/components/drawer/DeployLogsTab.svelte
@@ -17,14 +17,15 @@
 		livePods?: Pod[] | null;
 	} = $props();
 
-	const isBuilding = $derived(app.status?.phase === 'Building');
-	const isFailed = $derived(app.status?.phase === 'Failed');
-	const failedMessage = $derived(
-		app.status?.conditions?.find((c) => c.status === 'False')?.message ?? null
-	);
-
 	const selectedEnv = $derived(
 		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
+	);
+	const envStatusEntry = $derived(app.status?.environments?.find((e) => e.name === selectedEnv));
+	const envPhase = $derived(envStatusEntry?.phase ?? app.status?.phase);
+	const isBuilding = $derived(envPhase === 'Building');
+	const isFailed = $derived(envPhase === 'Failed');
+	const failedMessage = $derived(
+		envStatusEntry?.message ?? app.status?.conditions?.find((c) => c.status === 'False')?.message ?? null
 	);
 
 	let pods = $state<Pod[]>([]);

--- a/ui/src/lib/components/drawer/DeployLogsTab.svelte
+++ b/ui/src/lib/components/drawer/DeployLogsTab.svelte
@@ -2,6 +2,7 @@
 	import { onDestroy, untrack } from 'svelte';
 	import { AuthRequiredError, api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
+	import { resolveAppEnvironment } from '$lib/types';
 	import { Loader2, Search } from 'lucide-svelte';
 	import type { App, LogLineEvent, Pod } from '$lib/types';
 	import LogLine from '$lib/components/LogLine.svelte';
@@ -18,7 +19,7 @@
 	} = $props();
 
 	const selectedEnv = $derived(
-		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
+		resolveAppEnvironment(app, store.currentEnv(project))
 	);
 	const envStatusEntry = $derived(app.status?.environments?.find((e) => e.name === selectedEnv));
 	const envPhase = $derived(envStatusEntry?.phase ?? app.status?.phase);

--- a/ui/src/lib/components/drawer/DeploymentsTab.svelte
+++ b/ui/src/lib/components/drawer/DeploymentsTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { appNeedsRedeploy } from '$lib/types';
+	import { appNeedsRedeploy, resolveAppEnvironment } from '$lib/types';
 	import type { App } from '$lib/types';
 	import { RotateCw } from 'lucide-svelte';
 
@@ -20,7 +20,7 @@
 	} = $props();
 
 	const selectedEnv = $derived(
-		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
+		resolveAppEnvironment(app, store.currentEnv(project))
 	);
 	let reloading = $state(false);
 	let errorMsg = $state('');

--- a/ui/src/lib/components/drawer/SettingsTab.svelte
+++ b/ui/src/lib/components/drawer/SettingsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { store } from '$lib/store.svelte';
+	import { resolveAppEnvironment } from '$lib/types';
 	import type { App, AppSpec } from '$lib/types';
 
 	import SourceSection from './settings/SourceSection.svelte';
@@ -39,7 +40,7 @@
 	}
 
 	const selectedEnv = $derived(
-		store.currentEnv(project) || effectiveSpec.environments?.[0]?.name || 'production'
+		resolveAppEnvironment(app, store.currentEnv(project))
 	);
 	const envEntry = $derived(effectiveSpec.environments?.find(e => e.name === selectedEnv));
 	const envEnabled = $derived(envEntry?.enabled !== false);

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { appNeedsRedeploy } from '$lib/types';
+	import { appNeedsRedeploy, resolveAppEnvironment } from '$lib/types';
 	import type { App, EnvVar } from '$lib/types';
 	import { Loader2, X } from 'lucide-svelte';
 
@@ -64,7 +64,7 @@
 	}
 
 	const activeEnv = $derived(
-		store.currentEnv(project) || app.spec.environments?.[0]?.name || 'production'
+		resolveAppEnvironment(app, store.currentEnv(project))
 	);
 	const isGitSource = $derived(app.spec.source.type === 'git');
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -172,6 +172,16 @@ export function staleEnvironments(app: App): string[] {
 		.map(env => env.name);
 }
 
+export function resolveAppEnvironment(app: App, requestedEnv: string | null | undefined): string {
+	const knownEnvs = [
+		...(app.spec.environments ?? []).map((env) => env.name),
+		...(app.status?.environments ?? []).map((env) => env.name)
+	];
+	const uniqueEnvs = [...new Set(knownEnvs.filter(Boolean))];
+	if (requestedEnv && uniqueEnvs.includes(requestedEnv)) return requestedEnv;
+	return uniqueEnvs[0] ?? requestedEnv ?? 'production';
+}
+
 export interface SecretResponse {
 	name: string;
 	keys: string[];


### PR DESCRIPTION
## Summary
Fix app state rendering so the selected environment drives the UI phase shown in the graph node, app drawer, and deploy logs tab.

## Root cause
The UI was forcing `Building` from the app-level aggregate phase, so a build running in one environment could make a different selected environment appear to still be building.

## Changes
- prefer `status.environments[name].phase` for the selected environment in the app node and drawer
- make drawer auto-switching and optimistic state clearing follow the selected environment phase
- make deploy logs show build/failure placeholders based on the selected environment state

## Validation
- `npm run check` in `ui`
