### PR TITLE
fix(api): gate device-flow provider creation and validate GitProvider host (SSRF)

### DIFF
--- a/internal/api/device_flow.go
+++ b/internal/api/device_flow.go
@@ -5,6 +5,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -22,7 +23,18 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/authz"
 	"github.com/mortise-org/mortise/internal/git"
+)
+
+// Sentinel errors returned by getOrCreateGitProvider so handlers can map the
+// on-demand creation failure modes to the right HTTP status.
+var (
+	// errProviderCreateForbidden means the caller lacks permission to create a
+	// GitProvider on-demand (creation is admin-only, matching CreateGitProvider).
+	errProviderCreateForbidden = errors.New("creating a git provider requires admin privileges")
+	// errProviderHostInvalid means the caller-supplied host failed validation.
+	errProviderHostInvalid = errors.New("invalid git provider host")
 )
 
 const (
@@ -37,6 +49,7 @@ type DeviceFlowHandler struct {
 	client     client.Client
 	clientset  kubernetes.Interface
 	httpClient HTTPClient
+	authz      authz.PolicyEngine
 }
 
 // HTTPClient abstracts HTTP requests for testability.
@@ -44,8 +57,8 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func newDeviceFlowHandler(c client.Client, cs kubernetes.Interface) *DeviceFlowHandler {
-	return &DeviceFlowHandler{client: c, clientset: cs, httpClient: http.DefaultClient}
+func newDeviceFlowHandler(c client.Client, cs kubernetes.Interface, policy authz.PolicyEngine) *DeviceFlowHandler {
+	return &DeviceFlowHandler{client: c, clientset: cs, httpClient: http.DefaultClient, authz: policy}
 }
 
 // deviceCodeResponse is the JSON body returned from the device code request.
@@ -103,7 +116,7 @@ func (d *DeviceFlowHandler) RequestCode(w http.ResponseWriter, r *http.Request) 
 	gp, err := d.getOrCreateGitProvider(r.Context(), providerName, providerType, defaultHost)
 	if err != nil {
 		log.Error(err, "get git provider", "provider", providerName)
-		writeJSON(w, http.StatusNotFound, errorResponse{err.Error()})
+		writeGetOrCreateProviderError(w, providerName, err)
 		return
 	}
 
@@ -197,7 +210,7 @@ func (d *DeviceFlowHandler) Poll(w http.ResponseWriter, r *http.Request) {
 	gp, err := d.getOrCreateGitProvider(r.Context(), providerName, providerType, defaultHost)
 	if err != nil {
 		log.Error(err, "get git provider", "provider", providerName)
-		writeJSON(w, http.StatusNotFound, errorResponse{"git provider not found: " + providerName})
+		writeGetOrCreateProviderError(w, providerName, err)
 		return
 	}
 
@@ -369,7 +382,7 @@ func (d *DeviceFlowHandler) StorePAT(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := d.getOrCreateGitProvider(r.Context(), providerName, providerType, host); err != nil {
-		writeJSON(w, http.StatusNotFound, errorResponse{"git provider not found: " + providerName})
+		writeGetOrCreateProviderError(w, providerName, err)
 		return
 	}
 
@@ -418,6 +431,26 @@ func (d *DeviceFlowHandler) getOrCreateGitProvider(ctx context.Context, name str
 	}
 	if !k8serrors.IsNotFound(err) {
 		return nil, fmt.Errorf("get git provider %q: %w", name, err)
+	}
+
+	// Provider doesn't exist — creating one on-demand is a platform-scoped,
+	// admin-only act (it mirrors CreateGitProvider). Gate it before touching
+	// any host input so a viewer cannot mint cluster-scoped resources or drive
+	// a server-side request at an attacker-chosen host.
+	principal := PrincipalFromContext(ctx)
+	if principal == nil {
+		return nil, errProviderCreateForbidden
+	}
+	allowed, err := d.authz.Authorize(ctx, *principal, authz.Resource{Kind: "gitprovider"}, authz.ActionCreate)
+	if err != nil {
+		return nil, fmt.Errorf("authorize git provider creation: %w", err)
+	}
+	if !allowed {
+		return nil, errProviderCreateForbidden
+	}
+
+	if msg := validateGitProviderHost(host); msg != "" {
+		return nil, fmt.Errorf("%w: %s", errProviderHostInvalid, msg)
 	}
 
 	// Provider doesn't exist — try to create with the appropriate type.
@@ -510,6 +543,20 @@ func (d *DeviceFlowHandler) getGitProviderWithRetry(ctx context.Context, name st
 	}
 
 	return err
+}
+
+// writeGetOrCreateProviderError maps a getOrCreateGitProvider failure to the
+// appropriate HTTP status: 403 when on-demand creation is denied, 400 when the
+// supplied host is invalid, and 404 otherwise (provider genuinely absent).
+func writeGetOrCreateProviderError(w http.ResponseWriter, providerName string, err error) {
+	switch {
+	case errors.Is(err, errProviderCreateForbidden):
+		writeJSON(w, http.StatusForbidden, errorResponse{errProviderCreateForbidden.Error()})
+	case errors.Is(err, errProviderHostInvalid):
+		writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+	default:
+		writeJSON(w, http.StatusNotFound, errorResponse{"git provider not found: " + providerName})
+	}
 }
 
 // storeUserToken persists a git provider access token in a k8s Secret keyed

--- a/internal/api/device_flow_test.go
+++ b/internal/api/device_flow_test.go
@@ -17,6 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/auth"
 )
 
 // TestDeviceFlowRequestCodeNoProvider verifies that when no GitProvider exists,
@@ -564,5 +565,55 @@ func TestPerUserTokenStorage(t *testing.T) {
 	// Verify secret names are different.
 	if secret1Name == secret2Name {
 		t.Error("expected different secret names for different users")
+	}
+}
+
+// TestDeviceFlowViewerCannotCreateProvider verifies that a non-admin
+// (viewer) cannot trigger on-demand creation of a cluster-scoped GitProvider
+// via the device-flow endpoints. Creation is admin-only, mirroring the gate on
+// CreateGitProvider; without this a viewer could mint platform-scoped resources.
+func TestDeviceFlowViewerCannotCreateProvider(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
+	h := srv.Handler()
+
+	// No GitProvider exists, so this request would otherwise create one.
+	w := doRequest(h, http.MethodPost, "/api/auth/git/github/device", nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for viewer, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var list mortisev1alpha1.GitProviderList
+	if err := k8sClient.List(context.Background(), &list); err != nil {
+		t.Fatalf("list GitProviders: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected no GitProviders created by viewer, got %d", len(list.Items))
+	}
+}
+
+// TestDeviceFlowStorePATRejectsHostileHost verifies that a caller-supplied host
+// pointing at a link-local/metadata address is rejected at the API boundary,
+// closing the SSRF where StorePAT would otherwise persist Spec.Host verbatim
+// and a later RequestCode would issue a server-side request to it.
+func TestDeviceFlowStorePATRejectsHostileHost(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	// Admin so the request clears the authz gate and reaches host validation.
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	body := map[string]string{"token": "ghp_example", "host": "http://169.254.169.254"}
+	w := doRequest(h, http.MethodPost, "/api/auth/git/github/token", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for hostile host, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The hostile host must never have been persisted into a GitProvider.
+	var list mortisev1alpha1.GitProviderList
+	if err := k8sClient.List(context.Background(), &list); err != nil {
+		t.Fatalf("list GitProviders: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected no GitProvider created for hostile host, got %d", len(list.Items))
 	}
 }

--- a/internal/api/device_flow_test.go
+++ b/internal/api/device_flow_test.go
@@ -577,10 +577,29 @@ func TestDeviceFlowViewerCannotCreateProvider(t *testing.T) {
 	srv, _ := newTestServerAs(t, k8sClient, auth.RoleViewer)
 	h := srv.Handler()
 
-	// No GitProvider exists, so this request would otherwise create one.
-	w := doRequest(h, http.MethodPost, "/api/auth/git/github/device", nil)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for viewer, got %d: %s", w.Code, w.Body.String())
+	// Every route that can reach getOrCreateGitProvider must 403 a viewer.
+	// No GitProvider exists, so each request would otherwise create one.
+	creatingRoutes := []struct {
+		name string
+		path string
+		body any
+	}{
+		{"RequestCode", "/api/auth/git/github/device", nil},
+		{"Poll", "/api/auth/git/github/device/poll", map[string]string{"device_code": "code-123"}},
+		{"StorePAT", "/api/auth/git/github/token", map[string]string{"token": "ghp_viewer"}},
+	}
+	for _, route := range creatingRoutes {
+		w := doRequest(h, http.MethodPost, route.path, route.body)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s: expected 403 for viewer, got %d: %s", route.name, w.Code, w.Body.String())
+		}
+	}
+
+	// GitTokenStatus never creates a provider — a viewer may read their own
+	// token status. Pin that: 200, not 403, and still no GitProvider minted.
+	w := doRequest(h, http.MethodGet, "/api/auth/git/github/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GitTokenStatus: expected 200 for viewer, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var list mortisev1alpha1.GitProviderList

--- a/internal/api/gitproviders.go
+++ b/internal/api/gitproviders.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -300,13 +301,40 @@ func validateGitProviderRequest(req *createGitProviderRequest) string {
 	default:
 		return "type must be one of: github, gitlab, gitea"
 	}
-	host := strings.TrimSpace(req.Host)
+	return validateGitProviderHost(req.Host)
+}
+
+// validateGitProviderHost returns an error message describing why the host is
+// unacceptable, or "" if it is safe to use. It is the single boundary check
+// shared by the admin CreateGitProvider path and the on-demand device-flow
+// creation path. Beyond requiring an absolute http(s) URL, it rejects hosts
+// that point at loopback, private, or link-local addresses so that a
+// user-supplied host cannot drive a server-side request at cluster-internal
+// services or the cloud metadata endpoint (SSRF).
+func validateGitProviderHost(host string) string {
+	host = strings.TrimSpace(host)
 	if host == "" {
 		return "host is required"
 	}
 	u, err := url.Parse(host)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return "host must be an absolute URL (e.g. https://github.com)"
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "host scheme must be http or https"
+	}
+	if u.User != nil {
+		return "host must not contain user information"
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return "host must include a hostname"
+	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return "host must not be a loopback, private, or link-local address"
+		}
 	}
 	return ""
 }

--- a/internal/api/gitproviders_test.go
+++ b/internal/api/gitproviders_test.go
@@ -205,6 +205,38 @@ func TestCreateGitProviderValidation(t *testing.T) {
 				"host": "not-a-url",
 			},
 		},
+		{
+			name: "link-local metadata host",
+			body: map[string]any{
+				"name": "my-provider",
+				"type": "github",
+				"host": "http://169.254.169.254",
+			},
+		},
+		{
+			name: "loopback host",
+			body: map[string]any{
+				"name": "my-provider",
+				"type": "github",
+				"host": "http://127.0.0.1",
+			},
+		},
+		{
+			name: "private host",
+			body: map[string]any{
+				"name": "my-provider",
+				"type": "github",
+				"host": "https://10.0.0.5",
+			},
+		},
+		{
+			name: "non-http scheme",
+			body: map[string]any{
+				"name": "my-provider",
+				"type": "github",
+				"host": "file:///etc/passwd",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -96,7 +96,7 @@ func (s *Server) clock() kclock.Clock {
 func NewServer(c client.Client, cs kubernetes.Interface, dc dynamic.Interface, restConfig *rest.Config, authProvider auth.AuthProvider, jwt *auth.JWTHelper, ui fs.FS, policy authz.PolicyEngine) *Server {
 	kr := webhook.NewK8sReader(c)
 	wh := webhook.New(kr)
-	df := newDeviceFlowHandler(c, cs)
+	df := newDeviceFlowHandler(c, cs, policy)
 	srv := &Server{
 		client:        c,
 		clientset:     cs,


### PR DESCRIPTION
The per-user git device-flow endpoints (RequestCode/Poll/StorePAT) were mounted under `jwtAuthMiddleware` only, with no authorization check. Their shared `getOrCreateGitProvider` path creates a cluster-scoped GitProvider CRD on demand, so any authenticated user — including a viewer — could mint platform-scoped resources, bypassing the admin-only gate on CreateGitProvider. StorePAT additionally passed `body.Host` verbatim into `Spec.Host`; a later RequestCode issues a server-side POST to that host, yielding SSRF (e.g. `http://169.254.169.254`).

- Plumb the authz PolicyEngine into DeviceFlowHandler and gate on-demand provider creation behind an admin authz check (`gitprovider/create`), before any host input is touched.
- Extract a shared `validateGitProviderHost` validator used by both `gitproviders.go` and the device-flow path: requires an absolute http(s) URL and rejects loopback, private, and link-local hosts.
- Map the new failure modes to 403 (creation forbidden) and 400 (invalid host); genuine absence stays 404.
- Tests: viewer-role creation denial, hostile-host rejection with no GitProvider persisted, and private/link-local/loopback/non-http host rejection on the admin path.

Fixes #439
