### PR TITLE
fix(api): compute envstore mutations inside the conflict-retry callback

### DIFF
--- a/internal/api/env.go
+++ b/internal/api/env.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,6 +41,23 @@ type envVarResponse struct {
 type patchEnvRequest struct {
 	Set   map[string]string `json:"set"`
 	Unset []string          `json:"unset"`
+}
+
+// envConflictError is returned from envstore.Apply callbacks when a request
+// tries to modify a managed (non-user) var. Maps to HTTP 409.
+type envConflictError struct{ msg string }
+
+func (e *envConflictError) Error() string { return e.msg }
+
+// writeEnvStoreError maps an envstore.Apply error to the HTTP response:
+// envConflictError → 409, everything else → the generic error mapping.
+func writeEnvStoreError(w http.ResponseWriter, r *http.Request, err error) {
+	var conflict *envConflictError
+	if stderrors.As(err, &conflict) {
+		writeJSON(w, http.StatusConflict, errorResponse{conflict.msg})
+		return
+	}
+	writeError(w, r, err)
 }
 
 func declarativeEnvSources(app *mortisev1alpha1.App, envName string) map[string]string {
@@ -178,44 +196,6 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 	}
 	store := &envstore.Store{Client: s.client}
 
-	// Read existing vars so we can preserve non-user sources (binding, generated, shared).
-	existing, err := store.Get(r.Context(), envNs, app.Name)
-	if err != nil {
-		writeError(w, r, err)
-		return
-	}
-	existingSource := make(map[string]string, len(existing))
-	for _, e := range existing {
-		existingSource[e.Name] = e.Source
-	}
-	declarativeSource := declarativeEnvSources(app, envName)
-	for _, v := range vars {
-		if source, ok := declarativeSource[v.Name]; ok {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", v.Name, source)})
-			return
-		}
-		if src, ok := existingSource[v.Name]; ok && src != "" && src != "user" {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", v.Name, src)})
-			return
-		}
-	}
-
-	// Start with non-user vars and declarative projections from the existing
-	// Secret. secretRef values resolve with source "user", so the App spec is
-	// the ownership signal that distinguishes them from editable literals.
-	var merged []envstore.Env
-	for _, e := range existing {
-		if (e.Source != "user" && e.Source != "") || declarativeSource[e.Name] != "" {
-			merged = append(merged, e)
-		}
-	}
-	// Append the new user vars.
-	for _, v := range vars {
-		merged = append(merged, envstore.Env{Name: v.Name, Value: v.Value, Source: "user"})
-	}
-
 	projectName, ok2 := constants.ProjectFromControlNs(app.Namespace)
 	if !ok2 {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{fmt.Sprintf("app %q not in a control namespace (%q)", app.Name, app.Namespace)})
@@ -226,8 +206,43 @@ func (s *Server) PutEnv(w http.ResponseWriter, r *http.Request) {
 		constants.EnvironmentLabel: envName,
 		constants.AppNameLabel:     app.Name,
 	}
-	if err := store.Set(r.Context(), envNs, app.Name, merged, labels); err != nil {
-		writeError(w, r, err)
+	declarativeSource := declarativeEnvSources(app, envName)
+
+	// Compute the replacement set inside the conflict-retry callback so a
+	// concurrent writer's vars are re-read fresh instead of being clobbered.
+	err = store.Apply(r.Context(), envNs, app.Name, labels, func(existing []envstore.Env) ([]envstore.Env, error) {
+		existingSource := make(map[string]string, len(existing))
+		for _, e := range existing {
+			existingSource[e.Name] = e.Source
+		}
+		for _, v := range vars {
+			if source, ok := declarativeSource[v.Name]; ok {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot overwrite %q: managed by %s (only user-set vars can be modified)", v.Name, source)}
+			}
+			if src, ok := existingSource[v.Name]; ok && src != "" && src != "user" {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot overwrite %q: managed by %s (only user-set vars can be modified)", v.Name, src)}
+			}
+		}
+
+		// Start with non-user vars and declarative projections from the existing
+		// Secret. secretRef values resolve with source "user", so the App spec is
+		// the ownership signal that distinguishes them from editable literals.
+		var merged []envstore.Env
+		for _, e := range existing {
+			if (e.Source != "user" && e.Source != "") || declarativeSource[e.Name] != "" {
+				merged = append(merged, e)
+			}
+		}
+		// Append the new user vars.
+		for _, v := range vars {
+			merged = append(merged, envstore.Env{Name: v.Name, Value: v.Value, Source: "user"})
+		}
+		return merged, nil
+	})
+	if err != nil {
+		writeEnvStoreError(w, r, err)
 		return
 	}
 
@@ -281,70 +296,6 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 	}
 	store := &envstore.Store{Client: s.client}
 
-	// Read existing vars from Secret.
-	existing, err := store.Get(r.Context(), envNs, app.Name)
-	if err != nil {
-		writeError(w, r, err)
-		return
-	}
-	declarativeSource := declarativeEnvSources(app, envName)
-
-	// Apply unsets — reject non-user sources.
-	unsetMap := make(map[string]bool, len(req.Unset))
-	for _, k := range req.Unset {
-		if source, ok := declarativeSource[k]; ok {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot unset %q: managed by %s (only user-set vars can be removed)", k, source)})
-			return
-		}
-		unsetMap[k] = true
-	}
-	for _, e := range existing {
-		if unsetMap[e.Name] && e.Source != "" && e.Source != "user" {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot unset %q: managed by %s (only user-set vars can be removed)", e.Name, e.Source)})
-			return
-		}
-	}
-	var result []envstore.Env
-	for _, e := range existing {
-		if !unsetMap[e.Name] {
-			result = append(result, e)
-		}
-	}
-
-	// Apply sets — reject overwrites of non-user sources.
-	existingSource := make(map[string]string, len(result))
-	for _, e := range result {
-		existingSource[e.Name] = e.Source
-	}
-	for k := range req.Set {
-		if source, ok := declarativeSource[k]; ok {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", k, source)})
-			return
-		}
-		if src, ok := existingSource[k]; ok && src != "" && src != "user" {
-			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf(
-				"cannot overwrite %q: managed by %s (only user-set vars can be modified)", k, src)})
-			return
-		}
-	}
-	for k, v := range req.Set {
-		found := false
-		for i := range result {
-			if result[i].Name == k {
-				result[i].Value = v
-				result[i].Source = "user"
-				found = true
-				break
-			}
-		}
-		if !found {
-			result = append(result, envstore.Env{Name: k, Value: v, Source: "user"})
-		}
-	}
-
 	projectName, ok2 := constants.ProjectFromControlNs(app.Namespace)
 	if !ok2 {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{fmt.Sprintf("app %q not in a control namespace (%q)", app.Name, app.Namespace)})
