### PR TITLE
fix: controller quick fixes — domain-collision recovery, env seed race, GC scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   env vars (e.g. `DB_PASS` from `pg.password`). Includes new
   `GET /binding-keys` API endpoint and BindingsPicker UI rewrite.
 
+### Changed
+
+- **Finalizer GC now requires the `app.kubernetes.io/managed-by=mortise`
+  label and is scoped to project-labelled namespaces**: resources created
+  before the appLabels era (or by anything else that reuses Mortise's
+  name/project label keys without the managed-by label) are no longer
+  deleted by App-deletion GC. Operators relying on GC to clean up
+  pre-appLabels leftovers must remove those by hand once.
+
 ### Fixed
 
 - **`valueFrom.secretRef` resolution**: Field existed on the CRD but the

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -16,6 +16,7 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/controller"
 )
 
 // maxProjectNameLen caps the Project name so env namespaces (`pj-{name}-{env}`)
@@ -183,6 +184,14 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request) {
 		},
 		Spec: mortisev1alpha1.ProjectSpec{
 			Description: req.Description,
+			// Seed the default env at create instead of leaving it to the
+			// controller: a client adding an env (e.g. the UI POSTing
+			// staging) between create and first reconcile would otherwise
+			// suppress the controller's seed and leave the project without
+			// a production env.
+			Environments: []mortisev1alpha1.ProjectEnvironment{
+				{Name: controller.DefaultProjectEnvironment},
+			},
 		},
 	}
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -16,7 +16,6 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/constants"
-	"github.com/mortise-org/mortise/internal/controller"
 )
 
 // maxProjectNameLen caps the Project name so env namespaces (`pj-{name}-{env}`)
@@ -190,7 +189,7 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request) {
 			// suppress the controller's seed and leave the project without
 			// a production env.
 			Environments: []mortisev1alpha1.ProjectEnvironment{
-				{Name: controller.DefaultProjectEnvironment},
+				{Name: constants.DefaultProjectEnvironment},
 			},
 		},
 	}

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -44,6 +44,13 @@ func TestCreateProjectAsAdmin(t *testing.T) {
 		t.Fatalf("project CRD not found after create: %v", err)
 	}
 
+	// The default env is seeded at create, not left to the controller — a
+	// client adding an env before the first reconcile must not end up with a
+	// project that never gets production.
+	if len(project.Spec.Environments) != 1 || project.Spec.Environments[0].Name != "production" {
+		t.Errorf("expected create to seed the production environment, got %+v", project.Spec.Environments)
+	}
+
 	var activityCM corev1.ConfigMap
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "pj-my-saas", Name: "activity-my-saas"}, &activityCM); !errors.IsNotFound(err) {
 		t.Fatalf("expected API create to leave project activity ConfigMap to the controller, got err=%v configmap=%+v", err, activityCM)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,6 +9,10 @@ import (
 )
 
 const (
+	// DefaultProjectEnvironment is seeded into spec.environments when the
+	// controller observes an empty list. Matches Railway's default.
+	DefaultProjectEnvironment = "production"
+
 	// ControlNamespacePrefix prefixes the Project control namespace: `pj-{name}`.
 	// The control namespace holds App CRDs, GitProvider webhook secrets scoped to
 	// the project, and other project-owned objects that aren't env-scoped.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -216,4 +216,10 @@ const (
 	// EnvironmentLabel is the name of the owning environment; stamped on env
 	// namespaces, preview namespaces, and every per-env resource.
 	EnvironmentLabel = "mortise.dev/environment"
+
+	// ManagedByLabel + ManagedByValue mark every resource Mortise creates.
+	// Selecting on them keeps cluster-wide operations (GC, collision checks)
+	// from touching look-alike resources owned by users or other operators.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "mortise"
 )

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -77,6 +77,11 @@ const buildTimeout = 30 * time.Minute
 // flight to check for completion.
 const buildPollInterval = 15 * time.Second
 
+// domainCollisionRequeueInterval is how often the reconciler re-queues while
+// an App is Failed on a domain collision. Nothing watches the foreign Ingress
+// that owns the contested host, so recovery has to poll for it going away.
+const domainCollisionRequeueInterval = time.Minute
+
 // AppReconciler reconciles a App object
 type AppReconciler struct {
 	client.Client
@@ -226,6 +231,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	needsRequeue := false
 	buildStatusDirty := false
 	clearNoCache := false
+	var domainCollisionErrs []string
 	projectionEnvOrder := make([]string, 0, len(resolvedEnvs))
 	for _, env := range resolvedEnvs {
 		projectionEnvOrder = append(projectionEnvOrder, env.Name)
@@ -309,21 +315,12 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, &app, env.Name, allHosts); err != nil {
-					if updateErr := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
-						status.Phase = mortisev1alpha1.AppPhaseFailed
-						meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-							Type:               "DomainCollision",
-							Status:             metav1.ConditionTrue,
-							Reason:             "DomainInUse",
-							Message:            err.Error(),
-							ObservedGeneration: app.Generation,
-						})
-					}); updateErr != nil {
-						log.Error(updateErr, "update status after domain collision")
-					}
-					return ctrl.Result{}, nil
-				}
-				if err := r.reconcileIngress(ctx, &app, env, envNs); err != nil {
+					// Defer the failure to after the loop: returning here would
+					// drop build status accumulated for earlier envs, skip
+					// opted-out-env GC, and block every remaining env on one
+					// contested domain. Only this env's Ingress is withheld.
+					domainCollisionErrs = append(domainCollisionErrs, err.Error())
+				} else if err := r.reconcileIngress(ctx, &app, env, envNs); err != nil {
 					return ctrl.Result{}, fmt.Errorf("reconcile ingress for env %s: %w", env.Name, err)
 				}
 			}
