### PR TITLE
ci: pin lint tools, unify helm --wait budgets, fix k3d import on containerd store

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -8,4 +8,4 @@ plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
-    version: latest
+    version: v0.10.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,13 @@ jobs:
         run: go vet ./...
 
       - name: staticcheck
-        uses: dominikh/staticcheck-action@v1
-        with:
-          version: "v0.7.0"
+        # Direct pinned install instead of dominikh/staticcheck-action: the
+        # action's internal cache collides with setup-go's cache:true
+        # (deterministic 'File exists' tar errors on restore), and setup-go's
+        # module cache already covers the install.
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+          staticcheck ./...
 
   ui:
     name: UI typecheck + build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1
         with:
-          version: latest
+          version: "v0.7.0"
 
   ui:
     name: UI typecheck + build
@@ -152,7 +152,14 @@ jobs:
       - name: Install k3d
         run: |
           curl -fsSL -o /usr/local/bin/k3d "https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64"
+          echo "dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e  /usr/local/bin/k3d" | sha256sum --check
           chmod +x /usr/local/bin/k3d
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('ui/package-lock.json') }}
 
       - name: Start dev cluster
         run: make dev-up

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,11 @@ DEV_IMG ?= mortise:dev
 DEV_OBSERVER_IMG ?= mortise-observer:dev
 GITHUB_CLIENT_ID ?= Ov23lizLTd25E32VrWwl
 K3D_RUNTIME_ULIMIT ?= nofile=1048576:1048576
-DEV_HELM_TIMEOUT ?= 300s
+# Single budget for every helm --wait in this repo (#443): hosted CI runners
+# pull traefik/cert-manager/metrics-server images cold, and 180-300s budgets
+# have expired in real runs.
+HELM_WAIT_TIMEOUT ?= 600s
+DEV_HELM_TIMEOUT ?= $(HELM_WAIT_TIMEOUT)
 DEV_PORT_FORWARD_LOG ?= /tmp/$(DEV_CLUSTER)-port-forward.log
 DEV_PORT_FORWARD_READY_URL ?= http://localhost:8090/api/auth/status
 
@@ -232,6 +236,11 @@ dev-reset: ## Tear down dev cluster completely, rebuild, and start fresh
 INT_CLUSTER ?= mortise-int
 INT_IMG ?= mortise:int
 INT_OBSERVER_IMG ?= mortise-observer:int
+# Test fixtures plus the umbrella chart's dependency images (traefik,
+# metrics-server — versions from the packaged subcharts; cert-manager is
+# disabled in the integration install). Pre-importing the chart deps keeps
+# cold-registry pulls out of the helm --wait budget.
+INT_DEP_IMAGES ?= nginx:1.27 postgres:16 redis:7 busybox:1.37 alpine:3.20 docker.io/traefik:v3.3.3 registry.k8s.io/metrics-server/metrics-server:v0.7.2
 
 .PHONY: test-integration
 test-integration: ## Create k3d cluster, install chart + test deps, run integration tests, tear down
@@ -245,13 +254,24 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	$(CONTAINER_TOOL) build --target operator -t $(INT_IMG) .
 	$(CONTAINER_TOOL) build --target observer -t $(INT_OBSERVER_IMG) .
 	@echo "==> Pre-pulling test images..."
-	$(CONTAINER_TOOL) pull nginx:1.27
-	$(CONTAINER_TOOL) pull postgres:16
-	$(CONTAINER_TOOL) pull redis:7
-	$(CONTAINER_TOOL) pull busybox:1.37
-	$(CONTAINER_TOOL) pull alpine:3.20
+	for img in $(INT_DEP_IMAGES); do $(CONTAINER_TOOL) pull $$img || exit 1; done
 	@echo "==> Loading images into k3d..."