@@ -355,8 +306,66 @@ func (s *Server) PatchEnv(w http.ResponseWriter, r *http.Request) {
 		constants.EnvironmentLabel: envName,
 		constants.AppNameLabel:     app.Name,
 	}
-	if err := store.Set(r.Context(), envNs, app.Name, result, labels); err != nil {
-		writeError(w, r, err)
+	declarativeSource := declarativeEnvSources(app, envName)
+
+	// Apply the patch inside the conflict-retry callback so concurrent PATCHes
+	// each recompute from a fresh read — no dropped keys on races.
+	err = store.Apply(r.Context(), envNs, app.Name, labels, func(existing []envstore.Env) ([]envstore.Env, error) {
+		// Apply unsets — reject non-user sources.
+		unsetMap := make(map[string]bool, len(req.Unset))
+		for _, k := range req.Unset {
+			if source, ok := declarativeSource[k]; ok {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot unset %q: managed by %s (only user-set vars can be removed)", k, source)}
+			}
+			unsetMap[k] = true
+		}
+		for _, e := range existing {
+			if unsetMap[e.Name] && e.Source != "" && e.Source != "user" {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot unset %q: managed by %s (only user-set vars can be removed)", e.Name, e.Source)}
+			}
+		}
+		var result []envstore.Env
+		for _, e := range existing {
+			if !unsetMap[e.Name] {
+				result = append(result, e)
+			}
+		}
+
+		// Apply sets — reject overwrites of non-user sources.
+		existingSource := make(map[string]string, len(result))
+		for _, e := range result {
+			existingSource[e.Name] = e.Source
+		}
+		for k := range req.Set {
+			if source, ok := declarativeSource[k]; ok {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot overwrite %q: managed by %s (only user-set vars can be modified)", k, source)}
+			}
+			if src, ok := existingSource[k]; ok && src != "" && src != "user" {
+				return nil, &envConflictError{fmt.Sprintf(
+					"cannot overwrite %q: managed by %s (only user-set vars can be modified)", k, src)}
+			}
+		}
+		for k, v := range req.Set {
+			found := false
+			for i := range result {
+				if result[i].Name == k {
+					result[i].Value = v
+					result[i].Source = "user"
+					found = true
+					break
+				}
+			}
+			if !found {
+				result = append(result, envstore.Env{Name: k, Value: v, Source: "user"})
+			}
+		}
+		return result, nil
+	})
+	if err != nil {
+		writeEnvStoreError(w, r, err)
 		return
 	}
 

--- a/internal/api/env_handler_test.go
+++ b/internal/api/env_handler_test.go
@@ -3,7 +3,9 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -182,6 +184,68 @@ func TestPatchEnvSetAndUnset(t *testing.T) {
 	}
 	if names["REMOVE"] {
 		t.Error("expected REMOVE to be unset")
+	}
+}
+
+// TestPatchEnvConcurrentPatchesNoLostUpdates exercises the lost-update race:
+// concurrent PATCHes each setting a distinct key must all survive, because the
+// handler recomputes the result from a fresh read inside the conflict-retry
+// callback. A PATCH may fail on retry exhaustion under contention (retried
+// here); what it must never do is succeed while dropping another PATCH's key.
+func TestPatchEnvConcurrentPatchesNoLostUpdates(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "default")
+	seedAppForEnv(t, h)
+
+	doRequest(h, http.MethodPut, "/api/projects/default/apps/webapp/env?environment=production", []map[string]string{
+		{"name": "SEEDED", "value": "yes"},
+	})
+
+	const writers = 6
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("CONCURRENT_%d", i)
+			for attempt := 0; attempt < 20; attempt++ {
+				w := doRequest(h, http.MethodPatch, "/api/projects/default/apps/webapp/env?environment=production", map[string]any{
+					"set": map[string]string{key: fmt.Sprintf("v%d", i)},
+				})
+				if w.Code == http.StatusOK {
+					return
+				}
+			}
+			errs[i] = fmt.Errorf("PATCH setting %s never returned 200", key)
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := doRequest(h, http.MethodGet, "/api/projects/default/apps/webapp/env?environment=production", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var got []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	names := map[string]bool{}
+	for _, v := range got {
+		names[v["name"].(string)] = true
+	}
+	if !names["SEEDED"] {
+		t.Error("expected SEEDED to survive concurrent patches")
+	}
+	for i := range writers {
+		if key := fmt.Sprintf("CONCURRENT_%d", i); !names[key] {
+			t.Errorf("expected %s to survive concurrent patches — lost update", key)
+		}
 	}
 }
 

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2412,35 +2412,10 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 	//   when the CRD spec changes (no user override detected).
 	// - Keys whose Secret value differs from last-applied are preserved (the
 	//   user or UI changed them out-of-band).