@@ -362,7 +359,40 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
+	if len(domainCollisionErrs) > 0 {
+		if err := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
+			status.Phase = mortisev1alpha1.AppPhaseFailed
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:               "DomainCollision",
+				Status:             metav1.ConditionTrue,
+				Reason:             "DomainInUse",
+				Message:            strings.Join(domainCollisionErrs, "; "),
+				ObservedGeneration: app.Generation,
+			})
+		}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update status after domain collision: %w", err)
+		}
+		if needsRequeue {
+			return ctrl.Result{RequeueAfter: buildPollInterval}, nil
+		}
+		return ctrl.Result{RequeueAfter: domainCollisionRequeueInterval}, nil
+	}
+
+	// A clean pass over every env means any recorded collision is stale —
+	// clear the condition and force a status refresh so the App can leave
+	// Failed (shouldRefreshFailedAppStatus only covers build failures).
+	domainCollisionCleared := false
+	if meta.FindStatusCondition(app.Status.Conditions, "DomainCollision") != nil {
+		if err := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
+			meta.RemoveStatusCondition(&status.Conditions, "DomainCollision")
+		}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("clear domain collision condition: %w", err)
+		}
+		domainCollisionCleared = true
+	}
+
 	if !needsRequeue && (app.Status.Phase != mortisev1alpha1.AppPhaseFailed ||
+		domainCollisionCleared ||
 		shouldRefreshFailedAppStatus(&app, resolvedEnvs, previewEnvNames)) {
 		if err := r.updateStatus(ctx, &app, resolvedEnvs, previewEnvNames); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update status: %w", err)
@@ -4031,7 +4061,6 @@ func toSecretVolumesAndMounts(mounts []mortisev1alpha1.SecretMount) ([]corev1.Vo
 // ExternalName Service + Ingress to expose the external host through Mortise's
 // domain/TLS setup.
 func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortisev1alpha1.App) (ctrl.Result, error) {
-	log := logf.FromContext(ctx)
 	if app.Spec.Source.External == nil {
 		if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
 			status.Phase = mortisev1alpha1.AppPhaseFailed
@@ -4056,6 +4085,7 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 		resolvedEnvs = resolveEnvs(project, app)
 	}
 
+	var domainCollisionErrs []string
 	for i := range resolvedEnvs {
 		env := &resolvedEnvs[i]
 		envNs, err := appEnvNs(app, env.Name)
@@ -4076,19 +4106,11 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 			if env.Domain != "" {
 				allHosts := append([]string{env.Domain}, env.CustomDomains...)
 				if err := r.checkDomainCollisions(ctx, app, env.Name, allHosts); err != nil {
-					if updateErr := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
-						status.Phase = mortisev1alpha1.AppPhaseFailed
-						meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-							Type:               "DomainCollision",
-							Status:             metav1.ConditionTrue,
-							Reason:             "DomainInUse",
-							Message:            err.Error(),
-							ObservedGeneration: app.Generation,
-						})
-					}); updateErr != nil {
-						log.Error(updateErr, "update status after domain collision")
-					}
-					return ctrl.Result{}, nil
+					// Defer the failure to after the loop so one contested
+					// domain doesn't block the remaining envs. Only this
+					// env's Service + Ingress are withheld.
+					domainCollisionErrs = append(domainCollisionErrs, err.Error())
+					continue
 				}
 				if err := r.reconcileExternalNameService(ctx, app, env, envNs); err != nil {
 					return ctrl.Result{}, fmt.Errorf("reconcile externalname service for env %s: %w", env.Name, err)
@@ -4100,9 +4122,27 @@ func (r *AppReconciler) reconcileExternalSource(ctx context.Context, app *mortis
 		}
 	}
 
