### PR TITLE
fix env-scoped app status rendering

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -812,14 +812,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 					}
 					return "", false, true, false, nil
 				default:
-					app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
-					meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-						Type:               "BuildStarted",
-						Status:             metav1.ConditionTrue,
-						Reason:             "BuildInProgress",
-						Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
-						LastTransitionTime: metav1.NewTime(r.clock().Now()),
-					})
+					r.markEnvBuildInProgress(app, envName, revision)
 					return "", true, true, false, nil
 				}
 			}
@@ -853,16 +846,29 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 		return "", false, true, false, nil
 	default:
-		app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
-		meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-			Type:               "BuildStarted",
-			Status:             metav1.ConditionTrue,
-			Reason:             "BuildInProgress",
-			Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
-			LastTransitionTime: metav1.NewTime(r.clock().Now()),
-		})
+		r.markEnvBuildInProgress(app, envName, revision)
 		return "", true, true, false, nil
 	}
+}
+
+func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName, revision string) {
+	if app == nil {
+		return
+	}
+
+	app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
+	if es := ensureEnvStatus(app, envName); es != nil {
+		es.Phase = mortisev1alpha1.AppPhaseBuilding
+		es.Message = fmt.Sprintf("building revision %s", revision)
+	}
+
+	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+		Type:               "BuildStarted",
+		Status:             metav1.ConditionTrue,
+		Reason:             "BuildInProgress",
+		Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
+		LastTransitionTime: metav1.NewTime(r.clock().Now()),
+	})
 }
 
 // applyEnvBuildSuccess records the successful build for a specific environment.

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4284,6 +4284,15 @@ var _ = Describe("App Controller", func() {
 	})
 })
 