-	k3d image import $(INT_IMG) $(INT_OBSERVER_IMG) nginx:1.27 postgres:16 redis:7 busybox:1.37 alpine:3.20 -c $(INT_CLUSTER)
+	# With Docker's containerd image store (default on fresh Docker 28+
+	# installs), `docker save` of a pulled multi-arch image emits a tarball
+	# referencing blobs it does not contain, the node-side ctr import fails
+	# with "content digest not found" — and k3d still reports success and
+	# exits 0, so the failure only surfaces later as helm --wait timing out
+	# on ErrImageNeverPull pods (mo-29g). Import per-image with an explicit
+	# platform there; keep the plain k3d import on the legacy store.
+	@if $(CONTAINER_TOOL) info -f '{{json .DriverStatus}}' | grep -q io.containerd.snapshotter; then \
+		echo "containerd image store detected: importing per-image via ctr"; \
+		for img in $(INT_IMG) $(INT_OBSERVER_IMG) $(INT_DEP_IMAGES); do \
+			echo "importing $$img"; \
+			$(CONTAINER_TOOL) save --platform linux/amd64 $$img | docker exec -i k3d-$(INT_CLUSTER)-server-0 ctr -n k8s.io images import - || exit 1; \
+		done; \
+	else \
+		k3d image import $(INT_IMG) $(INT_OBSERVER_IMG) $(INT_DEP_IMAGES) -c $(INT_CLUSTER); \
+	fi
 	@echo "==> Installing CRDs..."
 	kubectl apply -f charts/mortise-core/crds/
 	@echo "==> Waiting for CRDs to be established..."
@@ -285,7 +305,7 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 		--set platformConfig.enabled=false \
 		--set cert-manager.enabled=false \
 		--set metrics-server.args='{--kubelet-insecure-tls}' \
-		--wait --timeout 180s
+		--wait --timeout $(HELM_WAIT_TIMEOUT)
 	@echo "==> Running integration tests..."
 	go test -v -parallel 25 -tags integration -count=1 -timeout 45m ./test/integration/... || \
 		{ echo "==> Tests failed; leaving cluster for diagnostics (run: k3d cluster delete $(INT_CLUSTER))"; exit 1; }
@@ -378,7 +398,7 @@ E2E_PASSWORD ?= admin123
 .PHONY: test-e2e
 test-e2e: ## Run Playwright E2E suite against the dev cluster (requires make dev-up).
 	@kubectl --context $(DEV_KUBE_CONTEXT) -n mortise-system rollout status deployment/mortise --timeout=30s
-	@cd ui && npm install --silent && npx playwright install chromium
+	@cd ui && npm ci --silent && npx playwright install chromium
 	@kubectl --context $(DEV_KUBE_CONTEXT) port-forward -n mortise-system svc/mortise $(E2E_PORT):80 >/dev/null 2>&1 & PF_PID=$$!; \
 	trap "kill $$PF_PID 2>/dev/null || true" EXIT; \
 	echo "==> Waiting for API at http://localhost:$(E2E_PORT)..."; \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 # Configuration
 # ---------------------------------------------------------------------------
 HELM_VERSION="${HELM_VERSION:-v3.17.3}"
+# Single helm --wait budget, matching HELM_WAIT_TIMEOUT in the Makefile (#443).
+HELM_WAIT_TIMEOUT="${HELM_WAIT_TIMEOUT:-600s}"
 MORTISE_CHART_REPO="${MORTISE_CHART_REPO:-https://mortise-org.github.io/mortise}"
 MORTISE_CHART_VERSION="${MORTISE_CHART_VERSION:-}"
 MORTISE_NAMESPACE="mortise-system"