-	// External apps are always Ready — there is no workload to wait for.
+	if len(domainCollisionErrs) > 0 {
+		if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+			status.Phase = mortisev1alpha1.AppPhaseFailed
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:               "DomainCollision",
+				Status:             metav1.ConditionTrue,
+				Reason:             "DomainInUse",
+				Message:            strings.Join(domainCollisionErrs, "; "),
+				ObservedGeneration: app.Generation,
+			})
+		}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update status after domain collision: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: domainCollisionRequeueInterval}, nil
+	}
+
+	// External apps are always Ready — there is no workload to wait for. A
+	// clean pass also clears any stale collision left by a previous reconcile.
 	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
 		status.Phase = mortisev1alpha1.AppPhaseReady
+		meta.RemoveStatusCondition(&status.Conditions, "DomainCollision")
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
 	}

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -2272,6 +2272,148 @@ var _ = Describe("App Controller", func() {
 		})
 	})
 
+	Context("domain collision recovery", func() {
+		ctx := context.Background()
+		const envNsStaging = "pj-default-project-staging"
+		const contestedDomain = "contested.example.com"
+
+		newPublicImageApp := func(name string, envs []mortisev1alpha1.Environment) *mortisev1alpha1.App {
+			return &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:  mortisev1alpha1.SourceTypeImage,
+						Image: testImageNginx,
+					},
+					Network:      mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: envs,
+				},
+			}
+		}
+
+		It("defers the failure, keeps other envs reconciling, and recovers when the domain frees up", func() {
+			withStagingEnv(ctx)
+			defer withoutStagingEnv(ctx)
+
+			owner := newPublicImageApp("collision-owner", []mortisev1alpha1.Environment{
+				{Name: "production", Domain: contestedDomain},
+			})
+			Expect(k8sClient.Create(ctx, owner)).To(Succeed())
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: owner.Name, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			var ownerIngress networkingv1.Ingress
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: owner.Name, Namespace: envNsProduction,
+			}, &ownerIngress)).To(Succeed())
+
+			victim := newPublicImageApp("collision-victim", []mortisev1alpha1.Environment{
+				{Name: "production", Domain: contestedDomain},
+				{Name: "staging", Domain: "collision-victim.example.com"},
+			})
+			Expect(k8sClient.Create(ctx, victim)).To(Succeed())
+
+			victimReq := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: victim.Name, Namespace: namespace},
+			}
+			result, err := reconciler.Reconcile(ctx, victimReq)
+			Expect(err).NotTo(HaveOccurred())
+			// Failed on a collision must requeue: nothing watches the foreign
+			// Ingress, so recovery depends on polling.
+			Expect(result.RequeueAfter).To(Equal(domainCollisionRequeueInterval))
+
+			var got mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, victimReq.NamespacedName, &got)).To(Succeed())
+			Expect(got.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseFailed))
+			cond := meta.FindStatusCondition(got.Status.Conditions, "DomainCollision")
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+			// Only the colliding env's Ingress is withheld — the workload for
+			// that env and the entire staging env still reconcile.
+			var ing networkingv1.Ingress
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: victim.Name, Namespace: envNsProduction}, &ing)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expected no production ingress for colliding app, got %v", err)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: victim.Name, Namespace: envNsStaging}, &ing)).To(Succeed())
+			var dep appsv1.Deployment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: victim.Name, Namespace: envNsProduction}, &dep)).To(Succeed())
+
+			// Free the domain and reconcile again: the condition clears and
+			// the App leaves Failed.
+			Expect(k8sClient.Delete(ctx, &ownerIngress)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, victimReq)
+			Expect(err).NotTo(HaveOccurred())
+
+			got = mortisev1alpha1.App{}
+			Expect(k8sClient.Get(ctx, victimReq.NamespacedName, &got)).To(Succeed())
+			Expect(meta.FindStatusCondition(got.Status.Conditions, "DomainCollision")).To(BeNil())
+			Expect(got.Status.Phase).NotTo(Equal(mortisev1alpha1.AppPhaseFailed))
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: victim.Name, Namespace: envNsProduction}, &ing)).To(Succeed())
+		})
+
+		It("recovers an external-source app from a domain collision", func() {
+			// Distinct domain from the previous test: purged apps leave their
+			// Ingresses behind (purge strips finalizers, so no GC runs), and a
+			// reused host would collide with that leftover.
+			const extContestedDomain = "ext-contested.example.com"
+			owner := newPublicImageApp("ext-collision-owner", []mortisev1alpha1.Environment{
+				{Name: "production", Domain: extContestedDomain},
+			})
+			Expect(k8sClient.Create(ctx, owner)).To(Succeed())
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: owner.Name, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			var ownerIngress networkingv1.Ingress
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: owner.Name, Namespace: envNsProduction,
+			}, &ownerIngress)).To(Succeed())
+
+			ext := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext-collision", Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{
+						Type:     mortisev1alpha1.SourceTypeExternal,
+						External: &mortisev1alpha1.ExternalSource{Host: "db.internal", Port: 5432},
+					},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{
+						{Name: "production", Domain: extContestedDomain},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ext)).To(Succeed())
+
+			extReq := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: ext.Name, Namespace: namespace},
+			}
+			result, err := reconciler.Reconcile(ctx, extReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(domainCollisionRequeueInterval))
+
+			var got mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, extReq.NamespacedName, &got)).To(Succeed())
+			Expect(got.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseFailed))
+			Expect(meta.FindStatusCondition(got.Status.Conditions, "DomainCollision")).NotTo(BeNil())
+
+			Expect(k8sClient.Delete(ctx, &ownerIngress)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, extReq)
+			Expect(err).NotTo(HaveOccurred())
+
+			got = mortisev1alpha1.App{}
+			Expect(k8sClient.Get(ctx, extReq.NamespacedName, &got)).To(Succeed())
+			Expect(meta.FindStatusCondition(got.Status.Conditions, "DomainCollision")).To(BeNil())
+			Expect(got.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseReady))
+			var ing networkingv1.Ingress
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ext.Name, Namespace: envNsProduction}, &ing)).To(Succeed())
+		})
+	})
+
 	Context("ExternalDNS annotation on Ingress", func() {
 		const appName = "test-externaldns"
 		ctx := context.Background()

--- a/internal/controller/app_env_gc.go
+++ b/internal/controller/app_env_gc.go
@@ -35,8 +35,11 @@ import (
 // via k8s GC on their respective owner deletes.
 //
 // Selection is by `app.kubernetes.io/name=<app>` + `mortise.dev/project=<proj>`
-// — that excludes look-alikes from other projects or foreign operators even
-// if someone reuses our label key.
+// + `app.kubernetes.io/managed-by=mortise`, restricted to namespaces the
+// project owns (labelled `mortise.dev/project=<proj>` by the Project and
+// PreviewEnvironment controllers). Both scopes matter: a cluster-wide list
+// with only the name+project labels would delete look-alike resources from
+// foreign operators or users who happen to reuse our label keys.
 func (r *AppReconciler) gcAppAcrossEnvs(ctx context.Context, app *mortisev1alpha1.App) error {
 	projectName, err := appProjectName(app)
 	if err != nil {
@@ -46,38 +49,48 @@ func (r *AppReconciler) gcAppAcrossEnvs(ctx context.Context, app *mortisev1alpha
 		// every App delete on a mal-formed namespace.
 		return nil
 	}
-	selector := client.MatchingLabels{
-		constants.AppNameLabel: app.Name,
+	var namespaces corev1.NamespaceList
+	if err := r.List(ctx, &namespaces, client.MatchingLabels{
 		constants.ProjectLabel: projectName,
+	}); err != nil {
+		return fmt.Errorf("list project namespaces: %w", err)
+	}
+	selector := client.MatchingLabels{
+		constants.AppNameLabel:   app.Name,
+		constants.ProjectLabel:   projectName,
+		constants.ManagedByLabel: constants.ManagedByValue,
 	}
 	tokenSelector := client.MatchingLabels{
 		"mortise.dev/deploy-token": "true",
 		"mortise.dev/app":          app.Name,
 	}
 
-	if err := r.deleteMatching(ctx, &appsv1.DeploymentList{}, selector); err != nil {
-		return fmt.Errorf("gc deployments: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &batchv1.CronJobList{}, selector); err != nil {
-		return fmt.Errorf("gc cronjobs: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &corev1.ServiceList{}, selector); err != nil {
-		return fmt.Errorf("gc services: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &networkingv1.IngressList{}, selector); err != nil {
-		return fmt.Errorf("gc ingresses: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &corev1.ConfigMapList{}, selector); err != nil {
-		return fmt.Errorf("gc configmaps: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &corev1.SecretList{}, selector); err != nil {
-		return fmt.Errorf("gc secrets: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &corev1.ServiceAccountList{}, selector); err != nil {
-		return fmt.Errorf("gc serviceaccounts: %w", err)
-	}
-	if err := r.deleteMatching(ctx, &corev1.PersistentVolumeClaimList{}, selector); err != nil {
-		return fmt.Errorf("gc pvcs: %w", err)
+	for i := range namespaces.Items {
+		inNs := client.InNamespace(namespaces.Items[i].Name)
+		if err := r.deleteMatching(ctx, &appsv1.DeploymentList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc deployments: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &batchv1.CronJobList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc cronjobs: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &corev1.ServiceList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc services: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &networkingv1.IngressList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc ingresses: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &corev1.ConfigMapList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc configmaps: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &corev1.SecretList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc secrets: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &corev1.ServiceAccountList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc serviceaccounts: %w", err)
+		}
+		if err := r.deleteMatching(ctx, &corev1.PersistentVolumeClaimList{}, selector, inNs); err != nil {
+			return fmt.Errorf("gc pvcs: %w", err)
+		}
 	}
 	if err := r.deleteMatching(ctx, &corev1.SecretList{}, tokenSelector, client.InNamespace(app.Namespace)); err != nil {
 		return fmt.Errorf("gc app deploy tokens: %w", err)
@@ -103,8 +116,9 @@ func (r *AppReconciler) gcOptedOutEnvs(ctx context.Context, app *mortisev1alpha1
 		}
 		envNs := constants.EnvNamespace(projectName, projEnv.Name)
 		selector := client.MatchingLabels{
-			constants.AppNameLabel: app.Name,
-			constants.ProjectLabel: projectName,
+			constants.AppNameLabel:   app.Name,
+			constants.ProjectLabel:   projectName,
+			constants.ManagedByLabel: constants.ManagedByValue,
 		}
 		inNs := client.InNamespace(envNs)
 		if err := r.deleteMatching(ctx, &appsv1.DeploymentList{}, selector, inNs); err != nil {

--- a/internal/controller/app_env_gc_test.go
+++ b/internal/controller/app_env_gc_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+func gcTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		mortisev1alpha1.AddToScheme,
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		batchv1.AddToScheme,
+		networkingv1.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+	return scheme
+}
+
+func gcTestConfigMap(name, namespace string, labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+	}
+}
+
+func gcTestNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+// TestGCAppAcrossEnvsScoping verifies finalizer GC only deletes resources that
+// carry the full Mortise ownership label set AND live in a namespace the
+// project owns. Look-alike resources labelled by users or foreign operators —
+// or living in foreign namespaces — must survive.
+func TestGCAppAcrossEnvsScoping(t *testing.T) {
+	scheme := gcTestScheme(t)
+
+	appLabelSet := map[string]string{
+		constants.AppNameLabel:   "web",
+		constants.ProjectLabel:   "demo",
+		constants.ManagedByLabel: constants.ManagedByValue,
+	}
+	unmanagedLabelSet := map[string]string{
+		constants.AppNameLabel: "web",
+		constants.ProjectLabel: "demo",
+	}
+
+	owned := gcTestConfigMap("owned", "pj-demo-production", appLabelSet)
+	unmanaged := gcTestConfigMap("unmanaged", "pj-demo-production", unmanagedLabelSet)
+	foreignNs := gcTestConfigMap("foreign-ns", "other-team", appLabelSet)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		gcTestNamespace("pj-demo", map[string]string{constants.ProjectLabel: "demo"}),
+		gcTestNamespace("pj-demo-production", map[string]string{constants.ProjectLabel: "demo"}),
+		gcTestNamespace("other-team", nil),
+		owned, unmanaged, foreignNs,
+	).Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "pj-demo"},
+	}
+	if err := r.gcAppAcrossEnvs(context.Background(), app); err != nil {
+		t.Fatalf("gcAppAcrossEnvs: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Name: "owned", Namespace: "pj-demo-production"}, &cm)
+	if !kerrors.IsNotFound(err) {
+		t.Errorf("expected fully-labelled configmap in project namespace to be deleted, got err=%v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "unmanaged", Namespace: "pj-demo-production"}, &cm); err != nil {
+		t.Errorf("expected configmap without managed-by label to survive, got err=%v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "foreign-ns", Namespace: "other-team"}, &cm); err != nil {
+		t.Errorf("expected configmap in non-project namespace to survive, got err=%v", err)
+	}
+}
+
+// TestGCOptedOutEnvsRequiresManagedByLabel verifies opt-out GC skips resources
+// that match the app+project labels but were not created by Mortise.
+func TestGCOptedOutEnvsRequiresManagedByLabel(t *testing.T) {
+	scheme := gcTestScheme(t)
+
+	owned := gcTestConfigMap("owned", "pj-demo-staging", map[string]string{
+		constants.AppNameLabel:   "web",
+		constants.ProjectLabel:   "demo",
+		constants.ManagedByLabel: constants.ManagedByValue,
+	})
+	unmanaged := gcTestConfigMap("unmanaged", "pj-demo-staging", map[string]string{
+		constants.AppNameLabel: "web",
+		constants.ProjectLabel: "demo",
+	})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owned, unmanaged).Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "pj-demo"},
+	}
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{
+				{Name: "production"},
+				{Name: "staging"},
+			},
+		},
+	}
+	// App resolves only production → staging is opted out and gets GC'd.
+	resolved := []mortisev1alpha1.Environment{{Name: "production"}}
+
+	if err := r.gcOptedOutEnvs(context.Background(), app, project, resolved); err != nil {
+		t.Fatalf("gcOptedOutEnvs: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Name: "owned", Namespace: "pj-demo-staging"}, &cm)
+	if !kerrors.IsNotFound(err) {
+		t.Errorf("expected Mortise-managed configmap in opted-out env to be deleted, got err=%v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "unmanaged", Namespace: "pj-demo-staging"}, &cm); err != nil {
+		t.Errorf("expected configmap without managed-by label to survive opt-out GC, got err=%v", err)
+	}
+}

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -47,10 +47,6 @@ const (
 	// projectFinalizer ensures the controller gets one last reconcile on delete
 	// so it can tear down owned namespaces before the CRD disappears.
 	projectFinalizer = "mortise.dev/project-finalizer"
-
-	// DefaultProjectEnvironment is seeded into spec.environments when the
-	// controller observes an empty list. Matches Railway's default.
-	DefaultProjectEnvironment = "production"
 )
 
 // Condition types and reasons exposed on Project.status.conditions.
@@ -173,7 +169,7 @@ func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	if !hasNonPreviewEnv {
 		project.Spec.Environments = append(project.Spec.Environments,
-			mortisev1alpha1.ProjectEnvironment{Name: DefaultProjectEnvironment})
+			mortisev1alpha1.ProjectEnvironment{Name: constants.DefaultProjectEnvironment})
 		specChanged = true
 	}
 	if specChanged {

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -158,12 +158,22 @@ func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	// Seed finalizer + default env in one spec-update pass.
+	// Seed finalizer + default env in one spec-update pass. This seed must
+	// stay even though the API also seeds production at create — it covers
+	// kubectl-created Projects. The guard is "no non-preview env present",
+	// not "no envs at all": preview envs written before the first reconcile
+	// don't count as a usable default and must not suppress the seed.
 	specChanged := controllerutil.AddFinalizer(&project, projectFinalizer)
-	if len(project.Spec.Environments) == 0 {
-		project.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{
-			{Name: DefaultProjectEnvironment},
+	hasNonPreviewEnv := false
+	for _, env := range project.Spec.Environments {
+		if !env.Preview {
+			hasNonPreviewEnv = true
+			break
 		}
+	}
+	if !hasNonPreviewEnv {
+		project.Spec.Environments = append(project.Spec.Environments,
+			mortisev1alpha1.ProjectEnvironment{Name: DefaultProjectEnvironment})
 		specChanged = true
 	}
 	if specChanged {

--- a/internal/controller/project_controller_test.go
+++ b/internal/controller/project_controller_test.go
@@ -83,6 +83,72 @@ var _ = Describe("Project Controller", func() {
 		})
 	})
 
+	Context("default environment seeding", func() {
+		const projectName = "env-seeding"
+		nsName := ProjectNamespace(projectName)
+
+		AfterEach(func() {
+			proj := &mortisev1alpha1.Project{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, proj); err == nil {
+				proj.Finalizers = nil
+				_ = k8sClient.Update(ctx, proj)
+				_ = k8sClient.Delete(ctx, proj)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}})
+		})
+
+		reconcileOnce := func() {
+			r := &ProjectReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), OperatorNamespace: "mortise-system", ServiceAccountName: "mortise-controller"}
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		envNames := func() []string {
+			var proj mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: projectName}, &proj)).To(Succeed())
+			names := make([]string, 0, len(proj.Spec.Environments))
+			for _, e := range proj.Spec.Environments {
+				names = append(names, e.Name)
+			}
+			return names
+		}
+
+		It("seeds production when the environment list is empty", func() {
+			project := &mortisev1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: projectName}}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+			reconcileOnce()
+			Expect(envNames()).To(Equal([]string{DefaultProjectEnvironment}))
+		})
+
+		It("seeds production when only preview environments exist", func() {
+			project := &mortisev1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: projectName},
+				Spec: mortisev1alpha1.ProjectSpec{
+					Environments: []mortisev1alpha1.ProjectEnvironment{
+						{Name: "preview-pr-7", Preview: true},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+			reconcileOnce()
+			Expect(envNames()).To(Equal([]string{"preview-pr-7", DefaultProjectEnvironment}))
+		})
+
+		It("does not seed production when a non-preview environment exists", func() {
+			project := &mortisev1alpha1.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: projectName},
+				Spec: mortisev1alpha1.ProjectSpec{
+					Environments: []mortisev1alpha1.ProjectEnvironment{
+						{Name: "staging"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, project)).To(Succeed())
+			reconcileOnce()
+			Expect(envNames()).To(Equal([]string{"staging"}))
+		})
+	})
+
 	Context("project create activity backfill", func() {
 		const projectName = "activity-backfill"
 

--- a/internal/controller/project_controller_test.go
+++ b/internal/controller/project_controller_test.go
@@ -32,6 +32,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/activity"
+	"github.com/mortise-org/mortise/internal/constants"
 )
 
 var _ = Describe("Project Controller", func() {
@@ -117,7 +118,7 @@ var _ = Describe("Project Controller", func() {
 			project := &mortisev1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: projectName}}
 			Expect(k8sClient.Create(ctx, project)).To(Succeed())
 			reconcileOnce()
-			Expect(envNames()).To(Equal([]string{DefaultProjectEnvironment}))
+			Expect(envNames()).To(Equal([]string{constants.DefaultProjectEnvironment}))
 		})
 
 		It("seeds production when only preview environments exist", func() {
@@ -131,7 +132,7 @@ var _ = Describe("Project Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, project)).To(Succeed())
 			reconcileOnce()
-			Expect(envNames()).To(Equal([]string{"preview-pr-7", DefaultProjectEnvironment}))
+			Expect(envNames()).To(Equal([]string{"preview-pr-7", constants.DefaultProjectEnvironment}))
 		})
 
 		It("does not seed production when a non-preview environment exists", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -165,6 +165,9 @@ func ensureNamespace(ctx context.Context, name string) {
 	}
 	ns = corev1.Namespace{}
 	ns.Name = name
+	// Mirror the project label the Project controller stamps on every
+	// namespace it owns — cross-namespace finalizer GC scopes by it.
+	ns.Labels = map[string]string{"mortise.dev/project": "default-project"}
 	Expect(k8sClient.Create(ctx, &ns)).To(Succeed())
 }
 

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/mortise-org/mortise/internal/constants"
 )
 
 const (
@@ -38,8 +40,8 @@ const (
 	SharedVarsSourceName = "shared-vars"
 
 	// ManagedByLabel marks Secrets owned by Mortise.
-	ManagedByLabel = "app.kubernetes.io/managed-by"
-	ManagedByValue = "mortise"
+	ManagedByLabel = constants.ManagedByLabel
+	ManagedByValue = constants.ManagedByValue
 
 	// Source annotations — comma-separated key lists tracking origin of each var.
 	AnnotationBindingKeys   = "mortise.dev/binding-keys"


### PR DESCRIPTION
Three controller quick fixes (Lane A of the 2026-08-09 audit, bead mo-paz).

## Domain-collision recovery (#438)

A domain collision previously returned `ctrl.Result{}, nil` mid-env-loop with `Phase: Failed`, which had four bad effects: no requeue (an app stuck in Failed forever, since nothing watches the foreign Ingress that owns the host), the `DomainCollision` condition was never cleared even after the domain freed up, build status accumulated for earlier envs was dropped before the batched flush, and every remaining env plus opted-out-env GC was skipped.

Now the collision is recorded and deferred past the loop: only the colliding env's Ingress is withheld, other envs reconcile normally, the App goes `Failed` with the aggregated condition **and requeues** (1m; build polling interval wins when a build is in flight). On the next clean pass the condition is removed and a status refresh lets the App leave `Failed`. The external-source path gets the same treatment.

## Env seed race (#281 residual)

`CreateProject` created a Project with no environments and left seeding `production` to the controller, whose guard was `len(envs) == 0`. A client adding an env between create and first reconcile (the UI POSTs `staging` right after create, error swallowed) suppressed the seed forever — the project never got `production`.

Both halves per the audit: the API now seeds `production` at create, and the controller guard becomes "no non-preview env present" (kept as a backstop for kubectl-created Projects; preview envs alone no longer suppress it).

## Finalizer GC scoping (#437, GC half)

`gcAppAcrossEnvs` listed eight resource kinds **cluster-wide** selecting only on `app.kubernetes.io/name` + `mortise.dev/project` — a user or foreign operator reusing those label keys would have their resources deleted on App delete. The GC now additionally requires `app.kubernetes.io/managed-by: mortise` (stamped by `appLabels` on everything Mortise creates) and only sweeps namespaces labelled as owned by the project (control + env + preview, the same label `deleteOwnedNamespaces` already scopes by). `gcOptedOutEnvs` gains the same managed-by guard. The managed-by pair moves to a shared `constants.ManagedByLabel`/`ManagedByValue`; `envstore` aliases it.

The adoption-guard half of #437 is deliberately not here — it collides with #411 and is tracked as phase 2.

## Tests

- envtest: collision defers, other envs keep reconciling, requeue interval returned, recovery clears the condition and phase (main + external-source paths)
- envtest: default-env seeding (empty, preview-only, non-preview-present) and API create seeding
- fake-client: GC deletes fully-labelled resources in project namespaces; skips unmanaged look-alikes and foreign namespaces (both GC entry points)
- test harness: suite namespaces now carry the project label the scoped GC selects on

`make test` fully green locally.

Fixes #438
Fixes #281
Part of #437 (GC scoping half only; adoption guards tracked on the issue)