### PR TITLE
fix(build): BuildRun reliability — persist terminal status before tracker delete; rebuild markers reach all envs

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -765,6 +765,9 @@ func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Envir
 // the image to use for this env's deployment, or "" if a build is still in
 // flight (caller should skip deployment and requeue). statusDirty is true when
 // applyEnvBuildSuccess mutated app.Status and the caller must flush.
+// shouldClearNoCache is true when this env consumed a pending rebuild request;
+// the caller clears the rebuild markers once after the env loop, so a mid-loop
+// error return leaves them in place and the rebuild stays pending.
 func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
 
@@ -830,6 +833,12 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 	}
 
+	// Reaching ensureAppBuildRun with markers pending means this env consumes
+	// the rebuild request: the ensured BuildRun carries its RequestID/NoCache.
+	// Report that so the caller clears the app-wide markers once after the
+	// env loop — clearing mid-loop would starve the remaining envs.
+	consumedRebuild := hasPendingRebuildRequest(app)
+
 	run, err := r.ensureAppBuildRun(ctx, app, envName, branch, revision, imageRef.Full, pullRef.Full)
 	if err != nil {
 		log.Error(err, "ensure buildrun failed", "env", envName)
@@ -840,15 +849,15 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	switch run.Status.Phase {
 	case mortisev1alpha1.BuildRunPhaseSucceeded:
 		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
-		return run.Status.Image, false, true, false, nil
+		return run.Status.Image, false, true, consumedRebuild, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
 		if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
 			return "", false, false, false, err
 		}
-		return "", false, true, false, nil
+		return "", false, true, consumedRebuild, nil
 	default:
 		r.markEnvBuildInProgress(app, envName, revision)
-		return "", true, true, false, nil
+		return "", true, true, consumedRebuild, nil
 	}
 }
 

--- a/internal/controller/build_tracker.go
+++ b/internal/controller/build_tracker.go
@@ -156,6 +156,19 @@ func (s *BuildTrackerStore) delete(key types.NamespacedName) {
 	s.trackers.Delete(key)
 }
 