-	existing, err := store.Get(ctx, envNs, app.Name)
-	if err != nil {
-		return fmt.Errorf("read existing env vars: %w", err)
-	}
-	existingByName := make(map[string]string, len(existing))
-	for _, e := range existing {
-		existingByName[e.Name] = e.Value
-	}
-
 	lastSpec := r.readLastSpecEnv(ctx, envNs, app.Name)
 	specEnvKeys := make(map[string]struct{}, len(env.Env))
 	for _, ev := range env.Env {
 		specEnvKeys[ev.Name] = struct{}{}
-	}
-	for _, existingEnv := range existing {
-		if existingEnv.Source != "" && existingEnv.Source != "user" {
-			continue
-		}
-		if _, stillInSpec := specEnvKeys[existingEnv.Name]; stillInSpec {
-			continue
-		}
-		lastVal, tracked := lastSpec[existingEnv.Name]
-		if !tracked || existingEnv.Value != lastVal {
-			continue
-		}
-		if err := store.Delete(ctx, envNs, app.Name, existingEnv.Name); err != nil {
-			return fmt.Errorf("remove stale spec env %q: %w", existingEnv.Name, err)
-		}
-		delete(existingByName, existingEnv.Name)
 	}
 
 	bindingRefs := make(map[string]bool, len(env.Bindings))
@@ -2448,7 +2423,12 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		bindingRefs[b.Ref] = true
 	}
 
