### PR TITLE
ci: add make ci-local — every CI gate, one command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,12 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 test-integration-fast: ## Run integration tests against the existing dev cluster (requires make dev-up + chart installed)
 	go test -tags integration -count=1 -timeout 5m ./test/integration/...
 
+##@ CI
+
+.PHONY: ci-local
+ci-local: ## Run every CI gate locally — THE push gate. SKIP_INTEGRATION=1 for fast mode (skips the cluster-backed gates).
+	scripts/ci-local.sh $(if $(SKIP_INTEGRATION),--skip-integration)
+
 ##@ Chart Tests
 
 .PHONY: verify-chart-dependency-drift
@@ -399,8 +405,13 @@ E2E_PASSWORD ?= admin123
 test-e2e: ## Run Playwright E2E suite against the dev cluster (requires make dev-up).
 	@kubectl --context $(DEV_KUBE_CONTEXT) -n mortise-system rollout status deployment/mortise --timeout=30s
 	@cd ui && npm ci --silent && npx playwright install chromium
-	@kubectl --context $(DEV_KUBE_CONTEXT) port-forward -n mortise-system svc/mortise $(E2E_PORT):80 >/dev/null 2>&1 & PF_PID=$$!; \
-	trap "kill $$PF_PID 2>/dev/null || true" EXIT; \
+	@# The port-forward runs under a supervisor loop: kubectl port-forward
+	@# exits on the first dropped backend connection, and a mid-suite death
+	@# fails every in-flight test with ERR_EMPTY_RESPONSE. setsid gives the
+	@# loop its own process group so the trap's group-kill reaps the loop and
+	@# whatever kubectl it currently has, without touching this recipe shell.
+	@setsid bash -c 'while true; do kubectl --context $(DEV_KUBE_CONTEXT) port-forward -n mortise-system svc/mortise $(E2E_PORT):80 >/dev/null 2>&1; sleep 1; done' & PF_PID=$$!; \
+	trap "kill -- -$$PF_PID 2>/dev/null || true" EXIT; \
 	echo "==> Waiting for API at http://localhost:$(E2E_PORT)..."; \
 	for i in $$(seq 1 30); do \
 		curl -sf http://localhost:$(E2E_PORT)/api/auth/status >/dev/null 2>&1 && break; \

--- a/Makefile
+++ b/Makefile
@@ -410,8 +410,13 @@ test-e2e: ## Run Playwright E2E suite against the dev cluster (requires make dev
 	@# fails every in-flight test with ERR_EMPTY_RESPONSE. setsid gives the
 	@# loop its own process group so the trap's group-kill reaps the loop and
 	@# whatever kubectl it currently has, without touching this recipe shell.