@@ -254,7 +256,7 @@ install_mortise() {
         $traefik_flag \
         $storage_flags \
         $dev_image_flags \
-        --wait --timeout 300s \
+        --wait --timeout "$HELM_WAIT_TIMEOUT" \
         $chart_version_flag
 
     info "Mortise installed"

--- a/test/chart/run.sh
+++ b/test/chart/run.sh
@@ -23,6 +23,8 @@ NAMESPACE="mortise-system"
 DEPS_NAMESPACE="mortise-deps"
 CHART_IMG="mortise:chart-test"
 K3D_RUNTIME_ULIMIT="${K3D_RUNTIME_ULIMIT:-nofile=1048576:1048576}"
+# Single helm --wait budget, matching HELM_WAIT_TIMEOUT in the Makefile (#443).
+HELM_WAIT_TIMEOUT="${HELM_WAIT_TIMEOUT:-600s}"
 
 passed=0
 failed=0
@@ -88,7 +90,7 @@ helm upgrade --install mortise "${REPO_ROOT}/charts/mortise" \
     --set mortise-core.image.tag=chart-test \
     --set mortise-core.image.pullPolicy=Never \
     --set platformConfig.domain=test.mortise.local \
-    --wait --timeout 300s 2>&1 || { fail "Umbrella chart install"; fatal "Cannot continue without chart installed"; }
+    --wait --timeout "$HELM_WAIT_TIMEOUT" 2>&1 || { fail "Umbrella chart install"; fatal "Cannot continue without chart installed"; }
 
 # Verify each component deployment exists and is available.
 components_ok=true
@@ -231,7 +233,7 @@ helm upgrade mortise "${REPO_ROOT}/charts/mortise" \
     --set mortise-core.image.pullPolicy=Never \
     --set platformConfig.domain=test.mortise.local \
     --set buildkit.enabled=false \
-    --wait --timeout 180s 2>&1 || { fail "Condition toggle upgrade"; }
+    --wait --timeout "$HELM_WAIT_TIMEOUT" 2>&1 || { fail "Condition toggle upgrade"; }
 
 sleep 5
 buildkit_exists=$(kubectl get deployment -n "$DEPS_NAMESPACE" buildkitd --no-headers 2>/dev/null | wc -l || true)
@@ -248,7 +250,7 @@ helm upgrade mortise "${REPO_ROOT}/charts/mortise" \
     --set mortise-core.image.tag=chart-test \
     --set mortise-core.image.pullPolicy=Never \
     --set platformConfig.domain=test.mortise.local \
-    --wait --timeout 180s 2>&1 || { fail "Re-enable upgrade"; }
+    --wait --timeout "$HELM_WAIT_TIMEOUT" 2>&1 || { fail "Re-enable upgrade"; }
 
 # ── Test 4: mortise-core standalone ─────────────────────────────────────
 
@@ -264,7 +266,7 @@ helm upgrade --install mortise-core "${REPO_ROOT}/charts/mortise-core" \
     --set image.repository=mortise \
     --set image.tag=chart-test \
     --set image.pullPolicy=Never \
-    --wait --timeout 180s 2>&1 || { fail "mortise-core standalone install"; }
+    --wait --timeout "$HELM_WAIT_TIMEOUT" 2>&1 || { fail "mortise-core standalone install"; }
 
 if wait_for_deployment "$NAMESPACE" "mortise" 60; then
     pass "mortise-core standalone — operator runs without infrastructure"


### PR DESCRIPTION
## Summary

CI-hygiene batch from the 2026-08-09 audit (#443 items 2–5) plus the k3d containerd-store import fix (tracker bead mo-29g).

- **Pin lint tools + drop staticcheck-action**: the lint job now runs `go install honnef.co/go/tools/cmd/staticcheck@v0.7.0 && staticcheck ./...` directly — pinning what `latest` resolved to in the last green run AND removing the action whose internal cache collides with setup-go's (the deterministic 43k-tar-error failure that hit #456 twice). The `sigs.k8s.io/logtools` golangci plugin is pinned `latest` → `v0.10.1`. A new upstream release can no longer break CI with no code change.
- **Unify helm `--wait` budgets**: one 600s constant — `HELM_WAIT_TIMEOUT` in the Makefile (dev + integration installs), mirrored in `test/chart/run.sh` (4 sites) and `scripts/install.sh`. Replaces the scattered 180s/300s values; a real dev-up run has expired at exactly 301s while pulling dep images cold.
- **Pre-import chart-dependency images**: traefik `v3.3.3` and metrics-server `v0.7.2` (versions from the packaged subcharts) join the fixture images in the k3d import list, keeping cold-registry pulls out of the `--wait` window.
- **k3d checksum drift**: the ui-e2e job now verifies the same sha256 the integration job already checks.
- **Install drift**: `make test-e2e` uses `npm ci` (was `npm install`); Playwright browsers cached keyed on `ui/package-lock.json`.
- **containerd-store import fix (mo-29g)**: with Docker's containerd image store (default on fresh Docker 28+), `docker save` of pulled multi-arch images emits tarballs referencing blobs they don't contain; the node-side `ctr import` fails — and k3d logs the ERRO but still exits 0, so the failure only surfaces later as `helm --wait` timing out on `ErrImageNeverPull` pods. The Makefile now detects the store via `docker info` and imports per-image with `docker save --platform linux/amd64 | ctr -n k8s.io images import -`; the legacy store (GitHub runners) keeps the plain `k3d image import` path.

**Deliberately excluded**: #443 item 1 (golangci-lint is never run in CI) — unknown first-run backlog; tracked separately as bead mo-6eh.

## Verification

- `make test` green (unit + envtest + svelte-check)
- `make test-charts` green
- `make test-integration` green end-to-end on a containerd-store Docker 29.1.3 host — 53/53, with the per-image import path exercised (previously this host could not run the suite at all)

Fixes #443

## Coordination notes

- Owns `ci.yml`, `Makefile`, `test/chart/run.sh`, `.custom-gcl.yml` per lane F; #433's CI diagnostics blocks untouched.
- `run.sh` timeout is a single `HELM_WAIT_TIMEOUT` env-overridable constant for the future #446 publish-drift lane to reuse.