-	var toMerge []envstore.Env
+	// Resolve spec env values outside the retry callback — they read other
+	// Secrets, not the app-env Secret being mutated.
+	type resolvedVar struct {
+		name, value, source string
+	}
+	var specVars []resolvedVar
 	var fromBindingEnvs []envstore.Env
 	resolvedSpecEnv := make(map[string]string, len(env.Env))
 	for _, ev := range env.Env {
@@ -2460,37 +2440,12 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		resolvedSpecEnv[ev.Name] = resolved
 
 		// fromBinding vars go into the binding-source list so they survive
-		// ReplaceSource("binding", ...) below.
+		// the binding-source replacement below.
 		if source == "binding" {
 			fromBindingEnvs = append(fromBindingEnvs, envstore.Env{Name: ev.Name, Value: resolved, Source: source})
 			continue
 		}
-
-		existingVal, exists := existingByName[ev.Name]
-		if !exists {
-			toMerge = append(toMerge, envstore.Env{Name: ev.Name, Value: resolved, Source: source})
-			continue
-		}
-		if resolved == existingVal {
-			continue
-		}
-		if lastVal, tracked := lastSpec[ev.Name]; tracked && existingVal == lastVal {
-			toMerge = append(toMerge, envstore.Env{Name: ev.Name, Value: resolved, Source: source})
-		}
-	}
-	for _, sv := range app.Spec.SharedVars {
-		if _, exists := existingByName[sv.Name]; !exists {
-			toMerge = append(toMerge, envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"})
-		}
-	}
-	if len(toMerge) > 0 {
-		if err := store.Merge(ctx, envNs, app.Name, toMerge, labels); err != nil {
-			return fmt.Errorf("seed env secret: %w", err)
-		}
-	}
-
-	if err := r.writeLastSpecEnv(ctx, envNs, app.Name, resolvedSpecEnv); err != nil {
-		return fmt.Errorf("write last-spec-env: %w", err)
+		specVars = append(specVars, resolvedVar{name: ev.Name, value: resolved, source: source})
 	}
 
 	var bindingEnvs []envstore.Env
@@ -2512,16 +2467,89 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 	// auto-generated binding vars when names collide.
 	bindingEnvs = append(bindingEnvs, fromBindingEnvs...)
 	if len(bindingEnvs) == 0 {
-		if deleted, err := r.deleteBindingOnlyEnvSecret(ctx, envNs, app.Name); err != nil {
+		if _, err := r.deleteBindingOnlyEnvSecret(ctx, envNs, app.Name); err != nil {
 			return fmt.Errorf("delete empty binding-only env secret: %w", err)
-		} else if deleted {
-			return nil
 		}
 	}
-	if len(existing) == 0 && len(toMerge) == 0 && len(bindingEnvs) == 0 {
-		return nil
+
+	// Stale-spec removal, spec seeding, and binding-source replacement all
+	// recompute from the fresh read inside the conflict-retry callback, so
+	// this reconcile can't clobber a concurrent user PATCH (and vice versa).
+	err = store.Apply(ctx, envNs, app.Name, labels, func(current []envstore.Env) ([]envstore.Env, error) {
+		// Drop user-visible vars that were removed from the spec and never
+		// overridden out-of-band.
+		kept := make([]envstore.Env, 0, len(current))
+		for _, e := range current {
+			if e.Source == "" || e.Source == "user" {
+				if _, stillInSpec := specEnvKeys[e.Name]; !stillInSpec {
+					if lastVal, tracked := lastSpec[e.Name]; tracked && e.Value == lastVal {
+						continue
+					}
+				}
+			}
+			kept = append(kept, e)
+		}
+		keptByName := make(map[string]string, len(kept))
+		for _, e := range kept {
+			keptByName[e.Name] = e.Value
+		}
+
+		// Seed spec vars that are missing or whose value tracks the last
+		// applied spec (no user override detected).
+		seed := make(map[string]envstore.Env)
+		for _, sv := range specVars {
+			existingVal, exists := keptByName[sv.name]
+			if !exists {
+				seed[sv.name] = envstore.Env{Name: sv.name, Value: sv.value, Source: sv.source}
+				continue
+			}
+			if sv.value == existingVal {
+				continue
+			}
+			if lastVal, tracked := lastSpec[sv.name]; tracked && existingVal == lastVal {
+				seed[sv.name] = envstore.Env{Name: sv.name, Value: sv.value, Source: sv.source}
+			}
+		}
+		for _, sv := range app.Spec.SharedVars {
+			if _, exists := keptByName[sv.Name]; !exists {
+				seed[sv.Name] = envstore.Env{Name: sv.Name, Value: sv.Value, Source: "shared"}
+			}
+		}
+
+		// Assemble: kept vars (binding-source dropped, seeds overriding by
+		// name), remaining seeds, then the recomputed binding vars last so
+		// they win on name collisions.
+		result := make([]envstore.Env, 0, len(kept)+len(seed)+len(bindingEnvs))
+		for _, e := range kept {
+			if e.Source == "binding" {
+				continue
+			}
+			if ne, ok := seed[e.Name]; ok {
+				result = append(result, ne)
+				delete(seed, e.Name)
+				continue
+			}
+			result = append(result, e)
+		}
+		for _, ne := range seed {
+			result = append(result, ne)
+		}
+		result = append(result, bindingEnvs...)
+
+		if len(current) == 0 && len(result) == 0 {
+			// Nothing to write — don't create an empty Secret.
+			return nil, envstore.ErrSkip
+		}
+		return result, nil
+	})
+	if err != nil {
+		return fmt.Errorf("apply env secret: %w", err)
 	}
-	return store.ReplaceSource(ctx, envNs, app.Name, "binding", bindingEnvs, labels)
+
+	if err := r.writeLastSpecEnv(ctx, envNs, app.Name, resolvedSpecEnv); err != nil {
+		return fmt.Errorf("write last-spec-env: %w", err)
+	}
+	return nil
 }
 
 // resolveEnvVarValue resolves the effective value and source for a spec env var.

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -11,6 +11,7 @@ package envstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -20,6 +21,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mortise-org/mortise/internal/constants"
@@ -151,33 +153,29 @@ func (s *Store) SetShared(ctx context.Context, namespace string, vars []Env, lab
 	return s.upsertSecret(ctx, namespace, SharedEnvName, vars, labels)
 }
 
+// ErrSkip can be returned by an Apply mutate callback to abort the apply
+// without writing anything (and without surfacing an error). Used to avoid
+// creating a Secret that would be empty.
+var ErrSkip = errors.New("envstore: skip apply")
+
+// Apply atomically mutates an app's env Secret. mutate receives the current
+// vars — freshly read on every conflict-retry attempt, nil if the Secret does
+// not exist — and returns the full desired set. Because the result is
+// recomputed from the latest read inside the retry loop, concurrent writers
+// cannot lose each other's updates.
+func (s *Store) Apply(ctx context.Context, namespace, appName string, labels map[string]string, mutate func(current []Env) ([]Env, error)) error {
+	return s.applySecret(ctx, namespace, AppEnvSecretName(appName), labels, mutate)
+}
+
 // Merge reads the existing Secret, merges in new vars (overwriting duplicates),
 // and writes back. Returns the merged set.
 func (s *Store) Merge(ctx context.Context, namespace, appName string, vars []Env, labels map[string]string) error {
 	if err := validateEnvVars(vars); err != nil {
 		return err
 	}
-	name := AppEnvSecretName(appName)
-	existing, err := s.getSecret(ctx, namespace, name)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-
-	merged := make(map[string]Env)
-	if existing != nil {
-		for _, e := range secretToEnvs(existing) {
-			merged[e.Name] = e
-		}
-	}
-	for _, e := range vars {
-		merged[e.Name] = e
-	}
-
-	flat := make([]Env, 0, len(merged))
-	for _, e := range merged {
-		flat = append(flat, e)
-	}
-	return s.upsertSecret(ctx, namespace, name, flat, labels)
+	return s.Apply(ctx, namespace, appName, labels, func(current []Env) ([]Env, error) {
+		return mergeEnvs(current, vars), nil
+	})
 }
 
 // MergeShared is like Merge but for the shared-env Secret.
@@ -185,26 +183,9 @@ func (s *Store) MergeShared(ctx context.Context, namespace string, vars []Env, l
 	if err := validateEnvVars(vars); err != nil {
 		return err
 	}
-	existing, err := s.getSecret(ctx, namespace, SharedEnvName)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-
-	merged := make(map[string]Env)
-	if existing != nil {
-		for _, e := range secretToEnvs(existing) {
-			merged[e.Name] = e
-		}
-	}
-	for _, e := range vars {
-		merged[e.Name] = e
-	}
-
-	flat := make([]Env, 0, len(merged))
-	for _, e := range merged {
-		flat = append(flat, e)
-	}
-	return s.upsertSecret(ctx, namespace, SharedEnvName, flat, labels)
+	return s.applySecret(ctx, namespace, SharedEnvName, labels, func(current []Env) ([]Env, error) {
+		return mergeEnvs(current, vars), nil
+	})
 }
 
 // ReplaceSource replaces all vars with the given source in an app's env Secret.
@@ -214,22 +195,15 @@ func (s *Store) ReplaceSource(ctx context.Context, namespace, appName, source st
 	if err := validateEnvVars(vars); err != nil {
 		return err
 	}
-	name := AppEnvSecretName(appName)
-	existing, err := s.getSecret(ctx, namespace, name)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-
-	var kept []Env
-	if existing != nil {
-		for _, e := range secretToEnvs(existing) {
+	return s.Apply(ctx, namespace, appName, labels, func(current []Env) ([]Env, error) {
+		var kept []Env
+		for _, e := range current {
 			if e.Source != source {
 				kept = append(kept, e)
 			}
 		}
-	}
-	kept = append(kept, vars...)
-	return s.upsertSecret(ctx, namespace, name, kept, labels)
+		return append(kept, vars...), nil
+	})
 }
 
 // Delete removes a key from an app's env Secret.
@@ -320,24 +294,9 @@ func (s *Store) MergeSharedSource(ctx context.Context, controlNs string, vars []
 	if err := validateEnvVars(vars); err != nil {
 		return err
 	}
-	existing, err := s.getSecret(ctx, controlNs, SharedVarsSourceName)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	merged := make(map[string]Env)
-	if existing != nil {
-		for _, e := range secretToEnvs(existing) {
-			merged[e.Name] = e
-		}
-	}
-	for _, e := range vars {
-		merged[e.Name] = e
-	}
-	flat := make([]Env, 0, len(merged))
-	for _, e := range merged {
-		flat = append(flat, e)
-	}
-	return s.upsertSecret(ctx, controlNs, SharedVarsSourceName, flat, labels)
+	return s.applySecret(ctx, controlNs, SharedVarsSourceName, labels, func(current []Env) ([]Env, error) {
+		return mergeEnvs(current, vars), nil
+	})
 }
 
 // EnsureSharedExists creates the shared-env Secret if it doesn't exist.
@@ -372,61 +331,112 @@ func (s *Store) getSecret(ctx context.Context, namespace, name string) (*corev1.
 }
 
 func (s *Store) upsertSecret(ctx context.Context, namespace, name string, vars []Env, labels map[string]string) error {
-	desired := buildSecret(namespace, name, vars, labels)
+	return s.applySecret(ctx, namespace, name, labels, func([]Env) ([]Env, error) {
+		return vars, nil
+	})
+}
 
-	var existing corev1.Secret
-	err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing)
-	if k8serrors.IsNotFound(err) {
-		if err := s.Client.Create(ctx, desired); err != nil {
-			if k8serrors.IsAlreadyExists(err) {
-				goto update
-			}
-			return fmt.Errorf("create env secret %s/%s: %w", namespace, name, err)
+// applySecret runs mutate against a fresh read of the Secret inside the
+// conflict-retry loop: every attempt re-reads the latest vars and recomputes
+// the desired set, so a retry after a conflict picks up the competing write
+// instead of clobbering it with a stale precomputed result.
+func (s *Store) applySecret(ctx context.Context, namespace, name string, labels map[string]string, mutate func(current []Env) ([]Env, error)) error {
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var existing corev1.Secret
+		getErr := s.Client.Get(ctx, key, &existing)
+		if getErr != nil && !k8serrors.IsNotFound(getErr) {
+			return fmt.Errorf("get env secret %s/%s: %w", namespace, name, getErr)
 		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("get env secret %s/%s: %w", namespace, name, err)
+
+		var current []Env
+		if getErr == nil {
+			current = secretToEnvs(&existing)
+		}
+		vars, err := mutate(current)
+		if err != nil {
+			if errors.Is(err, ErrSkip) {
+				return nil
+			}
+			return err
+		}
+		if err := validateEnvVars(vars); err != nil {
+			return err
+		}
+		desired := buildSecret(namespace, name, vars, labels)
+
+		if k8serrors.IsNotFound(getErr) {
+			if createErr := s.Client.Create(ctx, desired); createErr != nil {
+				if k8serrors.IsAlreadyExists(createErr) {
+					// Lost a create race — surface as a conflict so the retry
+					// loop re-reads and applies as an update.
+					return k8serrors.NewConflict(corev1.Resource("secrets"), name, createErr)
+				}
+				return fmt.Errorf("create env secret %s/%s: %w", namespace, name, createErr)
+			}
+			return nil
+		}
+
+		if !applyDesiredSecret(&existing, desired) {
+			return nil
+		}
+		return s.Client.Update(ctx, &existing)
+	})
+}
+
+// applyDesiredSecret copies desired data, source annotations, and labels onto
+// existing, reporting whether anything changed. Non-Mortise annotations and
+// labels on existing are preserved.
+func applyDesiredSecret(existing, desired *corev1.Secret) bool {
+	changed := false
+	if !secretDataEqual(existing.Data, desired.Data) {
+		existing.Data = desired.Data
+		changed = true
 	}
 
-update:
-	return UpdateWithConflictRetry(ctx, s.Client, types.NamespacedName{Namespace: namespace, Name: name}, func() *corev1.Secret {
-		return &corev1.Secret{}
-	}, func(existing *corev1.Secret) (bool, error) {
-		changed := false
-		if !secretDataEqual(existing.Data, desired.Data) {
-			existing.Data = desired.Data
+	if existing.Annotations == nil {
+		existing.Annotations = make(map[string]string)
+	}
+	for _, key := range []string{AnnotationBindingKeys, AnnotationGeneratedKeys, AnnotationSharedKeys} {
+		if _, ok := existing.Annotations[key]; ok {
+			delete(existing.Annotations, key)
 			changed = true
 		}
+	}
+	for k, v := range desired.Annotations {
+		if existing.Annotations[k] != v {
+			existing.Annotations[k] = v
+			changed = true
+		}
+	}
 
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string)
+	if existing.Labels == nil {
+		existing.Labels = make(map[string]string)
+	}
+	for k, v := range desired.Labels {
+		if existing.Labels[k] != v {
+			existing.Labels[k] = v
+			changed = true
 		}
-		for _, key := range []string{AnnotationBindingKeys, AnnotationGeneratedKeys, AnnotationSharedKeys} {
-			if _, ok := existing.Annotations[key]; ok {
-				delete(existing.Annotations, key)
-				changed = true
-			}
-		}
-		for k, v := range desired.Annotations {
-			if existing.Annotations[k] != v {
-				existing.Annotations[k] = v
-				changed = true
-			}
-		}
+	}
 
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string)
-		}
-		for k, v := range desired.Labels {
-			if existing.Labels[k] != v {
-				existing.Labels[k] = v
-				changed = true
-			}
-		}
+	return changed
+}
 
-		return changed, nil
-	})
+// mergeEnvs overlays vars onto current, overwriting duplicates by name.
+func mergeEnvs(current, vars []Env) []Env {
+	merged := make(map[string]Env, len(current)+len(vars))
+	for _, e := range current {
+		merged[e.Name] = e
+	}
+	for _, e := range vars {
+		merged[e.Name] = e
+	}
+	flat := make([]Env, 0, len(merged))
+	for _, e := range merged {
+		flat = append(flat, e)
+	}
+	return flat
 }
 
 func buildSecret(namespace, name string, vars []Env, extraLabels map[string]string) *corev1.Secret {

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -135,6 +135,9 @@ func (s *Store) GetShared(ctx context.Context, namespace string) ([]Env, error) 
 }
 
 // Set writes env vars to an app's env Secret, creating it if needed.
+// Set is a wholesale replace: callers must own the entire var set for this
+// Secret. It is only safe while no partial writer (Apply/Merge-based) shares
+// the Secret — a future partial co-writer would silently lose to it.
 // source indicates where the vars came from ("user", "binding", "generated").
 // If source is empty, existing source annotations for those keys are preserved.
 func (s *Store) Set(ctx context.Context, namespace, appName string, vars []Env, labels map[string]string) error {
@@ -146,6 +149,9 @@ func (s *Store) Set(ctx context.Context, namespace, appName string, vars []Env, 
 }
 
 // SetShared writes env vars to the shared-env Secret, creating it if needed.
+// SetShared is a wholesale replace under the same invariant as Set: safe only
+// while no partial writer shares the shared-env Secret (MergeSharedSource is
+// Apply-based and recomputes, so it does not conflict).
 func (s *Store) SetShared(ctx context.Context, namespace string, vars []Env, labels map[string]string) error {
 	if err := validateEnvVars(vars); err != nil {
 		return err

--- a/internal/envstore/envstore_test.go
+++ b/internal/envstore/envstore_test.go
@@ -244,6 +244,149 @@ func TestDeleteVarRetriesOnConflict(t *testing.T) {
 	}
 }
 
+func TestApplyConcurrentWritersBothSurvive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	existing := buildSecret("ns", AppEnvSecretName("app"), []Env{{Name: "FOO", Value: "1", Source: "user"}}, nil)
+	updateCalls := 0
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithInterceptorFuncs(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updateCalls++
+			if updateCalls == 1 {
+				// Simulate a second Apply landing between this writer's read
+				// and its update, then fail the stale update with a conflict.
+				competing := &Store{Client: c}
+				if err := competing.Apply(ctx, "ns", "app", nil, func(current []Env) ([]Env, error) {
+					return append(current, Env{Name: "BAZ", Value: "3", Source: "user"}), nil
+				}); err != nil {
+					return err
+				}
+				return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, obj.GetName(), errors.New("conflict"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}).Build()
+
+	store := &Store{Client: c}
+	err := store.Apply(context.Background(), "ns", "app", nil, func(current []Env) ([]Env, error) {
+		return append(current, Env{Name: "BAR", Value: "2", Source: "user"}), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(context.Background(), "ns", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, e := range got {
+		names[e.Name] = true
+	}
+	for _, want := range []string{"FOO", "BAR", "BAZ"} {
+		if !names[want] {
+			t.Errorf("expected %s to survive concurrent Apply calls, got %v", want, got)
+		}
+	}
+}
+
+func TestApplyCreatesWhenMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store := &Store{Client: c}
+	err := store.Apply(context.Background(), "ns", "app", nil, func(current []Env) ([]Env, error) {
+		if current != nil {
+			t.Errorf("expected nil current for missing secret, got %v", current)
+		}
+		return []Env{{Name: "A", Value: "1", Source: "user"}}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(context.Background(), "ns", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "A" {
+		t.Fatalf("expected [A], got %v", got)
+	}
+}
+
+func TestApplyErrSkipDoesNotCreateSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store := &Store{Client: c}
+	err := store.Apply(context.Background(), "ns", "app", nil, func(current []Env) ([]Env, error) {
+		return nil, ErrSkip
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := store.SecretExists(context.Background(), "ns", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("ErrSkip should not create the secret")
+	}
+}
+
+func TestApplyRetriesAsUpdateOnLostCreateRace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	createCalls := 0
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			createCalls++
+			if createCalls == 1 {
+				// Simulate another writer creating the secret first.
+				winner := buildSecret("ns", AppEnvSecretName("app"), []Env{{Name: "WINNER", Value: "1", Source: "user"}}, nil)
+				if err := c.Create(ctx, winner); err != nil {
+					return err
+				}
+				return apierrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "secrets"}, obj.GetName())
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}).Build()
+
+	store := &Store{Client: c}
+	err := store.Apply(context.Background(), "ns", "app", nil, func(current []Env) ([]Env, error) {
+		return append(current, Env{Name: "LOSER", Value: "2", Source: "user"}), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(context.Background(), "ns", "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, e := range got {
+		names[e.Name] = true
+	}
+	if !names["WINNER"] || !names["LOSER"] {
+		t.Fatalf("expected both writers' vars after create race, got %v", got)
+	}
+}
+
 func TestUpdateWithConflictRetryStopsWhenUnchanged(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/internal/envstore/retry.go
+++ b/internal/envstore/retry.go
@@ -3,15 +3,14 @@ package envstore
 import (
 	"context"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const maxConflictRetries = 3
-
 // UpdateWithConflictRetry re-reads the latest object and retries the update
-// when the API server rejects it with an optimistic-lock conflict.
+// when the API server rejects it with an optimistic-lock conflict. Backed by
+// retry.DefaultRetry (5 attempts with jittered backoff).
 func UpdateWithConflictRetry[T client.Object](
 	ctx context.Context,
 	c client.Client,
@@ -19,27 +18,16 @@ func UpdateWithConflictRetry[T client.Object](
 	newObject func() T,
 	mutate func(T) (bool, error),
 ) error {
-	for attempt := 0; attempt < maxConflictRetries; attempt++ {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		obj := newObject()
 		if err := c.Get(ctx, key, obj); err != nil {
 			return err
 		}
 
 		changed, err := mutate(obj)
-		if err != nil {
+		if err != nil || !changed {
 			return err
 		}
-		if !changed {
-			return nil
-		}
-
-		if err := c.Update(ctx, obj); err != nil {
-			if !apierrors.IsConflict(err) || attempt == maxConflictRetries-1 {
-				return err
-			}
-			continue
-		}
-		return nil
-	}
-	return nil
+		return c.Update(ctx, obj)
+	})
 }


### PR DESCRIPTION
## Summary

Lane G (tracker bead mo-gmu): eliminates the lost-update race on concurrent env-var writes. Every envstore mutation used to compute its desired result from a read taken **before** the conflict-retry loop — the retry's fresh Get bought only a fresh resourceVersion, so a retry after a conflict wholesale-replaced the Secret with the stale precomputed value, silently dropping the very write it had conflicted with.

- **`Store.Apply`**: a mutate-callback API generalizing the one call site that already had the correct read-modify-write idiom (`Delete`). The callback receives current vars freshly read on **every** attempt (nil when the Secret doesn't exist) and returns the full desired set. `Set`/`Merge`/`MergeShared`/`MergeSharedSource`/`ReplaceSource` are reimplemented on it; a lost create race surfaces as a conflict so the next attempt applies as an update; `ErrSkip` declines to create an empty Secret.
- **Retry policy**: `retry.DefaultRetry` (5 attempts, jittered backoff) replaces 3 attempts with none.
- **Call sites**: `PatchEnv` and `ImportEnv` pass their merge logic as the callback (envstore conflict errors map to HTTP responses); the App controller's `reconcileEnvSecret` — previously four separate racy writes (stale-spec deletes, seed merge, binding-source replace) — is now one recomputed-in-callback Apply, so a reconcile can't clobber a concurrent user PATCH or vice versa. Clone and shared-vars-replace sites keep `Set` semantics deliberately: their results don't depend on the target's current state, and `Set` itself is now conflict-safe.
- **Concurrency tests** (none existed): interceptor-injected conflicts prove two concurrent `Apply` writers both survive, a lost create race retries as an update, `ErrSkip` creates nothing, and a handler-level concurrent-PATCH test asserts no dropped keys.

## Provenance

Implementation and tests are polecat rust's (auto-saved branch `polecat/rust/mo-gmu+msmtf4wq` after a session death, pre-verification). Evaluated against the lane spec: complete and correct — every real RMW call site converted, test shapes exactly as specified. This PR is that work rebased onto current main, squashed, and verified.

## Verification

- `internal/envstore`, `internal/api`, `internal/controller` test suites green; `make ci-local` fast gates green.
- Full `make ci-local`: 5/6 green; the integration gate failed on exactly the known mo-k5p signature (`TestFromBindingProjectsNamedKey` at its ready-ceiling; 64 forbidden errors, **zero** fast-requeue lines — as expected, since this branch predates #464's classifier). This is a useful control: main-without-#464 still flakes, corroborating #464's before/after delta. Zero overlap with this diff (different failure plane entirely).

Fixes #415.