+// cancelAndDelete atomically removes the tracker for the given key and cancels
+// its build goroutine, releasing the build context and log buffer. Used when
+// the BuildRun disappears mid-build (e.g. App deletion cascades to it).
+func (s *BuildTrackerStore) cancelAndDelete(key types.NamespacedName) {
+	v, ok := s.trackers.LoadAndDelete(key)
+	if !ok {
+		return
+	}
+	if t := v.(*buildTracker); t.cancel != nil {
+		t.cancel()
+	}
+}
+
 // GetBuildLogs returns the current build log lines for the given App, or nil
 // if no build is in progress. Exported for use by the API layer.
 func (s *BuildTrackerStore) GetBuildLogs(key types.NamespacedName) []string {

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -67,6 +67,12 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	var br mortisev1alpha1.BuildRun
 	if err := r.Get(ctx, req.NamespacedName, &br); err != nil {
 		if errors.IsNotFound(err) {
+			// The BuildRun is gone (e.g. App deletion cascaded mid-build).
+			// Cancel any in-flight build goroutine so it doesn't run to the
+			// 30min build timeout holding its log ring.
+			if r.Builds != nil {
+				r.Builds.cancelAndDelete(req.NamespacedName)
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -101,36 +107,51 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 			return ctrl.Result{RequeueAfter: buildRunPollInterval}, nil
 		case buildPhaseSucceeded, buildPhaseFailed:
-			r.Builds.delete(key)
+			// Persist the terminal outcome BEFORE dropping the tracker. If the
+			// tracker is deleted first and any write below fails, the next
+			// reconcile sees phase Running with no tracker and treats a
+			// finished build as lost — triggering a duplicate rebuild or a
+			// terminal BuildInterrupted failure.
 			logRef, err := r.persistBuildRunLog(ctx, &br, tracker)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 
 			now := metav1.NewTime(r.clock().Now())
-			br.Status.FinishedAt = &now
-			br.Status.CompletedAt = &now
-			br.Status.LogRef = logRef
-			if phase == buildPhaseSucceeded {
-				br.Status.Phase = mortisev1alpha1.BuildRunPhaseSucceeded
-				br.Status.Image = image
-				br.Status.Digest = digest
-				br.Status.DetectedPort = detectedPort
-				br.Status.FailureReason = ""
-				br.Status.FailureMessage = ""
-				setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseSucceeded, br.Generation, "build completed", now)
-			} else {
-				br.Status.Phase = mortisev1alpha1.BuildRunPhaseFailed
-				br.Status.FailureReason = "BuildFailed"
-				br.Status.FailureMessage = errMsg
-				setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseFailed, br.Generation, errMsg, now)
-			}
-			if err := r.Status().Update(ctx, &br); err != nil {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				var latest mortisev1alpha1.BuildRun
+				if err := r.Get(ctx, req.NamespacedName, &latest); err != nil {
+					return err
+				}
+				latest.Status.FinishedAt = &now
+				latest.Status.CompletedAt = &now
+				latest.Status.LogRef = logRef
+				if phase == buildPhaseSucceeded {
+					latest.Status.Phase = mortisev1alpha1.BuildRunPhaseSucceeded
+					latest.Status.Image = image
+					latest.Status.Digest = digest
+					latest.Status.DetectedPort = detectedPort
+					latest.Status.FailureReason = ""
+					latest.Status.FailureMessage = ""
+					setBuildRunCondition(&latest.Status.Conditions, mortisev1alpha1.BuildRunPhaseSucceeded, latest.Generation, "build completed", now)
+				} else {
+					latest.Status.Phase = mortisev1alpha1.BuildRunPhaseFailed
+					latest.Status.FailureReason = "BuildFailed"
+					latest.Status.FailureMessage = errMsg
+					setBuildRunCondition(&latest.Status.Conditions, mortisev1alpha1.BuildRunPhaseFailed, latest.Generation, errMsg, now)
+				}
+				if err := r.Status().Update(ctx, &latest); err != nil {
+					return err
+				}
+				br = latest
+				return nil
+			}); err != nil {
 				return ctrl.Result{}, err
 			}
 			if err := r.projectTerminalBuildRunStatus(ctx, &br); err != nil {
 				return ctrl.Result{}, err
 			}
+			r.Builds.delete(key)
 			if err := r.gcBuildRunHistory(ctx, &br); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -150,6 +171,21 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName) (ctrl.Result, error) {
+	// A concurrent reconcile may have persisted the terminal outcome and
+	// dropped the tracker after our (possibly cached) read. Re-read before
+	// treating a finished build as lost.
+	var latest mortisev1alpha1.BuildRun
+	if err := r.Get(ctx, key, &latest); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if isBuildRunTerminal(&latest) {
+		return ctrl.Result{}, nil
+	}
+	br = &latest
+
 	if br.Status.StartedAt == nil {
 		return ctrl.Result{RequeueAfter: buildRunTrackerLossGrace}, nil
 	}
@@ -356,6 +392,20 @@ func (r *BuildRunReconciler) mergedBuildRunLogLines(ctx context.Context, br *mor
 	if existing.Data["lines"] != "" {
 		merged = append(merged, strings.Split(existing.Data["lines"], "\n")...)
 	}
+	// A terminal persist can be retried after a failed status write; if the
+	// current lines already landed verbatim, don't append them again.
+	if n := len(current); n > 0 && len(merged) >= n {
+		dup := true
+		for i, line := range merged[len(merged)-n:] {
+			if line != current[i] {
+				dup = false
+				break
+			}
+		}
+		if dup {
+			return merged, nil
+		}
+	}
 	if len(merged) > 0 && len(current) > 0 && merged[len(merged)-1] == current[0] {
 		current = current[1:]
 	}
@@ -545,19 +595,26 @@ func buildRunRetentionSortTime(run *mortisev1alpha1.BuildRun) time.Time {
 }
 
 func upsertConfigMap(ctx context.Context, c client.Client, desired *corev1.ConfigMap) error {
-	var existing corev1.ConfigMap
+	// The legacy app-scoped log ConfigMap is shared across all envs of an
+	// app, so concurrent reconciles genuinely race on this read-modify-write:
+	// retry both update conflicts and lost create races.
 	key := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
-	if err := c.Get(ctx, key, &existing); err != nil {
-		if errors.IsNotFound(err) {
-			return c.Create(ctx, desired)
+	return retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return errors.IsConflict(err) || errors.IsAlreadyExists(err)
+	}, func() error {
+		var existing corev1.ConfigMap
+		if err := c.Get(ctx, key, &existing); err != nil {
+			if errors.IsNotFound(err) {
+				return c.Create(ctx, desired)
+			}
+			return err
 		}
-		return err
-	}
-	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
-	existing.Data = desired.Data
-	existing.OwnerReferences = desired.OwnerReferences
-	return c.Update(ctx, &existing)
+		existing.Labels = desired.Labels
+		existing.Annotations = desired.Annotations
+		existing.Data = desired.Data
+		existing.OwnerReferences = desired.OwnerReferences
+		return c.Update(ctx, &existing)
+	})
 }
 
 func parseImageRef(full string) registry.ImageRef {

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -160,7 +160,7 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if br.Status.Phase == mortisev1alpha1.BuildRunPhaseRunning {
-		return r.handleLostBuildRunTracker(ctx, &br, key)
+		return r.handleLostBuildRunTracker(ctx, key)
 	}
 
 	attempt := br.Status.Attempt
@@ -170,7 +170,7 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return r.startBuildRunAttempt(ctx, &br, key, attempt, "")
 }
 
-func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName) (ctrl.Result, error) {
+func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {
 	// A concurrent reconcile may have persisted the terminal outcome and
 	// dropped the tracker after our (possibly cached) read. Re-read before
 	// treating a finished build as lost.
@@ -184,7 +184,7 @@ func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, br *
 	if isBuildRunTerminal(&latest) {
 		return ctrl.Result{}, nil
 	}
-	br = &latest
+	br := &latest
 
 	if br.Status.StartedAt == nil {
 		return ctrl.Result{RequeueAfter: buildRunTrackerLossGrace}, nil

--- a/internal/controller/buildrun_controller_recovery_test.go
+++ b/internal/controller/buildrun_controller_recovery_test.go
@@ -355,9 +355,7 @@ func TestHandleLostTrackerDoesNotRestartTerminalBuildRun(t *testing.T) {
 	// run to Failed/BuildInfraUnavailable, which the assertions below catch.
 	r := &BuildRunReconciler{Client: c, Scheme: scheme, Clock: clock, Builds: &BuildTrackerStore{}}
 
-	stale := run.DeepCopy()
-	stale.Status.Phase = mortisev1alpha1.BuildRunPhaseRunning
-	res, err := r.handleLostBuildRunTracker(context.Background(), stale, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+	res, err := r.handleLostBuildRunTracker(context.Background(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
 	if err != nil {
 		t.Fatalf("handleLostBuildRunTracker: %v", err)
 	}

--- a/internal/controller/buildrun_controller_recovery_test.go
+++ b/internal/controller/buildrun_controller_recovery_test.go
@@ -9,12 +9,15 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/build"
@@ -193,6 +196,184 @@ func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
 	}
 	if !strings.Contains(updated.Status.FailureMessage, "tracker lost") {
 		t.Fatalf("expected interruption message, got %q", updated.Status.FailureMessage)
+	}
+}
+
+// Regression for GH #434 (half A): the terminal outcome must be durable before
+// the tracker is dropped. If a status write fails, the tracker has to survive
+// so the next reconcile retries persistence instead of treating a finished
+// build as lost (duplicate rebuild / bogus BuildInterrupted).
+func TestBuildRunTerminalStatusPersistsBeforeTrackerDelete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-3", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment: "production",
+			Repo:        "https://example.com/repo.git",
+			Revision:    "abc123",
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   1,
+			StartedAt: &started,
+		},
+	}
+
+	failNextStatusWrite := true
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if _, ok := obj.(*mortisev1alpha1.BuildRun); ok && failNextStatusWrite {
+					failNextStatusWrite = false
+					return apierrors.NewInternalError(fmt.Errorf("injected status write failure"))
+				}
+				return cl.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	key := types.NamespacedName{Name: run.Name, Namespace: run.Namespace}
+	store := &BuildTrackerStore{}
+	store.set(key, &buildTracker{
+		phase:  buildPhaseSucceeded,
+		image:  "registry.example.com/demo:abc123",
+		digest: "sha256:deadbeef",
+		logs:   []string{"step 1", "step 2"},
+	})
+
+	clock := clocktesting.NewFakeClock(started.Add(time.Minute))
+	r := &BuildRunReconciler{Client: c, Scheme: scheme, Clock: clock, Builds: store}
+
+	req := ctrl.Request{NamespacedName: key}
+	if _, err := r.Reconcile(context.Background(), req); err == nil {
+		t.Fatal("expected first reconcile to surface the injected status write failure")
+	}
+	if store.get(key) == nil {
+		t.Fatal("tracker must survive a failed terminal status write")
+	}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), key, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseSucceeded {
+		t.Fatalf("expected succeeded buildrun, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Image != "registry.example.com/demo:abc123" {
+		t.Fatalf("expected image persisted, got %q", updated.Status.Image)
+	}
+	if store.get(key) != nil {
+		t.Fatal("expected tracker removed after terminal status persisted")
+	}
+
+	var logCM corev1.ConfigMap
+	if err := c.Get(context.Background(), types.NamespacedName{Name: buildRunLogConfigMapName(run.Name), Namespace: run.Namespace}, &logCM); err != nil {
+		t.Fatalf("get buildrun log configmap: %v", err)
+	}
+	if logCM.Data["lines"] != "step 1\nstep 2" {
+		t.Fatalf("expected log lines persisted exactly once across the retry, got %q", logCM.Data["lines"])
+	}
+}
+
+// Regression for GH #434 (half B): deleting a BuildRun mid-build (e.g. via App
+// deletion cascade) must cancel the build goroutine and release the tracker
+// instead of leaking both until the 30min build timeout.
+func TestBuildRunReconcileCancelsTrackerWhenBuildRunDeleted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	key := types.NamespacedName{Name: "gone", Namespace: "pj-default"}
+	cancelled := false
+	store := &BuildTrackerStore{}
+	store.set(key, &buildTracker{phase: buildPhaseRunning, cancel: func() { cancelled = true }})
+
+	r := &BuildRunReconciler{Client: c, Scheme: scheme, Builds: store}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile deleted buildrun: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("expected deleted buildrun's tracker to be cancelled")
+	}
+	if store.get(key) != nil {
+		t.Fatal("expected deleted buildrun's tracker to be removed")
+	}
+}
+
+// A stale cached read can show phase Running after a concurrent reconcile
+// already persisted the terminal outcome and dropped the tracker. The lost-
+// tracker path must re-read and leave terminal BuildRuns alone.
+func TestHandleLostTrackerDoesNotRestartTerminalBuildRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-4", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment: "production",
+			Revision:    "abc123",
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseSucceeded,
+			Attempt:   1,
+			StartedAt: &started,
+			Image:     "registry.example.com/demo:abc123",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Second))
+	// No BuildClient configured: an erroneous restart attempt would flip the
+	// run to Failed/BuildInfraUnavailable, which the assertions below catch.
+	r := &BuildRunReconciler{Client: c, Scheme: scheme, Clock: clock, Builds: &BuildTrackerStore{}}
+
+	stale := run.DeepCopy()
+	stale.Status.Phase = mortisev1alpha1.BuildRunPhaseRunning
+	res, err := r.handleLostBuildRunTracker(context.Background(), stale, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+	if err != nil {
+		t.Fatalf("handleLostBuildRunTracker: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for terminal buildrun, got %v", res.RequeueAfter)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseSucceeded {
+		t.Fatalf("expected terminal buildrun left untouched, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Attempt != 1 {
+		t.Fatalf("expected no restart attempt, got attempt %d", updated.Status.Attempt)
 	}
 }
 

--- a/internal/controller/buildrun_support.go
+++ b/internal/controller/buildrun_support.go
@@ -354,13 +354,11 @@ func (r *AppReconciler) ensureAppBuildRun(ctx context.Context, app *mortisev1alp
 		}
 		return nil, err
 	}
-	if app.Annotations[rebuildRequestedAtAnnotation] != "" || app.Annotations[rebuildNoCacheRequestedAtAnnotation] != "" || app.Annotations["mortise.dev/no-cache-build"] != "" {
-		patch := client.MergeFrom(app.DeepCopy())
-		clearRebuildRequestMarkers(app)
-		if err := r.Patch(ctx, app, patch); err != nil && !errors.IsNotFound(err) {
-			return nil, err
-		}
-	}
+	// Rebuild request markers are deliberately NOT cleared here: the env loop
+	// reuses one *App across environments, so clearing after the first env's
+	// Create would make envs 2..N short-circuit and skip the rebuild. The
+	// caller clears the markers once after every env has consumed them
+	// (reconcileEnvBuild's shouldClearNoCache return).
 	return &run, nil
 }
 

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -18,7 +18,10 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 )
 