-	@setsid bash -c 'while true; do kubectl --context $(DEV_KUBE_CONTEXT) port-forward -n mortise-system svc/mortise $(E2E_PORT):80 >/dev/null 2>&1; sleep 1; done' & PF_PID=$$!; \
-	trap "kill -- -$$PF_PID 2>/dev/null || true" EXIT; \
+	@# macOS has no setsid: there the loop instead stops cooperatively via a
+	@# sentinel file (created by the trap), after pkill -P reaps the kubectl
+	@# it currently has — no respawn race, no group kill needed.
+	@SETSID="$$(command -v setsid || true)"; \
+	PF_STOP="$$(mktemp -u)"; \
+	$$SETSID bash -c 'while [ ! -e "$$0" ]; do kubectl --context $(DEV_KUBE_CONTEXT) port-forward -n mortise-system svc/mortise $(E2E_PORT):80 >/dev/null 2>&1; sleep 1; done' "$$PF_STOP" & PF_PID=$$!; \
+	trap "touch $$PF_STOP; kill -- -$$PF_PID 2>/dev/null || pkill -P $$PF_PID 2>/dev/null || true; wait $$PF_PID 2>/dev/null || true; rm -f $$PF_STOP" EXIT; \
 	echo "==> Waiting for API at http://localhost:$(E2E_PORT)..."; \
 	for i in $$(seq 1 30); do \
 		curl -sf http://localhost:$(E2E_PORT)/api/auth/status >/dev/null 2>&1 && break; \

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# ci-local: run every gate .github/workflows/ci.yml runs, locally.
+#
+# Usage:
+#   scripts/ci-local.sh                     # all six gates (needs Docker + k3d)
+#   scripts/ci-local.sh --skip-integration  # fast mode: skip the two
+#                                           # cluster-backed gates
+#                                           # (integration, ui-e2e)
+#
+# Gates mirror the CI jobs one-to-one and are version-matched to them (the
+# staticcheck pin is read out of ci.yml so it cannot drift). The cheap gates
+# run first so a broken unit test doesn't cost a 10-minute cluster build;
+# CI runs all jobs regardless of each other's outcome, and so does this
+# script — every gate runs, failures are collected, and the summary at the
+# end is the verdict. Exit is non-zero if any gate failed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CI_YML="${REPO_ROOT}/.github/workflows/ci.yml"
+cd "$REPO_ROOT"
+
+SKIP_CLUSTER_GATES=false
+for arg in "$@"; do
+    case "$arg" in
+        --skip-integration) SKIP_CLUSTER_GATES=true ;;
+        *) echo "unknown flag: $arg (only --skip-integration is supported)" >&2; exit 2 ;;
+    esac
+done
+
+# Version-match staticcheck to the CI pin (the 'staticcheck@vX.Y.Z' install
+# line in ci.yml's lint job). Falls back to 'latest' only if the pin is ever
+# removed from ci.yml, which keeps local == CI either way.
+STATICCHECK_VERSION="$(grep -oE 'staticcheck@[^ "]+' "$CI_YML" | head -1 | cut -d@ -f2)"
+STATICCHECK_VERSION="${STATICCHECK_VERSION:-latest}"
+
+gate_names=()
+gate_results=()
+gate_times=()
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
+
+run_gate() {
+    local name="$1"; shift
+    local start=$SECONDS rc=0
+    bold ""
+    bold "━━━ ci-local gate: ${name} ━━━"
+    "$@" || rc=$?
+    gate_names+=("$name")
+    gate_times+=($((SECONDS - start)))
+    if [ "$rc" -eq 0 ]; then
+        gate_results+=("pass")
+    else
+        gate_results+=("FAIL")
+        red "gate '${name}' failed (exit ${rc})"
+    fi
+}
+
+skip_gate() {
+    gate_names+=("$1")
+    gate_results+=("skip")
+    gate_times+=(0)
+}
+
+# ── Gates (cheap first; cluster-backed last) ─────────────────────────────
+
+gate_unit()   { make test; }
+
+gate_charts() {
+    helm repo add traefik https://traefik.github.io/charts --force-update
+    helm repo add jetstack https://charts.jetstack.io --force-update
+    helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ --force-update
+    helm repo update
+    make test-charts
+}
+
+gate_lint() {
+    go vet ./... || return 1
+    echo "staticcheck ${STATICCHECK_VERSION} (pin from ci.yml)"
+    go run "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}" ./...
+}
+
+gate_ui() {
+    (cd ui && npm ci && npm run check && npm run build)
+}
+
+gate_integration() { make test-integration; }
+
+gate_ui_e2e() {
+    local rc=0
+    # CI=true mirrors the hosted runners: Playwright's config keys retries
+    # (2 vs 0) off process.env.CI, and without it local runs are strictly
+    # flakier than the CI gate they're standing in for.
+    make dev-up && CI=true make test-e2e || rc=$?
+    make dev-down || true
+    return "$rc"
+}
+
+run_gate "unit+envtest"    gate_unit
+run_gate "helm lint"       gate_charts
+run_gate "vet+staticcheck" gate_lint
+run_gate "ui build"        gate_ui
+if $SKIP_CLUSTER_GATES; then
+    skip_gate "integration"
+    skip_gate "ui-e2e"
+else
+    run_gate "integration" gate_integration
+    run_gate "ui-e2e"      gate_ui_e2e
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+bold ""
+bold "━━━ ci-local summary ━━━"
+failed=0
+for i in "${!gate_names[@]}"; do
+    line="$(printf '%-16s %-4s %4ss' "${gate_names[$i]}" "${gate_results[$i]}" "${gate_times[$i]}")"
+    case "${gate_results[$i]}" in
+        pass) green "$line" ;;
+        skip) echo  "$line" ;;
+        *)    red   "$line"; failed=$((failed + 1)) ;;
+    esac
+done
+bold ""
+if [ "$failed" -gt 0 ]; then
+    red "ci-local: ${failed} gate(s) failed — do not push"
+    exit 1
+fi
+if $SKIP_CLUSTER_GATES; then
+    green "ci-local: all non-cluster gates green (integration + ui-e2e skipped — run full before pushing)"
+else
+    green "ci-local: all gates green — safe to push"
+fi

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -28,11 +28,14 @@ for arg in "$@"; do
     esac
 done
 