+func envStatusByName(statuses []mortisev1alpha1.EnvironmentStatus, name string) *mortisev1alpha1.EnvironmentStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return &statuses[i]
+		}
+	}
+	return nil
+}
+
 var _ = Describe("renderDomainTemplate", func() {
 	It("uses default template with project scoping", func() {
 		result := renderDomainTemplate("", "api", "team-a", "production", "example.com")
@@ -5097,6 +5106,10 @@ var _ = Describe("App Controller — git source", func() {
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
 			Expect(app.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseBuilding))
+			prodStatus := envStatusByName(app.Status.Environments, "production")
+			Expect(prodStatus).NotTo(BeNil())
+			Expect(prodStatus.Phase).To(Equal(mortisev1alpha1.AppPhaseBuilding))
+			Expect(prodStatus.Message).To(ContainSubstring("building revision revasync"))
 
 			// A second reconcile while the build is still in flight should also
 			// return quickly and the phase should still be Building (no

--- a/ui/src/lib/components/AppDrawer.svelte
+++ b/ui/src/lib/components/AppDrawer.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { resolveAppEnvironment } from '$lib/types';
-	import type { App, BuildLogsResponse, Pod } from '$lib/types';
+	import { appPhaseForEnvironment, resolveAppEnvironment } from '$lib/types';
+	import type { App, AppPhase, BuildLogsResponse, Pod } from '$lib/types';
 	import { X, GitBranch, Container, Cloud, ExternalLink, Rocket } from 'lucide-svelte';
 	import DeploymentsTab from './drawer/DeploymentsTab.svelte';
 	import VariablesTab from './drawer/VariablesTab.svelte';
@@ -16,16 +16,20 @@
 		appName,
 		autoRedeploy = false,
 		liveApp = null,
+		phaseOverride = null,
 		liveBuildLogs = null,
 		livePods = null,
+		onPhaseOverride = () => {},
 		onClose
 	}: {
 		project: string;
 		appName: string;
 		autoRedeploy?: boolean;
 		liveApp?: App | null;
+		phaseOverride?: AppPhase | null;
 		liveBuildLogs?: BuildLogsResponse | null;
 		livePods?: Pod[] | null;
+		onPhaseOverride?: (envName: string, phase: AppPhase | null) => void;
 		onClose: () => void;
 	} = $props();
 
@@ -37,9 +41,9 @@
 	const envStatusEntry = $derived(liveApp?.status?.environments?.find((e) => e.name === selectedEnv));
 	const envSpecEntry = $derived(liveApp?.spec.environments?.find((e) => e.name === selectedEnv));
 	const envEnabled = $derived(envSpecEntry?.enabled !== false);
-	const envPhase = $derived.by<string | null>(() => {
-		return envStatusEntry?.phase ?? liveApp?.status?.phase ?? null;
-	});
+	const envPhase = $derived.by<AppPhase | null>(() => (
+		liveApp ? appPhaseForEnvironment(liveApp, selectedEnv) : null
+	));
 
 	let reloading = $state(false);
 	let errorMsg = $state('');
@@ -69,9 +73,9 @@
 	// Status display derives from liveApp (polled) with an optimistic override layer.
 	// $derived memoises by value: "Building"==="Building" → zero downstream updates
 	// when the phase hasn't actually changed, even though liveApp is a new object each poll.
-	let optimisticPhase = $state<string | null>(null);
+	let optimisticPhase = $state<AppPhase | null>(null);
 	const effectivePhase = $derived(
-		optimisticPhase ?? envPhase
+		phaseOverride ?? optimisticPhase ?? envPhase
 	);
 	const phaseMessage = $derived(
 		effectivePhase === 'Degraded'
@@ -86,8 +90,18 @@
 		}
 	});
 
+	$effect(() => {
+		if (!phaseOverride) return;
+		if (!envPhase) return;
+		if (envPhase === phaseOverride || envPhase !== 'Ready') {
+			onPhaseOverride(selectedEnv, null);
+		}
+	});
+
 	function applyOptimisticPhase(phase: string) {
-		optimisticPhase = phase;
+		const next = phase as AppPhase;
+		optimisticPhase = next;
+		if (selectedEnv) onPhaseOverride(selectedEnv, next);
 	}
 
 	async function doRebuild() {

--- a/ui/src/lib/components/AppNode.svelte
+++ b/ui/src/lib/components/AppNode.svelte
@@ -3,13 +3,14 @@
 	import type { NodeProps } from '@xyflow/svelte';
 	import { Handle, Position } from '@xyflow/svelte';
 	import { GitBranch, Container, Cloud, Clock, HardDrive, RotateCw } from 'lucide-svelte';
-	import { appNeedsRedeploy } from '$lib/types';
+	import { appNeedsRedeploy, appPhaseForEnvironment } from '$lib/types';
 	import type { App, AppPhase } from '$lib/types';
 
 	interface AppNodeData {
 		app: App;
 		projectName: string;
 		env: string;
+		phaseOverride?: AppPhase | null;
 		onOpen: (appName: string) => void;
 	}
 
@@ -21,8 +22,7 @@
 	const envStatusEntry = $derived(app.status?.environments?.find((e) => e.name === envName));
 	const enabled = $derived(envEntry?.enabled !== false);
 	const phase = $derived.by<AppPhase | undefined>(() => {
-		if (envStatusEntry?.phase) return envStatusEntry.phase;
-		return app.status?.phase;
+		return nodeData.phaseOverride ?? appPhaseForEnvironment(app, envName) ?? undefined;
 	});
 	const isExternal = $derived(app.spec.source.type === 'external' as string);
 	const isPrivate = $derived(app.spec.network?.public === false);

--- a/ui/src/lib/components/ProjectCanvas.svelte
+++ b/ui/src/lib/components/ProjectCanvas.svelte
@@ -13,12 +13,14 @@
 		app: App;
 		projectName: string;
 		env: string;
+		phaseOverride?: import('$lib/types').AppPhase | null;
 		onOpen: (appName: string) => void;
 	}
 
 	interface Props {
 		projectName: string;
 		apps: App[];
+		phaseOverrides?: Record<string, import('$lib/types').AppPhase | null>;
 		selectedApp?: string | null;
 		onAppOpen: (appName: string) => void;
 		onAddApp?: () => void;
@@ -26,7 +28,7 @@
 		onPaneClick?: () => void;
 	}
 
-	let { projectName, apps, selectedApp = null, onAppOpen, onAddApp, onDeleteApp, onPaneClick }: Props = $props();
+	let { projectName, apps, phaseOverrides = {}, selectedApp = null, onAppOpen, onAddApp, onDeleteApp, onPaneClick }: Props = $props();
 
 	const currentEnv = $derived(
 		store.currentEnv(projectName) || apps[0]?.spec.environments?.[0]?.name || 'production'
@@ -77,6 +79,7 @@
 					app,
 					projectName,
 					env,
+					phaseOverride: phaseOverrides[`${app.metadata.name}:${env}`] ?? null,
 					onOpen: onAppOpen
 				} satisfies AppNodeData
 			};

--- a/ui/src/lib/components/drawer/DeployLogsTab.svelte
+++ b/ui/src/lib/components/drawer/DeployLogsTab.svelte
@@ -2,7 +2,7 @@
 	import { onDestroy, untrack } from 'svelte';
 	import { AuthRequiredError, api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { resolveAppEnvironment } from '$lib/types';
+	import { appPhaseForEnvironment, resolveAppEnvironment } from '$lib/types';
 	import { Loader2, Search } from 'lucide-svelte';
 	import type { App, LogLineEvent, Pod } from '$lib/types';
 	import LogLine from '$lib/components/LogLine.svelte';
@@ -22,7 +22,7 @@
 		resolveAppEnvironment(app, store.currentEnv(project))
 	);
 	const envStatusEntry = $derived(app.status?.environments?.find((e) => e.name === selectedEnv));
-	const envPhase = $derived(envStatusEntry?.phase ?? app.status?.phase);
+	const envPhase = $derived(appPhaseForEnvironment(app, selectedEnv));
 	const isBuilding = $derived(envPhase === 'Building');
 	const isFailed = $derived(envPhase === 'Failed');
 	const failedMessage = $derived(

--- a/ui/src/lib/components/drawer/DeploymentsTab.svelte
+++ b/ui/src/lib/components/drawer/DeploymentsTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { appNeedsRedeploy, resolveAppEnvironment } from '$lib/types';
+	import { appNeedsRedeploy, appPhaseForEnvironment, resolveAppEnvironment } from '$lib/types';
 	import type { App } from '$lib/types';
 	import { RotateCw } from 'lucide-svelte';
 
@@ -29,14 +29,14 @@
 		app.status?.environments?.find((e) => e.name === selectedEnv) ?? null
 	);
 
-	const phase = $derived(phaseProp ?? app.status?.phase ?? 'Pending');
+	const phase = $derived(phaseProp ?? appPhaseForEnvironment(app, selectedEnv) ?? 'Pending');
 
 	const needsRedeploy = $derived(!autoRedeploy && appNeedsRedeploy(app));
 
 	async function doRedeploy() {
 		errorMsg = '';
 		reloading = true;
-		const prevPhase = app.status?.phase;
+		const prevPhase = phase;
 		onOptimisticPhase?.('Deploying');
 		try {
 			await api.redeploy(project, app.metadata.name, selectedEnv);
@@ -83,7 +83,7 @@
 	async function doRollback(envName: string, index: number) {
 		errorMsg = '';
 		reloading = true;
-		const prevPhase = app.status?.phase;
+		const prevPhase = phase;
 		onOptimisticPhase?.('Deploying');
 		try {
 			await api.rollback(project, app.metadata.name, envName, index);

--- a/ui/src/lib/types.test.ts
+++ b/ui/src/lib/types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { appPhaseForEnvironment, type App } from './types';
+
+function makeApp(status: App['status']): App {
+	return {
+		metadata: { name: 'web' },
+		spec: {
+			source: { type: 'git' },
+			environments: [{ name: 'production' }, { name: 'staging' }]
+		},
+		status
+	};
+}
+
+describe('appPhaseForEnvironment', () => {
+	it('prefers an in-progress build run for the selected environment', () => {
+		const app = makeApp({
+			phase: 'Building',
+			environments: [
+				{
+					name: 'production',
+					phase: 'Ready',
+					currentBuildRunRef: { name: 'run-1', phase: 'Running' }
+				},
+				{
+					name: 'staging',
+					phase: 'Ready'
+				}
+			]
+		});
+
+		expect(appPhaseForEnvironment(app, 'production')).toBe('Building');
+		expect(appPhaseForEnvironment(app, 'staging')).toBe('Ready');
+	});
+
+	it('does not let a stale failed build ref override the environment phase', () => {
+		const app = makeApp({
+			phase: 'Failed',
+			environments: [
+				{
+					name: 'production',
+					phase: 'Deploying',
+					currentBuildRunRef: { name: 'run-2', phase: 'Failed' }
+				}
+			]
+		});
+
+		expect(appPhaseForEnvironment(app, 'production')).toBe('Deploying');
+	});
+
+	it('falls back to the top-level phase only when no per-environment status exists', () => {
+		const app = makeApp({
+			phase: 'Pending',
+			environments: []
+		});
+
+		expect(appPhaseForEnvironment(app, 'production')).toBe('Pending');
+	});
+});

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -117,6 +117,13 @@ export interface DeployRecord {
 	timestamp: string;
 }
 
+export type BuildRunPhase = 'Pending' | 'Running' | 'Succeeded' | 'Failed';
+
+export interface BuildRunReference {
+	name: string;
+	phase?: BuildRunPhase;
+}
+
 export interface EnvironmentStatus {
 	name: string;
 	phase?: AppPhase;
@@ -127,6 +134,8 @@ export interface EnvironmentStatus {
 	domain?: string;
 	autoDomain?: string;
 	deployHistory?: DeployRecord[];
+	currentBuildRunRef?: BuildRunReference;
+	lastSuccessfulBuildRunRef?: BuildRunReference;
 	pendingEnvHash?: string;
 	deployedEnvHash?: string;
 	certificateStatus?: string;
@@ -180,6 +189,29 @@ export function resolveAppEnvironment(app: App, requestedEnv: string | null | un
 	const uniqueEnvs = [...new Set(knownEnvs.filter(Boolean))];
 	if (requestedEnv && uniqueEnvs.includes(requestedEnv)) return requestedEnv;
 	return uniqueEnvs[0] ?? requestedEnv ?? 'production';
+}
+
+function isBuildingRunPhase(phase: BuildRunPhase | undefined): boolean {
+	return phase === 'Pending' || phase === 'Running';
+}
+
+export function appPhaseForEnvironment(app: App, envName: string | null | undefined): AppPhase | null {
+	if (!envName) return app.status?.phase ?? null;
+
+	const envStatus = app.status?.environments?.find((env) => env.name === envName) ?? null;
+	if (!envStatus) {
+		// Only fall back to top-level phase when no per-environment status exists at all.
+		return (app.status?.environments?.length ?? 0) === 0 ? (app.status?.phase ?? null) : null;
+	}
+
+	if (isBuildingRunPhase(envStatus.currentBuildRunRef?.phase)) {
+		return 'Building';
+	}
+	if (envStatus.phase) {
+		return envStatus.phase;
+	}
+
+	return (app.status?.environments?.length ?? 0) === 0 ? (app.status?.phase ?? null) : null;
 }
 
 export interface SecretResponse {

--- a/ui/src/routes/projects/[project]/+page.svelte
+++ b/ui/src/routes/projects/[project]/+page.svelte
@@ -4,7 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api';
 	import { store } from '$lib/store.svelte';
-	import { appNeedsRedeploy, staleEnvironments } from '$lib/types';
+	import { appNeedsRedeploy, appPhaseForEnvironment, resolveAppEnvironment, staleEnvironments } from '$lib/types';
 	import type { App, AppPhase, Project, BuildLogsResponse, Pod } from '$lib/types';
 	import { connectProjectEvents } from '$lib/projectEvents';
 	import ProjectCanvas from '$lib/components/ProjectCanvas.svelte';
@@ -26,6 +26,7 @@
 	let deploying = $state(false);
 	let deployError = $state('');
 	let showDetailsModal = $state(false);
+	let phaseOverrides = $state<Record<string, AppPhase | null>>({});
 
 	// SSE-fed state for build logs
 	let buildLogs = $state<Map<string, BuildLogsResponse>>(new Map());
@@ -36,6 +37,37 @@
 	);
 
 	let eventStream: Awaited<ReturnType<typeof connectProjectEvents>> | null = null;
+
+	function phaseOverrideKey(appName: string, envName: string): string {
+		return `${appName}:${envName}`;
+	}
+
+	function applyPhaseOverride(appName: string, envName: string, phase: AppPhase | null) {
+		const key = phaseOverrideKey(appName, envName);
+		if (phase) {
+			phaseOverrides = { ...phaseOverrides, [key]: phase };
+			return;
+		}
+		if (!(key in phaseOverrides)) return;
+		const next = { ...phaseOverrides };
+		delete next[key];
+		phaseOverrides = next;
+	}
+
+	function reconcilePhaseOverrides(app: App) {
+		const next = { ...phaseOverrides };
+		let changed = false;
+		for (const [key, phase] of Object.entries(phaseOverrides)) {
+			if (!key.startsWith(`${app.metadata.name}:`) || !phase) continue;
+			const envName = key.slice(app.metadata.name.length + 1);
+			const realPhase = appPhaseForEnvironment(app, envName);
+			if (realPhase && (realPhase === phase || realPhase !== 'Ready')) {
+				delete next[key];
+				changed = true;
+			}
+		}
+		if (changed) phaseOverrides = next;
+	}
 
 	onMount(async () => {
 		if (!localStorage.getItem('mortise_token')) {
@@ -85,6 +117,7 @@
 		eventStream?.close();
 		eventStream = connectProjectEvents(projectName, {
 			onAppUpdated: (app) => {
+				reconcilePhaseOverrides(app);
 				const idx = apps.findIndex(a => a.metadata.name === app.metadata.name);
 				if (idx >= 0) {
 					apps[idx] = app;
@@ -320,6 +353,7 @@
 				<ProjectCanvas
 					{projectName}
 					{apps}
+					{phaseOverrides}
 					selectedApp={urlApp}
 					onAppOpen={(name) => selectedApp = name}
 					onPaneClick={() => selectedApp = null}
@@ -449,7 +483,8 @@
 						</thead>
 						<tbody>
 							{#each apps as app}
-								{@const phase = app.status?.phase}
+								{@const appEnv = resolveAppEnvironment(app, selectedEnv)}
+								{@const phase = phaseOverrides[phaseOverrideKey(app.metadata.name, appEnv)] ?? appPhaseForEnvironment(app, appEnv)}
 								{@const style = phase ? phaseStyles[phase] : undefined}
 								{@const Icon = sourceIcon(app)}
 								{@const domain = app.spec.environments?.[0]?.domain}
@@ -525,8 +560,13 @@
 			appName={selectedApp}
 			autoRedeploy={project?.autoRedeploy ?? false}
 			liveApp={drawerApp}
+			phaseOverride={drawerApp ? (phaseOverrides[phaseOverrideKey(drawerApp.metadata.name, resolveAppEnvironment(drawerApp, selectedEnv))] ?? null) : null}
 			liveBuildLogs={buildLogs.get(selectedApp ?? '') ?? null}
 			livePods={podUpdates.get((selectedApp ?? '') + ':' + (store.currentEnv(projectName) ?? '')) ?? null}
+			onPhaseOverride={(envName, phase) => {
+				if (!selectedApp) return;
+				applyPhaseOverride(selectedApp, envName, phase);
+			}}
 			onClose={() => selectedApp = null}
 		/>
 	{/key}

--- a/ui/src/routes/projects/[project]/apps/[app]/+page.svelte
+++ b/ui/src/routes/projects/[project]/apps/[app]/+page.svelte
@@ -8,7 +8,8 @@
 	import AppDrawer from '$lib/components/AppDrawer.svelte';
 	import ProjectCanvas from '$lib/components/ProjectCanvas.svelte';
 	import ViewModeToggle from '$lib/components/ViewModeToggle.svelte';
-	import type { App } from '$lib/types';
+	import { appPhaseForEnvironment, resolveAppEnvironment } from '$lib/types';
+	import type { App, AppPhase } from '$lib/types';
 
 	const projectName = $derived(page.params.project ?? '');
 	const appName = $derived(page.params.app ?? '');
@@ -17,6 +18,39 @@
 	let loading = $state(true);
 	let eventStream: Awaited<ReturnType<typeof connectProjectEvents>> | null = null;
 	let destroyed = false;
+	let phaseOverrides = $state<Record<string, AppPhase | null>>({});
+	const liveApp = $derived(apps.find(a => a.metadata.name === appName) ?? null);
+
+	function phaseOverrideKey(targetApp: string, envName: string): string {
+		return `${targetApp}:${envName}`;
+	}
+
+	function applyPhaseOverride(targetApp: string, envName: string, phase: AppPhase | null) {
+		const key = phaseOverrideKey(targetApp, envName);
+		if (phase) {
+			phaseOverrides = { ...phaseOverrides, [key]: phase };
+			return;
+		}
+		if (!(key in phaseOverrides)) return;
+		const next = { ...phaseOverrides };
+		delete next[key];
+		phaseOverrides = next;
+	}
+
+	function reconcilePhaseOverrides(app: App) {
+		const next = { ...phaseOverrides };
+		let changed = false;
+		for (const [key, phase] of Object.entries(phaseOverrides)) {
+			if (!key.startsWith(`${app.metadata.name}:`) || !phase) continue;
+			const envName = key.slice(app.metadata.name.length + 1);
+			const realPhase = appPhaseForEnvironment(app, envName);
+			if (realPhase && (realPhase === phase || realPhase !== 'Ready')) {
+				delete next[key];
+				changed = true;
+			}
+		}
+		if (changed) phaseOverrides = next;
+	}
 
 	onMount(async () => {
 		if (!localStorage.getItem('mortise_token')) {
@@ -30,6 +64,7 @@
 			if (destroyed) return;
 			eventStream = connectProjectEvents(projectName, {
 				onAppUpdated: (app) => {
+					reconcilePhaseOverrides(app);
 					const idx = apps.findIndex(a => a.metadata.name === app.metadata.name);
 					if (idx >= 0) {
 						apps[idx] = app;
@@ -77,6 +112,7 @@
 			<ProjectCanvas
 				{projectName}
 				{apps}
+				{phaseOverrides}
 				selectedApp={appName}
 				onAppOpen={(name) => goto(`/projects/${enc(projectName)}/apps/${enc(name)}`)}
 			/>
@@ -87,7 +123,9 @@
 			<AppDrawer
 				project={projectName}
 				{appName}
-				liveApp={apps.find(a => a.metadata.name === appName) ?? null}
+				{liveApp}
+				phaseOverride={liveApp ? (phaseOverrides[phaseOverrideKey(appName, resolveAppEnvironment(liveApp, store.currentEnv(projectName)))] ?? null) : null}
+				onPhaseOverride={(envName, phase) => applyPhaseOverride(appName, envName, phase)}
 				onClose={closeDrawer}
 			/>
 		{/key}


### PR DESCRIPTION
## Summary
- stamp `Building` onto the active `EnvironmentStatus` during git builds
- resolve UI status from env-specific build run + env phase instead of app-global phase
- share optimistic rebuild/redeploy phase overrides across canvas, list, and drawer

## Testing
- make test
- npm run check
- npx vitest run ui/src/lib/types.test.ts
- go test ./internal/controller/...