-func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
+// ensureAppBuildRun must NOT clear the rebuild markers itself: the env loop
+// shares one *App, so a mid-loop clear starves envs after the first (GH #436).
+// Markers are cleared once by the app controller after the env loop.
+func TestEnsureAppBuildRunCreatesRunAndPreservesRebuildMarkers(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add scheme: %v", err)
@@ -69,11 +72,17 @@ func TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers(t *testing.T) {
 	if len(run.OwnerReferences) != 1 || run.OwnerReferences[0].Kind != "App" || run.OwnerReferences[0].Name != app.Name {
 		t.Fatalf("expected buildrun owner App/%s, got %+v", app.Name, run.OwnerReferences)
 	}
-	if got := app.Annotations[rebuildRequestedAtAnnotation]; got != "" {
-		t.Fatalf("expected rebuild request marker cleared, got %q", got)
+	if run.Spec.RequestID != "req-1" {
+		t.Fatalf("expected run to carry rebuild request id, got %q", run.Spec.RequestID)
 	}
-	if got := app.Annotations[rebuildNoCacheRequestedAtAnnotation]; got != "" {
-		t.Fatalf("expected no-cache rebuild marker cleared, got %q", got)
+	if !run.Spec.NoCache {
+		t.Fatal("expected no-cache rebuild request to set NoCache on the run")
+	}
+	if got := app.Annotations[rebuildRequestedAtAnnotation]; got != "req-1" {
+		t.Fatalf("expected rebuild request marker preserved for later envs, got %q", got)
+	}
+	if got := app.Annotations[rebuildNoCacheRequestedAtAnnotation]; got != "req-2" {
+		t.Fatalf("expected no-cache rebuild marker preserved for later envs, got %q", got)
 	}
 }
 
@@ -636,7 +645,7 @@ func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -649,8 +658,112 @@ func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *t
 	if !statusDirty {
 		t.Fatal("expected manual rebuild to dirty status")
 	}
+	if !shouldClearNoCache {
+		t.Fatal("expected consumed rebuild request to arm shouldClearNoCache")
+	}
 	if app.Status.CurrentBuildRunName == "manual-run" {
 		t.Fatal("expected manual rebuild to replace the previous terminal run")
+	}
+}
+
+// Regression for GH #436: a rebuild request must reach every environment.
+// Under the old mid-loop marker clear, the first env's ensureAppBuildRun
+// cleared the app-wide annotations in place, so later envs short-circuited on
+// LastBuiltSHA and never rebuilt.
+func TestReconcileEnvBuildRebuildRequestReachesEveryEnv(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision":        "same-sha",
+				"mortise.dev/git-token-owner": "owner@example.com",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:        mortisev1alpha1.SourceTypeGit,
+				Repo:        "https://example.com/repo.git",
+				Branch:      "main",
+				ProviderRef: "github",
+			},
+		},
+	}
+
+	envs := []string{"production", "staging"}
+	objs := []client.Object{}
+	for _, env := range envs {
+		target := "registry.example.com/mortise/demo:same-sh-" + env
+		lastRun := &mortisev1alpha1.BuildRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      env + "-last-run",
+				Namespace: app.Namespace,
+			},
+			Spec: appBuildRunSpec(app, env, "main", "same-sha", target, target),
+			Status: mortisev1alpha1.BuildRunStatus{
+				Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+				Image: "registry.example.com/demo:" + env + "-old",
+			},
+		}
+		objs = append(objs, lastRun)
+		app.Status.Environments = append(app.Status.Environments, mortisev1alpha1.EnvironmentStatus{
+			Name:           env,
+			LastBuiltSHA:   "same-sha",
+			LastBuiltImage: lastRun.Status.Image,
+			LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{
+				Name:  lastRun.Name,
+				Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+			},
+		})
+	}
+
+	// Markers set AFTER computing the last runs' specs, so those runs match
+	// the marker-free spec each env would otherwise short-circuit against.
+	app.Annotations[rebuildRequestedAtAnnotation] = "req-1"
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(append(objs, app)...).Build()
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		RegistryBackend: &fakeRegistryBackend{},
+	}
+
+	for _, env := range envs {
+		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, env, "main", "same-sha")
+		if err != nil {
+			t.Fatalf("reconcileEnvBuild %s: %v", env, err)
+		}
+		if image != "" {
+			t.Fatalf("expected env %s to start a rebuild instead of reusing %q", env, image)
+		}
+		if !requeue {
+			t.Fatalf("expected env %s rebuild to requeue", env)
+		}
+		if !shouldClearNoCache {
+			t.Fatalf("expected env %s to arm the post-loop marker clear", env)
+		}
+	}
+
+	if got := app.Annotations[rebuildRequestedAtAnnotation]; got != "req-1" {
+		t.Fatalf("expected rebuild marker intact until the post-loop clear, got %q", got)
+	}
+
+	var runs mortisev1alpha1.BuildRunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(app.Namespace)); err != nil {
+		t.Fatalf("list buildruns: %v", err)
+	}
+	if len(runs.Items) != 4 {
+		t.Fatalf("expected a fresh rebuild run per env (4 total), got %d", len(runs.Items))
+	}
+	for _, env := range envs {
+		if name := currentBuildRunNameForEnv(app, env); name == "" || name == env+"-last-run" {
+			t.Fatalf("expected env %s to point at a fresh rebuild run, got %q", env, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two BuildRun reliability fixes (Lane B of the 2026-08-09 audit, bead mo-lnl).

### #434 — BuildRun tracker race

**Half A — delete-before-persist.** The terminal branch of `BuildRunReconciler.Reconcile` deleted the in-memory tracker *before* the fallible log ConfigMap and status writes. Any failure there left the BuildRun at phase Running with no tracker, so the next reconcile treated a *finished* build as lost — restarting a duplicate full rebuild, or at attempt 2 latching a bogus terminal `BuildInterrupted` failure on an already-succeeded build. Now:

- The log ConfigMap and terminal status are persisted first (status write wrapped in `RetryOnConflict` with a re-read, matching `projectTerminalBuildRunStatus`); the tracker is dropped only after everything durable has landed.
- `upsertConfigMap` retries on conflicts and lost create races — it read-modify-writes the legacy app-scoped log ConfigMap shared by all envs of an app, so these races are real.
- `handleLostBuildRunTracker` re-reads the BuildRun and leaves terminal ones alone before deciding to restart.
- `mergedBuildRunLogLines` gained a full-suffix dedup so the now-reachable persist retry doesn't duplicate log lines.

**Half B — NotFound leak.** Reconciling a deleted BuildRun (e.g. App deletion cascading mid-build) returned without touching the tracker, leaking the build goroutine and its log ring (up to 2MB) until the 30min build timeout. The NotFound branch now cancels and removes the tracker via a new atomic `BuildTrackerStore.cancelAndDelete` helper.

### #436 — rebuild markers consumed by first env only

`ensureAppBuildRun` cleared the app-wide rebuild annotations mid env-loop, right after the first successful Create. The env loop shares one `*App`, so envs 2..N saw empty markers and short-circuited (`buildRunSelectionHash` deliberately ignores Trigger/RequestID/NoCache, so same-SHA rebuilds always matched the previous run) — a requested rebuild/no-cache rebuild never reached later environments. Now:

- The mid-loop clear is removed; markers survive the whole loop, so every env creates its rebuild run.
- `reconcileEnvBuild`'s previously dead `shouldClearNoCache` return is armed on the paths that consumed a pending rebuild request; the existing post-loop clear hook in the app controller (previously dead code) now fires once after all envs have consumed the markers.
- Deliberate, documented, and tested edge case: a mid-loop error return leaves the markers in place, so the rebuild stays pending across reconciles instead of being half-applied. The marker-consumption code stays app-scoped in a shape a per-env scope (#455) can extend.

### Test changes

- **`TestEnsureAppBuildRunCreatesAndClearsRebuildMarkers` pinned the wrong behavior and was deliberately changed** to `TestEnsureAppBuildRunCreatesRunAndPreservesRebuildMarkers`: it now asserts the markers survive `ensureAppBuildRun` (and that the run carries RequestID/NoCache).
- New multi-env regression test `TestReconcileEnvBuildRebuildRequestReachesEveryEnv` — placed in `buildrun_support_test.go` beside the other `reconcileEnvBuild` unit tests (the audit suggested `app_controller_test.go`, but that file is the ginkgo/envtest suite; this follows the repo's copy-the-nearest-test convention).
- New `TestBuildRunTerminalStatusPersistsBeforeTrackerDelete` (injects a status-write failure, asserts the tracker survives for retry and logs persist exactly once), `TestBuildRunReconcileCancelsTrackerWhenBuildRunDeleted`, and `TestHandleLostTrackerDoesNotRestartTerminalBuildRun`.
- All six new/updated tests were verified to fail against the pre-fix code.

`make test` fully green locally (unit + envtest + chart/UI checks); `go vet ./...` clean.

Fixes #434
Fixes #436