-# Version-match staticcheck to the CI pin (the 'staticcheck@vX.Y.Z' install
-# line in ci.yml's lint job). Falls back to 'latest' only if the pin is ever
-# removed from ci.yml, which keeps local == CI either way.
-STATICCHECK_VERSION="$(grep -oE 'staticcheck@[^ "]+' "$CI_YML" | head -1 | cut -d@ -f2)"
-STATICCHECK_VERSION="${STATICCHECK_VERSION:-latest}"
+# Version-match staticcheck to the CI pin (the 'go install …staticcheck@vX'
+# line in ci.yml's lint job). A missing pin is a hard error: silently falling
+# back to 'latest' would reintroduce exactly the drift this parse prevents.
+STATICCHECK_VERSION="$(grep -oE 'go install honnef\.co/go/tools/cmd/staticcheck@[^ "]+' "$CI_YML" | head -1 | cut -d@ -f2)"
+if [ -z "$STATICCHECK_VERSION" ]; then
+    echo "ci-local: could not find the staticcheck install line in $CI_YML — the lint gate cannot be version-matched to CI. Fix the parse or the workflow." >&2
+    exit 2
+fi
 
 gate_names=()
 gate_results=()
@@ -89,12 +92,22 @@ gate_ui() {
 gate_integration() { make test-integration; }
 
 gate_ui_e2e() {
-    local rc=0
+    local rc=0 preexisting=false
+    # A live dev cluster belongs to the developer — reconverge it via dev-up
+    # but do NOT tear it down afterwards. Only clusters this gate created get
+    # dev-downed.
+    if k3d cluster list 2>/dev/null | grep -q "^${DEV_CLUSTER:-mortise-dev}\b"; then
+        preexisting=true
+        echo "note: dev cluster already exists — reusing it and leaving it up afterwards"
+    fi
     # CI=true mirrors the hosted runners: Playwright's config keys retries
-    # (2 vs 0) off process.env.CI, and without it local runs are strictly
-    # flakier than the CI gate they're standing in for.
+    # (2 vs 0) and workers (4 vs 8) off process.env.CI, so this is the
+    # CI-parity run the push gate wants. For flake-hunting, run the suite
+    # directly WITHOUT CI=true — zero retries surfaces what parity hides.
     make dev-up && CI=true make test-e2e || rc=$?
-    make dev-down || true
+    if ! $preexisting; then
+        make dev-down || true
+    fi
     return "$rc"
 }
 


### PR DESCRIPTION
## Summary

Adds `make ci-local` (tracker bead mo-osm): one command that runs every gate `.github/workflows/ci.yml` runs, locally, with a per-gate pass/fail summary. Per the Overseer mandate, a green `make ci-local` is the push gate.

- Six gates mirroring the six CI jobs: unit+envtest, helm lint/template, go vet + staticcheck, UI typecheck/build, integration (k3d), UI E2E (dev cluster + Playwright).
- **Version-matched by construction**: the staticcheck version is parsed out of ci.yml's install line, so the local pin can never drift from CI's.
- **Retry parity**: the e2e gate sets `CI=true` — Playwright's config gives CI 2 retries and workers=4 but local runs 0 retries and workers=8, so an unflagged local run is both flakier and unrepresentative.
- Cheap gates run first; all gates run regardless of earlier failures (CI's jobs are independent, so a full picture per run). `SKIP_INTEGRATION=1` skips the two cluster-backed gates for the fast inner loop.
- Hardens `make test-e2e`'s port-forward with a setsid supervisor loop: `kubectl port-forward` exits on the first dropped backend connection, and a mid-suite death failed every in-flight test with `ERR_EMPTY_RESPONSE` (observed live; with the supervisor the suite then passed 160/160 three runs straight).

## Base branch note

Based on `fix/ci-hygiene-lane-f` (#458) as the bead offered, **so #458 must merge first**; this PR then sits at exactly main+1. Basing on main was tried and its integration gate fails on any containerd-store Docker host without #458's import fix — the two are functionally coupled.

## Verification

Five full runs on the crew1 box during development. Every gate has passed; the fast gates are green in every run, and ui-e2e is green in the last three runs (160/160) since the port-forward supervisor. The integration gate is red in 3 of 4 recent runs on this box due to a **product bug the gate surfaced**: App reconciles race per-namespace RBAC propagation and controller-runtime's exponential backoff turns the transient forbidden errors into minutes-long stalls, blowing test ready-ceilings. Filed with full RCA as bead mo-k5p. `ci-local` deliberately does not auto-retry that gate — hiding exactly the class of failure the gate exists to surface would defeat it.

Fixes the local-coverage gap called out when #456 hit an unexercised CI job.