### PR TITLE
fix: harden webhook registration against missing externalDomain and lost secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to Mortise are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Webhook registration requires `externalDomain`** (#450): the App
+  controller no longer falls back to `spec.domain` when
+  `spec.externalDomain` is unset. The app wildcard domain does not route
+  to the Mortise API, so the fallback registered (and, via stale-hook
+  cleanup, replaced working hooks with) callbacks that could never
+  deliver. When `externalDomain` is empty, registration is skipped and
+  the App records a `WebhookConfigured=False` condition. Installs that
+  serve Mortise on the platform domain must set `externalDomain` to the
+  same value.
+
+### Fixed
+
+- **Secretless webhook registration** (#451): the App controller no
+  longer registers webhooks for a GitProvider without a usable
+  `webhookSecretRef`. The webhook handler rejects unsigned deliveries,
+  so such hooks could never deliver; registration is now skipped with a
+  `WebhookConfigured=False` condition until the secret is configured.
+- **GitProvider self-heal** (#451): the GitProvider reconciler
+  re-attaches a lost `spec.webhookSecretRef` when the managed
+  `gitprovider-webhook-{name}` Secret still exists, and reports a
+  `WebhookSecretConfigured` status condition either way.
+- **Registry pull URL warning** (#449): the operator logs a startup
+  warning when `spec.registry.url` is cluster-internal and
+  `spec.registry.pullURL` is empty, instead of silently templating
+  image refs kubelets cannot pull.
+
 ## [1.0.2] - 2026-05-19
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -779,10 +779,15 @@ subdomain automatically, rooted at the platform domain configured at install.
 **Two domain concepts.** `PlatformConfig.spec.domain` is used exclusively for
 generating app subdomains. `PlatformConfig.spec.externalDomain` is where Mortise
 itself is publicly reachable — git webhook callbacks, deploy token API calls, and
-the UI all use this address. If `externalDomain` is empty, `domain` is used as
-fallback. This separation matters when app traffic routes through a wildcard DNS
-record (e.g. `*.apps.example.com`) while the Mortise API lives at a separate
-address (e.g. `mortise.example.com`, a Cloudflare Tunnel, or an IP).
+the UI all use this address. Webhook registration requires `externalDomain`;
+when it is empty the App controller skips registration and records a
+`WebhookConfigured=False` condition instead of guessing (the apex of the app
+domain generally does not route to the Mortise API, and registering there
+produces hooks that can never deliver). Installs that do serve Mortise at the
+apex set `externalDomain` to the same value as `domain`. This separation
+matters when app traffic routes through a wildcard DNS record (e.g.
+`*.apps.example.com`) while the Mortise API lives at a separate address
+(e.g. `mortise.example.com`, a Cloudflare Tunnel, or an IP).
 The default pattern includes the project name to prevent hostname collisions
 when two projects have apps with the same name:
 
@@ -1332,9 +1337,12 @@ users don't need to configure one manually.
 
 After credentials are configured, the per-repo webhook is registered
 automatically by the App controller when it reconciles a git-source app.
-The callback URL is `https://{externalDomain}/api/webhooks/{provider}`
-(falls back to `domain` if `externalDomain` is not set). The git host
-must be able to reach this address for push-to-deploy to work.
+The callback URL is `https://{externalDomain}/api/webhooks/{provider}`.
+Registration requires `externalDomain` and a usable provider
+`webhookSecretRef`; when either is missing the controller skips
+registration and records the reason on the App's `WebhookConfigured`
+condition. The git host must be able to reach this address for
+push-to-deploy to work.
 
 **Device flow API routes:**
 - `POST /api/auth/git/{provider}/device`: initiates device flow, returns user code + verification URI.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,6 +156,16 @@ func stacksFromPlatformConfig(cfg *platformconfig.Config, log logr.Logger) stack
 		bc = bk
 	}
 
+	// Kubelet resolves image refs via host DNS, so cluster-internal .svc
+	// registry URLs are unpullable from nodes. Without pullURL the pull ref
+	// falls back to the push URL and every fresh deploy ImagePullBackOffs.
+	if cfg.Registry.URL != "" && cfg.Registry.PullURL == "" && strings.Contains(cfg.Registry.URL, ".svc") {
+		log.Info("WARNING: spec.registry.pullURL is empty and spec.registry.url is cluster-internal; "+
+			"kubelet-facing image refs will use the push URL, which nodes typically cannot resolve. "+
+			"Set spec.registry.pullURL (and restart the operator) if pods fail to pull built images.",
+			"url", cfg.Registry.URL)
+	}
+
 	return stacks{
 		build: bc,
 		registry: registry.NewOCIBackend(registry.Config{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,9 +145,12 @@ Mortise API. Webhook callbacks are sent to
   where the Mortise API is on a different hostname or port than the
   wildcard used for app routing
 
-**When you don't:**
-- The platform domain also serves as the Mortise API address — the
-  default behavior when external domain is empty
+**It is required for automatic webhook registration.** When it is
+empty, the App controller skips webhook registration and records a
+`WebhookConfigured=False` condition; pushes then need a manual redeploy.
+The app wildcard domain is not assumed to route to the Mortise API, so
+Mortise never registers callbacks against it. If your platform domain
+does also serve the Mortise API, set `externalDomain` to the same value.
 
 Set it in **Settings > External Domain** in the UI, or via the
 PlatformConfig CRD:
@@ -157,8 +160,6 @@ spec:
   domain: apps.example.com          # used for app subdomains
   externalDomain: mortise.example.com  # where Mortise API is reachable
 ```
-
-If left empty, the platform domain is used for webhook callbacks.
 
 ### Webhook reachability
 

--- a/internal/api/device_flow.go
+++ b/internal/api/device_flow.go
@@ -443,7 +443,7 @@ func (d *DeviceFlowHandler) getOrCreateGitProvider(ctx context.Context, name str
 	if _, err := cryptorand.Read(webhookSecretBytes); err != nil {
 		return nil, fmt.Errorf("generate webhook secret: %w", err)
 	}
-	secretName := "gitprovider-webhook-" + name
+	secretName := git.WebhookSecretName(name)
 	whSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,

--- a/internal/api/gitproviders.go
+++ b/internal/api/gitproviders.go
@@ -278,7 +278,7 @@ func (s *Server) GetWebhookSecret(w http.ResponseWriter, r *http.Request) {
 
 // webhookSecretName returns the Secret name for a GitProvider's webhook HMAC key.
 func webhookSecretName(providerName string) string {
-	return "gitprovider-webhook-" + providerName
+	return git.WebhookSecretName(providerName)
 }
 
 // validateGitProviderRequest returns an error message describing why the

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -109,6 +109,7 @@ const (
 	webhookConditionType       = "WebhookConfigured"
 	webhookRegisteredReason    = "Registered"
 	webhookMissingURLReason    = "WebhookURLUnavailable"
+	webhookMissingSecretReason = "WebhookSecretUnavailable"
 	webhookInputHashMessageKey = "inputHash="
 )
 
@@ -2787,17 +2788,18 @@ func isMortiseManaged(obj client.Object) bool {
 func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.App, gp *mortisev1alpha1.GitProvider, token string) error {
 	log := logf.FromContext(ctx)
 
-	// Resolve the webhook URL from PlatformConfig domain.
+	// Resolve the webhook URL from PlatformConfig. Only externalDomain serves
+	// the Mortise API; spec.domain is the wildcard base for user apps, so
+	// falling back to it would register (and, via stale-hook cleanup, replace
+	// working hooks with) URLs that route nowhere.
 	var pc mortisev1alpha1.PlatformConfig
 	if err := r.Get(ctx, types.NamespacedName{Name: "platform"}, &pc); err != nil {
 		return fmt.Errorf("get PlatformConfig: %w", err)
 	}
 	host := pc.Spec.ExternalDomain
 	if host == "" {
-		host = pc.Spec.Domain
-	}
-	if host == "" {
-		r.setWebhookCondition(ctx, app, metav1.ConditionFalse, webhookMissingURLReason, "platform domain is not configured")
+		r.setWebhookCondition(ctx, app, metav1.ConditionFalse, webhookMissingURLReason,
+			"platformConfig.spec.externalDomain is not configured; webhook registration skipped")
 		return nil
 	}
 
@@ -2807,7 +2809,9 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 	}
 	webhookURL := fmt.Sprintf("%s://%s/api/webhooks/%s", scheme, host, gp.Name)
 
-	// Resolve webhook secret.
+	// Resolve webhook secret. The webhook handler rejects every delivery for
+	// a provider without a usable secret, so registering a secretless hook
+	// only produces 403s — skip and say why instead.
 	var webhookSecret string
 	if gp.Spec.WebhookSecretRef != nil {
 		var s corev1.Secret
@@ -2817,6 +2821,11 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 		}, &s); err == nil {
 			webhookSecret = string(s.Data[gp.Spec.WebhookSecretRef.Key])
 		}
+	}
+	if webhookSecret == "" {
+		r.setWebhookCondition(ctx, app, metav1.ConditionFalse, webhookMissingSecretReason,
+			fmt.Sprintf("GitProvider %q has no usable webhookSecretRef; webhook registration skipped", gp.Name))
+		return nil
 	}
 	inputHash := webhookRegistrationInputHash(app, gp, webhookURL, webhookSecret)
 	if webhookConditionInputHash(app) == inputHash {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4800,21 +4800,42 @@ var _ = Describe("App Controller — git source", func() {
 	})
 
 	Context("webhook registration", func() {
+		// makeWebhookSecret creates the HMAC Secret a GitProvider's
+		// webhookSecretRef points at; ensureWebhook skips registration when a
+		// provider has no usable secret.
+		makeWebhookSecret := func(ctx context.Context, providerName string) (*corev1.Secret, *mortisev1alpha1.SecretRef) {
+			_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+			s := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      git.WebhookSecretName(providerName),
+					Namespace: "mortise-system",
+					Labels:    map[string]string{"app.kubernetes.io/managed-by": "mortise"},
+				},
+				Data: map[string][]byte{git.WebhookSecretKey: []byte("hmac-secret")},
+			}
+			Expect(k8sClient.Create(ctx, s)).To(Succeed())
+			return s, &mortisev1alpha1.SecretRef{Namespace: "mortise-system", Name: s.Name, Key: git.WebhookSecretKey}
+		}
+
 		It("latches registration on a status condition input hash", func() {
 			ctx := context.Background()
 
 			pc := &mortisev1alpha1.PlatformConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
-				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com", ExternalDomain: "mortise.example.com"},
 			}
 			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
 			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
 
+			whSecret, whRef := makeWebhookSecret(ctx, "gh-webhook-latch")
+			defer func() { Expect(k8sClient.Delete(ctx, whSecret)).To(Succeed()) }()
+
 			gp := &mortisev1alpha1.GitProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-latch"},
 				Spec: mortisev1alpha1.GitProviderSpec{
-					Type: mortisev1alpha1.GitProviderTypeGitHub,
-					Host: "https://github.com",
+					Type:             mortisev1alpha1.GitProviderTypeGitHub,
+					Host:             "https://github.com",
+					WebhookSecretRef: whRef,
 				},
 			}
 			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
@@ -4852,17 +4873,21 @@ var _ = Describe("App Controller — git source", func() {
 
 			pc := &mortisev1alpha1.PlatformConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
-				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com", ExternalDomain: "mortise.example.com"},
 			}
 			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
 			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
 
+			whSecret, whRef := makeWebhookSecret(ctx, "gh-webhook-failure")
+			defer func() { Expect(k8sClient.Delete(ctx, whSecret)).To(Succeed()) }()
+
 			gp := &mortisev1alpha1.GitProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-failure"},
 				Spec: mortisev1alpha1.GitProviderSpec{
-					Type:     mortisev1alpha1.GitProviderTypeGitHub,
-					Host:     "https://github.com",
-					ClientID: "test-client-id",
+					Type:             mortisev1alpha1.GitProviderTypeGitHub,
+					Host:             "https://github.com",
+					ClientID:         "test-client-id",
+					WebhookSecretRef: whRef,
 				},
 			}
 			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
@@ -4913,16 +4938,20 @@ var _ = Describe("App Controller — git source", func() {
 
 			pc := &mortisev1alpha1.PlatformConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
-				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com", ExternalDomain: "mortise.example.com"},
 			}
 			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
 			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
 
+			whSecret, whRef := makeWebhookSecret(ctx, "gh-webhook-permanent")
+			defer func() { Expect(k8sClient.Delete(ctx, whSecret)).To(Succeed()) }()
+
 			gp := &mortisev1alpha1.GitProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-permanent"},
 				Spec: mortisev1alpha1.GitProviderSpec{
-					Type: mortisev1alpha1.GitProviderTypeGitHub,
-					Host: "https://github.com",
+					Type:             mortisev1alpha1.GitProviderTypeGitHub,
+					Host:             "https://github.com",
+					WebhookSecretRef: whRef,
 				},
 			}
 			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
@@ -4966,16 +4995,20 @@ var _ = Describe("App Controller — git source", func() {
 
 			pc := &mortisev1alpha1.PlatformConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
-				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com", ExternalDomain: "mortise.example.com"},
 			}
 			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
 			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
 
+			whSecret, whRef := makeWebhookSecret(ctx, "gh-webhook-transient")
+			defer func() { Expect(k8sClient.Delete(ctx, whSecret)).To(Succeed()) }()
+
 			gp := &mortisev1alpha1.GitProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-transient"},
 				Spec: mortisev1alpha1.GitProviderSpec{
-					Type: mortisev1alpha1.GitProviderTypeGitHub,
-					Host: "https://github.com",
+					Type:             mortisev1alpha1.GitProviderTypeGitHub,
+					Host:             "https://github.com",
+					WebhookSecretRef: whRef,
 				},
 			}
 			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
@@ -5003,6 +5036,95 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(HaveOccurred())
 			Expect(api.listCount).To(Equal(2))
 			Expect(api.registerCount).To(Equal(2))
+		})
+
+		It("skips registration when externalDomain is not configured", func() {
+			ctx := context.Background()
+
+			// Only spec.domain set: the app wildcard domain does not serve the
+			// Mortise API, so no webhook may be registered against it.
+			pc := &mortisev1alpha1.PlatformConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
+
+			whSecret, whRef := makeWebhookSecret(ctx, "gh-webhook-nodomain")
+			defer func() { Expect(k8sClient.Delete(ctx, whSecret)).To(Succeed()) }()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-nodomain"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type:             mortisev1alpha1.GitProviderTypeGitHub,
+					Host:             "https://github.com",
+					WebhookSecretRef: whRef,
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			app := makeGitSourceApp("git-webhook-nodomain", namespace, gp.Name)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+
+			api := &fakeWebhookAPI{}
+			r := gitSourceReconciler(&fakeBuildClient{digest: "sha256:nodomain"}, &fakeGitClient{}, &fakeRegistryBackend{})
+			r.GitAPIFactory = func(_ *mortisev1alpha1.GitProvider, _, _ string) (git.GitAPI, error) {
+				return api, nil
+			}
+
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(Succeed())
+			Expect(api.listCount).To(Equal(0))
+			Expect(api.registerCount).To(Equal(0))
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+			cond := meta.FindStatusCondition(app.Status.Conditions, webhookConditionType)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(webhookMissingURLReason))
+		})
+
+		It("skips registration when the provider has no usable webhook secret", func() {
+			ctx := context.Background()
+
+			pc := &mortisev1alpha1.PlatformConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+				Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com", ExternalDomain: "mortise.example.com"},
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, pc)).To(Succeed()) }()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-webhook-nosecret"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type: mortisev1alpha1.GitProviderTypeGitHub,
+					Host: "https://github.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			app := makeGitSourceApp("git-webhook-nosecret", namespace, gp.Name)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+
+			api := &fakeWebhookAPI{}
+			r := gitSourceReconciler(&fakeBuildClient{digest: "sha256:nosecret"}, &fakeGitClient{}, &fakeRegistryBackend{})
+			r.GitAPIFactory = func(_ *mortisev1alpha1.GitProvider, _, _ string) (git.GitAPI, error) {
+				return api, nil
+			}
+
+			Expect(r.ensureWebhook(ctx, app, gp, "tok")).To(Succeed())
+			Expect(api.registerCount).To(Equal(0))
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+			cond := meta.FindStatusCondition(app.Status.Conditions, webhookConditionType)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(webhookMissingSecretReason))
 		})
 	})
 

--- a/internal/controller/gitprovider_controller.go
+++ b/internal/controller/gitprovider_controller.go
@@ -22,15 +22,18 @@ import (
 	"net/url"
 	"os"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 // providerClientIDEnvVars maps each GitProvider type to the environment
@@ -113,7 +116,67 @@ func (r *GitProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	// Re-attach the managed webhook Secret when the ref was lost (e.g. the CR
+	// was recreated from a manifest that omitted it). Without the ref every
+	// delivery is rejected 403 and builds silently stop triggering.
+	if gp.Spec.WebhookSecretRef == nil {
+		if requeue, err := r.reattachWebhookSecret(ctx, &gp); err != nil {
+			return ctrl.Result{}, err
+		} else if requeue {
+			return ctrl.Result{Requeue: true}, nil
+		}
+	}
+	setWebhookSecretCondition(&gp)
+
 	return ctrl.Result{}, r.markReady(ctx, &gp)
+}
+
+// reattachWebhookSecret re-links spec.webhookSecretRef to the conventionally
+// named managed Secret if it still exists. Returns true when the spec was
+// patched (caller requeues to observe the update).
+func (r *GitProviderReconciler) reattachWebhookSecret(ctx context.Context, gp *mortisev1alpha1.GitProvider) (bool, error) {
+	log := logf.FromContext(ctx)
+	secretName := git.WebhookSecretName(gp.Name)
+	var s corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{Namespace: git.TokenSecretNamespace, Name: secretName}, &s); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if s.Labels["app.kubernetes.io/managed-by"] != "mortise" || len(s.Data[git.WebhookSecretKey]) == 0 {
+		return false, nil
+	}
+	log.Info("re-attaching lost webhookSecretRef", "secret", secretName)
+	patch := client.MergeFrom(gp.DeepCopy())
+	gp.Spec.WebhookSecretRef = &mortisev1alpha1.SecretRef{
+		Namespace: git.TokenSecretNamespace,
+		Name:      secretName,
+		Key:       git.WebhookSecretKey,
+	}
+	if err := r.Patch(ctx, gp, patch); err != nil {
+		return false, fmt.Errorf("re-attach webhookSecretRef: %w", err)
+	}
+	return true, nil
+}
+
+// setWebhookSecretCondition records whether webhook deliveries can be
+// verified, so a missing secret is visible on the CR instead of only as 403s
+// in the webhook handler. Flushed by the markReady status update.
+func setWebhookSecretCondition(gp *mortisev1alpha1.GitProvider) {
+	cond := metav1.Condition{
+		Type:               "WebhookSecretConfigured",
+		Status:             metav1.ConditionTrue,
+		Reason:             "SecretConfigured",
+		Message:            "webhook deliveries can be verified",
+		ObservedGeneration: gp.Generation,
+	}
+	if gp.Spec.WebhookSecretRef == nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "WebhookSecretMissing"
+		cond.Message = "spec.webhookSecretRef is not set; all webhook deliveries will be rejected"
+	}
+	meta.SetStatusCondition(&gp.Status.Conditions, cond)
 }
 
 func (r *GitProviderReconciler) markReady(ctx context.Context, gp *mortisev1alpha1.GitProvider) error {

--- a/internal/controller/gitprovider_controller_test.go
+++ b/internal/controller/gitprovider_controller_test.go
@@ -23,11 +23,13 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/git"
 )
 
 var _ = Describe("GitProvider Controller", func() {
@@ -176,6 +178,87 @@ var _ = Describe("GitProvider Controller", func() {
 	Context("when the resource does not exist", func() {
 		It("returns nil without error", func() {
 			Expect(reconcile("does-not-exist")).To(Succeed())
+		})
+	})
+
+	Context("when webhookSecretRef was lost but the managed secret survives", func() {
+		const gpName = "gp-reattach"
+
+		BeforeEach(func() {
+			_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: git.TokenSecretNamespace}})
+			s := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      git.WebhookSecretName(gpName),
+					Namespace: git.TokenSecretNamespace,
+					Labels:    map[string]string{"app.kubernetes.io/managed-by": "mortise"},
+				},
+				Data: map[string][]byte{git.WebhookSecretKey: []byte("hmac")},
+			}
+			Expect(k8sClient.Create(ctx, s)).To(Succeed())
+
+			gp := makeProvider(gpName, mortisev1alpha1.GitProviderTypeGitHub, "unused")
+			gp.Spec.WebhookSecretRef = nil
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			gp := &mortisev1alpha1.GitProvider{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: gpName}, gp); err == nil {
+				Expect(k8sClient.Delete(ctx, gp)).To(Succeed())
+			}
+			s := &corev1.Secret{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: git.TokenSecretNamespace, Name: git.WebhookSecretName(gpName)}, s); err == nil {
+				Expect(k8sClient.Delete(ctx, s)).To(Succeed())
+			}
+		})
+
+		It("re-attaches the ref and reaches Ready with WebhookSecretConfigured=True", func() {
+			Expect(reconcile(gpName)).To(Succeed())
+
+			var updated mortisev1alpha1.GitProvider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gpName}, &updated)).To(Succeed())
+			Expect(updated.Spec.WebhookSecretRef).NotTo(BeNil())
+			Expect(updated.Spec.WebhookSecretRef.Name).To(Equal(git.WebhookSecretName(gpName)))
+			Expect(updated.Spec.WebhookSecretRef.Namespace).To(Equal(git.TokenSecretNamespace))
+			Expect(updated.Spec.WebhookSecretRef.Key).To(Equal(git.WebhookSecretKey))
+
+			// Second pass (the requeue) completes the status projection.
+			Expect(reconcile(gpName)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gpName}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(mortisev1alpha1.GitProviderPhaseReady))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "WebhookSecretConfigured")
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("when webhookSecretRef is nil and no managed secret exists", func() {
+		const gpName = "gp-no-webhook-secret"
+
+		BeforeEach(func() {
+			gp := makeProvider(gpName, mortisev1alpha1.GitProviderTypeGitHub, "unused")
+			gp.Spec.WebhookSecretRef = nil
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			gp := &mortisev1alpha1.GitProvider{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: gpName}, gp); err == nil {
+				Expect(k8sClient.Delete(ctx, gp)).To(Succeed())
+			}
+		})
+
+		It("stays Ready but reports WebhookSecretConfigured=False", func() {
+			Expect(reconcile(gpName)).To(Succeed())
+
+			var updated mortisev1alpha1.GitProvider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gpName}, &updated)).To(Succeed())
+			Expect(updated.Spec.WebhookSecretRef).To(BeNil())
+			Expect(updated.Status.Phase).To(Equal(mortisev1alpha1.GitProviderPhaseReady))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "WebhookSecretConfigured")
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("WebhookSecretMissing"))
 		})
 	})
 

--- a/internal/git/tokens.go
+++ b/internal/git/tokens.go
@@ -15,6 +15,18 @@ import (
 // TokenSecretNamespace is where user git tokens and provider secrets are stored.
 const TokenSecretNamespace = "mortise-system"
 
+// WebhookSecretKey is the key inside a provider webhook Secret that holds the
+// shared HMAC secret.
+const WebhookSecretKey = "webhookSecret"
+
+// WebhookSecretName returns the k8s Secret name holding the webhook HMAC
+// secret for a provider. Pattern: gitprovider-webhook-{providerName}. Every
+// GitProvider creation path mints this Secret; the GitProvider reconciler
+// uses the same convention to re-attach a lost webhookSecretRef.
+func WebhookSecretName(providerName string) string {
+	return "gitprovider-webhook-" + providerName
+}
+
 // UserTokenSecretName returns the k8s Secret name for a user's token for a
 // specific provider. Pattern: user-{providerName}-token-{hex(email)}.
 func UserTokenSecretName(providerName, email string) string {


### PR DESCRIPTION
## Summary

Operator-side fixes for the 2026-07-25 Jazure incident where an operator upgrade left every push-to-deploy pipeline silently dead. Closes #450 and #451; partially addresses #449 (the startup warning; the config hot-reload half stays open).

## Fixes

**Webhook registration requires `externalDomain` (#450)**
`ensureWebhook` fell back to `spec.domain` when `spec.externalDomain` was unset. The app wildcard domain does not route to the Mortise API, so the fallback registered callbacks that could never deliver, and the stale-hook cleanup in the same function would delete working hooks whose URL did not match the miscomputed one. Registration is now skipped with a `WebhookConfigured=False` / `WebhookURLUnavailable` condition when `externalDomain` is empty. This is a documented behavior change: SPEC.md, docs/configuration.md, and the changelog now state that installs serving Mortise on the platform domain must set `externalDomain` explicitly.

**No secretless webhook registration (#451)**
When a GitProvider had no usable `webhookSecretRef`, `ensureWebhook` still registered the hook with an empty secret while the webhook handler hard-rejects every unsigned delivery with 403. Registration is now skipped with a `WebhookConfigured=False` / `WebhookSecretUnavailable` condition.

**GitProvider webhookSecretRef self-heal (#451)**
Both creation paths mint a managed `gitprovider-webhook-{name}` Secret, but nothing repaired a CR recreated without the ref (exactly what happened on Jazure, where the Secret survived the whole time). The GitProvider reconciler now re-attaches the ref when the managed Secret exists (mirroring the existing clientID backfill pattern from #139) and reports a `WebhookSecretConfigured` condition either way, so the broken state is visible on the CR instead of only as 403s. The secret-name convention moved to `internal/git.WebhookSecretName` so the API, device flow, and controller share one definition.

**Registry pull URL startup warning (#449)**
The operator now logs a warning at startup when `spec.registry.url` is cluster-internal (`.svc`) and `spec.registry.pullURL` is empty — the combination that silently templates image refs kubelets cannot resolve. The larger fix (hot-reloading PlatformConfig registry config) remains tracked in #449.

## Testing

- Updated the four existing webhook-registration envtest specs for the new requirements (externalDomain + webhook secret present).
- New specs: registration skipped with the right condition when externalDomain is missing; when the provider has no usable secret; GitProvider re-attaches a lost ref from the managed Secret; GitProvider stays Ready but reports `WebhookSecretConfigured=False` when no managed Secret exists.
- `make test` green locally.

## Deployment note (Jazure)

After this lands, Jazure needs `spec.externalDomain: mortise.jazure.net` set on the PlatformConfig for webhook registration to resume (previously it worked only via the apex fallback accidentally pointing at a once-valid host). Existing hooks keep working either way.
