### PR TITLE
fix(controller): ownership guards on six workload adoption/update/delete paths

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -100,6 +101,14 @@ const rbacPropagationRequeue = 2 * time.Second
 // from writing into an env namespace old enough that RBAC propagation cannot
 // explain it.
 const appRBACForbiddenCondition = "RBACForbidden"
+
+// appResourceConflictCondition is set when a workload reconcile finds a
+// pre-existing resource carrying one of this App's reserved names without the
+// Mortise managed-by label. Per CLAUDE.md "Mortise owns only what it creates"
+// the reconciler refuses to adopt, update, or delete such a resource; the
+// condition makes the conflict visible on the App instead of only in operator
+// logs.
+const appResourceConflictCondition = "ResourceConflict"
 
 // AppReconciler reconciles a App object
 type AppReconciler struct {
@@ -420,10 +429,22 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		rbacForbiddenCleared = true
 	}
+	// Same for a stale ResourceConflict condition: every workload write this
+	// pass passed its ownership guard, so the foreign resource is gone.
+	resourceConflictCleared := false
+	if meta.FindStatusCondition(app.Status.Conditions, appResourceConflictCondition) != nil {
+		if err := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
+			meta.RemoveStatusCondition(&status.Conditions, appResourceConflictCondition)
+		}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("clear resource conflict condition: %w", err)
+		}
+		resourceConflictCleared = true
+	}
 
 	if !needsRequeue && (app.Status.Phase != mortisev1alpha1.AppPhaseFailed ||
 		domainCollisionCleared ||
 		rbacForbiddenCleared ||
+		resourceConflictCleared ||
 		shouldRefreshFailedAppStatus(&app, resolvedEnvs, previewEnvNames)) {
 		if err := r.updateStatus(ctx, &app, resolvedEnvs, previewEnvNames); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update status: %w", err)
@@ -446,7 +467,10 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 // envResourceError converts a failure from a per-env resource reconcile into
-// the (Result, error) pair Reconcile should return. The scoped-RBAC model
+// the (Result, error) pair Reconcile should return. An ownership-guard
+// conflict (resourceConflictError) marks the App Failed with a
+// ResourceConflict condition — it cannot resolve until the user renames or
+// deletes the foreign resource. The scoped-RBAC model
 // grants the operator write access to each pj-* namespace via a RoleBinding
 // created during namespace bootstrap, and App reconciles race that
 // propagation: a Forbidden inside a young env namespace is transient, so
@@ -455,6 +479,22 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 // misconfiguration — mark the App Failed and return the error.
 func (r *AppReconciler) envResourceError(ctx context.Context, app *mortisev1alpha1.App, envNs, envName, op string, err error) (ctrl.Result, error) {
 	wrapped := fmt.Errorf("%s for env %s: %w", op, envName, err)
+	var conflict *resourceConflictError
+	if stderrors.As(err, &conflict) {
+		if updateErr := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+			status.Phase = mortisev1alpha1.AppPhaseFailed
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:               appResourceConflictCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "ResourceConflict",
+				Message:            wrapped.Error(),
+				ObservedGeneration: app.Generation,
+			})
+		}); updateErr != nil {
+			logf.FromContext(ctx).Error(updateErr, "update status after resource conflict", "namespace", envNs)
+		}
+		return ctrl.Result{}, wrapped
+	}
 	if !errors.IsForbidden(err) {
 		return ctrl.Result{}, wrapped
 	}
@@ -1592,6 +1632,13 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		return err
 	}
 
+	// Ownership guard before the selector-mismatch delete below: a foreign
+	// Deployment's selector never matches ours, so without this check it
+	// would be deleted on sight.
+	if err := conflictIfUnmanaged(&existing, "Deployment"); err != nil {
+		return err
+	}
+
 	if deploymentSelectorMismatch(&existing, desired) {
 		if err := r.Delete(ctx, &existing); err != nil {
 			return fmt.Errorf("delete Deployment with stale selector: %w", err)
@@ -1607,6 +1654,9 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	return envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: name, Namespace: envNs}, func() *appsv1.Deployment {
 		return &appsv1.Deployment{}
 	}, func(existing *appsv1.Deployment) (bool, error) {
+		if err := conflictIfUnmanaged(existing, "Deployment"); err != nil {
+			return false, err
+		}
 		desiredAnnotations := mergeAnnotations(nil, desired.Annotations)
 		for k, v := range existing.Annotations {
 			if strings.HasPrefix(k, "deployment.kubernetes.io/") {
@@ -1843,9 +1893,16 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		return err
 	}
 
+	if err := conflictIfUnmanaged(&existing, "CronJob"); err != nil {
+		return err
+	}
+
 	return envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: name, Namespace: envNs}, func() *batchv1.CronJob {
 		return &batchv1.CronJob{}
 	}, func(existing *batchv1.CronJob) (bool, error) {
+		if err := conflictIfUnmanaged(existing, "CronJob"); err != nil {
+			return false, err
+		}
 		desiredPodAnnotations := mergeAnnotations(nil, desired.Spec.JobTemplate.Spec.Template.Annotations)
 		if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/restartedAt"]; ok {
 			desiredPodAnnotations = mergeAnnotations(desiredPodAnnotations, map[string]string{
@@ -1976,10 +2033,19 @@ func (r *AppReconciler) reconcileService(ctx context.Context, app *mortisev1alph
 		return err
 	}
 
+	// The goto path skips this guard (the racing creator may be foreign);
+	// the closure guard below re-checks against the re-fetched object.
+	if err := conflictIfUnmanaged(&existing, "Service"); err != nil {
+		return err
+	}
+
 update:
 	return envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: name, Namespace: envNs}, func() *corev1.Service {
 		return &corev1.Service{}
 	}, func(existing *corev1.Service) (bool, error) {
+		if err := conflictIfUnmanaged(existing, "Service"); err != nil {
+			return false, err
+		}
 		changed := false
 		if !equality.Semantic.DeepEqual(existing.Annotations, desired.Annotations) {
 			existing.Annotations = desired.Annotations
@@ -2100,9 +2166,16 @@ func (r *AppReconciler) reconcileIngress(ctx context.Context, app *mortisev1alph
 		return err
 	}
 
+	if err := conflictIfUnmanaged(&existing, "Ingress"); err != nil {
+		return err
+	}
+
 	return envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: name, Namespace: envNs}, func() *networkingv1.Ingress {
 		return &networkingv1.Ingress{}
 	}, func(existing *networkingv1.Ingress) (bool, error) {
+		if err := conflictIfUnmanaged(existing, "Ingress"); err != nil {
+			return false, err
+		}
 		changed := false
 		if !equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
 			existing.Spec = desired.Spec
@@ -2218,10 +2291,19 @@ func (r *AppReconciler) reconcileServiceAccount(ctx context.Context, app *mortis
 		return err
 	}
 
+	// Ownership guard: silently relabeling a foreign ServiceAccount and
+	// swapping its imagePullSecrets would redirect its pods' image pulls.
+	if err := conflictIfUnmanaged(&existing, "ServiceAccount"); err != nil {
+		return err
+	}
+
 	if !equality.Semantic.DeepEqual(existing.Labels, desired.Labels) || !imagePullSecretsEqual(existing.ImagePullSecrets, desired.ImagePullSecrets) {
 		return envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: app.Name, Namespace: envNs}, func() *corev1.ServiceAccount {
 			return &corev1.ServiceAccount{}
 		}, func(existing *corev1.ServiceAccount) (bool, error) {
+			if err := conflictIfUnmanaged(existing, "ServiceAccount"); err != nil {
+				return false, err
+			}
 			changed := false
 			if !equality.Semantic.DeepEqual(existing.Labels, desired.Labels) {
 				existing.Labels = desired.Labels
@@ -2312,10 +2394,19 @@ func (r *AppReconciler) reconcilePVCs(ctx context.Context, app *mortisev1alpha1.
 			return err
 		}
 
+		// The goto path skips this guard (the racing creator may be foreign);
+		// the closure guard below re-checks against the re-fetched object.
+		if err := conflictIfUnmanaged(&existing, "PersistentVolumeClaim"); err != nil {
+			return err
+		}
+
 	updatePVC:
 		if err := envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{Name: name, Namespace: envNs}, func() *corev1.PersistentVolumeClaim {
 			return &corev1.PersistentVolumeClaim{}
 		}, func(existing *corev1.PersistentVolumeClaim) (bool, error) {
+			if err := conflictIfUnmanaged(existing, "PersistentVolumeClaim"); err != nil {
+				return false, err
+			}
 			// PVC spec is largely immutable; only storage size can be expanded (requires bound claim + expandable SC)
 			changed := false
 			currentSize := existing.Spec.Resources.Requests[corev1.ResourceStorage]
@@ -2998,6 +3089,31 @@ func (r *AppReconciler) hashEnvSecretData(ctx context.Context, appName, envNs st
 func isMortiseManaged(obj client.Object) bool {
 	labels := obj.GetLabels()
 	return labels[envstore.ManagedByLabel] == envstore.ManagedByValue
+}
+
+// resourceConflictError reports a pre-existing resource that carries one of
+// this App's reserved names but not the Mortise managed-by label. Terminal
+// until the user renames or deletes the conflicting resource;
+// envResourceError translates it into a Failed ResourceConflict condition.
+type resourceConflictError struct {
+	kind      string
+	name      string
+	namespace string
+}
+
+func (e *resourceConflictError) Error() string {
+	return fmt.Sprintf("%s %q already exists in namespace %q and is not managed by Mortise; rename or delete it to let Mortise deploy this app", e.kind, e.name, e.namespace)
+}
+
+// conflictIfUnmanaged is the ownership guard for workload reconcile paths:
+// it returns a *resourceConflictError when obj is not Mortise-managed. Call
+// it both after the initial read AND inside the conflict-retry closure so a
+// foreign resource created between the two is still refused.
+func conflictIfUnmanaged(obj client.Object, kind string) error {
+	if isMortiseManaged(obj) {
+		return nil
+	}
+	return &resourceConflictError{kind: kind, name: obj.GetName(), namespace: obj.GetNamespace()}
 }
 
 // ensureWebhook registers a webhook on the git repo if not already done.

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -4412,6 +4412,13 @@ func (r *AppReconciler) reconcileExternalNameService(ctx context.Context, app *m
 		return err
 	}
 
+	// Ownership guard before the type-change delete below: a foreign
+	// Service is almost never ExternalName-typed, so without this check it
+	// would be deleted on sight.
+	if err := conflictIfUnmanaged(&existing, "Service"); err != nil {
+		return err
+	}
+
 	// Transitioning between Service types (e.g. ClusterIP → ExternalName)
 	// requires deleting and recreating the Service because the API server
 	// rejects updates that clear ClusterIP on a ClusterIP-type Service.

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -6412,6 +6412,45 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(got.Labels).NotTo(HaveKey("app.kubernetes.io/managed-by"))
 		})
 
+		It("does not delete a pre-existing unmanaged Service on the external-source type-change path", func() {
+			const appName = "own-guard-extsvc"
+			// A foreign ClusterIP Service: the ExternalName type-change logic
+			// would otherwise delete-and-recreate it on sight.
+			userSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName(appName),
+					Namespace: envNsProduction,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "legacy"},
+					Ports:    []corev1.ServicePort{{Name: "legacy", Port: 9999}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userSvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userSvc) }()
+
+			app := makeImageApp(appName, func(spec *mortisev1alpha1.AppSpec) {
+				spec.Source = mortisev1alpha1.AppSource{
+					Type:     mortisev1alpha1.SourceTypeExternal,
+					External: &mortisev1alpha1.ExternalSource{Host: "db.internal", Port: 5432},
+				}
+				// The ExternalName Service is only reconciled for public apps
+				// with a domain.
+				spec.Network = mortisev1alpha1.NetworkConfig{Public: true}
+				spec.Environments[0].Domain = "own-guard-extsvc.example.com"
+			})
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got corev1.Service
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName(appName), Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(got.Spec.Type).NotTo(Equal(corev1.ServiceTypeExternalName))
+			Expect(got.Spec.Selector).To(HaveKeyWithValue("app", "legacy"))
+		})
+
 		It("clears the ResourceConflict condition once the foreign resource is gone", func() {
 			const appName = "own-guard-recover"
 			userSvc := &corev1.Service{

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -6163,6 +6163,295 @@ var _ = Describe("App Controller — git source", func() {
 		})
 	})
 
+	Context("ownership guards on workload paths (#437)", func() {
+		ctx := context.Background()
+
+		makeImageApp := func(appName string, mutate func(*mortisev1alpha1.AppSpec)) *mortisev1alpha1.App {
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+					Environments: []mortisev1alpha1.Environment{
+						{Name: "production", Replicas: ptr.To[int32](1)},
+					},
+				},
+			}
+			if mutate != nil {
+				mutate(&app.Spec)
+			}
+			return app
+		}
+
+		// reconcileExpectingConflict reconciles the App, expecting the
+		// ownership guard to hard-fail and envResourceError to stamp the
+		// Failed phase + ResourceConflict condition.
+		reconcileExpectingConflict := func(appName string) {
+			GinkgoHelper()
+			r := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not managed by Mortise"))
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fresh)).To(Succeed())
+			Expect(fresh.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseFailed))
+			cond := meta.FindStatusCondition(fresh.Status.Conditions, appResourceConflictCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("ResourceConflict"))
+		}
+
+		It("does not delete a pre-existing unmanaged Deployment on selector mismatch", func() {
+			const appName = "own-guard-deploy"
+			userDep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentName(appName),
+					Namespace: envNsProduction,
+					// No managed-by label — not ours.
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](2),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "legacy"}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "legacy"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "legacy", Image: "busybox:1.36"}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userDep)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userDep) }()
+
+			app := makeImageApp(appName, nil)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			// The foreign Deployment survives with its own selector — the
+			// selector-mismatch delete must not fire on unmanaged resources.
+			var got appsv1.Deployment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName(appName), Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(got.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "legacy"))
+			Expect(got.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:1.36"))
+		})
+
+		It("does not adopt a pre-existing unmanaged CronJob", func() {
+			const appName = "own-guard-cron"
+			userCJ := &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cronJobName(appName),
+					Namespace: envNsProduction,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 0 * * *",
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RestartPolicy: corev1.RestartPolicyOnFailure,
+									Containers:    []corev1.Container{{Name: "legacy", Image: "busybox:1.36"}},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userCJ)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userCJ) }()
+
+			app := makeImageApp(appName, func(spec *mortisev1alpha1.AppSpec) {
+				spec.Kind = mortisev1alpha1.AppKindCron
+				spec.Environments[0].Schedule = "*/5 * * * *"
+			})
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got batchv1.CronJob
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cronJobName(appName), Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.Spec.Schedule).To(Equal("0 0 * * *"))
+			Expect(got.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:1.36"))
+		})
+
+		It("does not overwrite the selector and ports of a pre-existing unmanaged Service", func() {
+			const appName = "own-guard-svc"
+			userSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName(appName),
+					Namespace: envNsProduction,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "legacy"},
+					Ports:    []corev1.ServicePort{{Name: "legacy", Port: 9999}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userSvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userSvc) }()
+
+			app := makeImageApp(appName, nil)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got corev1.Service
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName(appName), Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.Spec.Selector).To(HaveKeyWithValue("app", "legacy"))
+			Expect(got.Spec.Ports[0].Port).To(Equal(int32(9999)))
+			Expect(got.Labels).NotTo(HaveKey("app.kubernetes.io/managed-by"))
+		})
+
+		It("does not redirect image pulls of a pre-existing unmanaged ServiceAccount", func() {
+			const appName = "own-guard-sa"
+			userSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: envNsProduction,
+				},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "user-pull-secret"}},
+			}
+			Expect(k8sClient.Create(ctx, userSA)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userSA) }()
+
+			app := makeImageApp(appName, nil)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got corev1.ServiceAccount
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.ImagePullSecrets).To(Equal([]corev1.LocalObjectReference{{Name: "user-pull-secret"}}))
+			Expect(got.Labels).NotTo(HaveKey("app.kubernetes.io/managed-by"))
+		})
+
+		It("does not replace the spec of a pre-existing unmanaged Ingress", func() {
+			const appName = "own-guard-ing"
+			pathType := networkingv1.PathTypePrefix
+			userIng := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ingressName(appName),
+					Namespace: envNsProduction,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "user-owned.example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path:     "/",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "user-svc",
+											Port: networkingv1.ServiceBackendPort{Number: 8080},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userIng)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userIng) }()
+
+			app := makeImageApp(appName, func(spec *mortisev1alpha1.AppSpec) {
+				spec.Network = mortisev1alpha1.NetworkConfig{Public: true}
+				spec.Environments[0].Domain = "own-guard-ing.example.com"
+			})
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got networkingv1.Ingress
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ingressName(appName), Namespace: envNsProduction}, &got)).To(Succeed())
+			Expect(got.Spec.Rules[0].Host).To(Equal("user-owned.example.com"))
+			Expect(got.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name).To(Equal("user-svc"))
+		})
+
+		It("does not resize or relabel a pre-existing unmanaged PVC", func() {
+			const appName = "own-guard-pvc"
+			pvcNm := pvcName(appName, "data")
+			userPVC := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcNm,
+					Namespace: envNsProduction,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userPVC)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, userPVC) }()
+
+			app := makeImageApp(appName, func(spec *mortisev1alpha1.AppSpec) {
+				spec.Storage = []mortisev1alpha1.VolumeSpec{
+					{Name: "data", MountPath: "/data", Size: resource.MustParse("2Gi")},
+				}
+			})
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			var got corev1.PersistentVolumeClaim
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pvcNm, Namespace: envNsProduction}, &got)).To(Succeed())
+			storageReq := got.Spec.Resources.Requests[corev1.ResourceStorage]
+			Expect(storageReq.Equal(resource.MustParse("1Gi"))).To(BeTrue())
+			Expect(got.Labels).NotTo(HaveKey("app.kubernetes.io/managed-by"))
+		})
+
+		It("clears the ResourceConflict condition once the foreign resource is gone", func() {
+			const appName = "own-guard-recover"
+			userSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName(appName),
+					Namespace: envNsProduction,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "legacy"},
+					Ports:    []corev1.ServicePort{{Name: "legacy", Port: 9999}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userSvc)).To(Succeed())
+
+			app := makeImageApp(appName, nil)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconcileExpectingConflict(appName)
+
+			// User resolves the conflict; the next pass recovers.
+			Expect(k8sClient.Delete(ctx, userSvc)).To(Succeed())
+
+			r := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &fresh)).To(Succeed())
+			Expect(meta.FindStatusCondition(fresh.Status.Conditions, appResourceConflictCondition)).To(BeNil())
+			Expect(fresh.Status.Phase).NotTo(Equal(mortisev1alpha1.AppPhaseFailed))
+
+			var svc corev1.Service
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName(appName), Namespace: envNsProduction}, &svc)).To(Succeed())
+			Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "mortise"))
+		})
+	})
+
 	Context("custom network port", func() {
 		const appName = "custom-port-app"
 		ctx := context.Background()


### PR DESCRIPTION
Completes #437 (the GC-scoping half landed in #457): the six workload adoption/update/delete paths in the App reconciler now check Mortise ownership before touching anything.

## What

- New `conflictIfUnmanaged` guard + typed `resourceConflictError`: a pre-existing resource carrying one of an App's reserved names without the `app.kubernetes.io/managed-by: mortise` label is refused — never adopted, updated, or deleted. Checked **twice** per path (after the initial read AND inside the conflict-retry closure), mirroring the ConfigMap/credentials-Secret paths that already did this correctly, so a foreign resource created between read and write is still refused.
- Guarded paths: Deployment (guard placed **before** the selector-mismatch delete — previously a foreign Deployment's non-matching selector got it deleted on sight), CronJob, Service, ServiceAccount (previously its `imagePullSecrets` could be silently swapped, redirecting a foreign workload's image pulls), Ingress (wholesale spec replace), PVC (resize + relabel).
- Conflicts surface on the App: `envResourceError` maps the typed error to `Failed` + a `ResourceConflict` condition with an actionable message (rename or delete the conflicting resource). The condition clears on the next clean pass, same pattern as `DomainCollision` and `RBACForbidden`.

## Why hard-fail instead of skip-and-log

A silent skip leaves the App half-deployed with no signal. The condition tells the user exactly which resource is in the way; deleting or renaming it un-wedges the App on the next reconcile (covered by the recovery test).

## Tests

Seven envtest specs: one per guarded path (foreign resource survives untouched, byte-for-byte assertions on the fields the old code would have destroyed, App gets `Failed` + `ResourceConflict`) plus a recovery spec (delete the foreign resource → condition clears, App proceeds, resource is recreated managed).

## Gates

`make test`, `go vet`, staticcheck v0.7.0 (CI pin), `make test-charts` — green. `make test-integration`: 54/57 pass; the 3 timeouts (`TestPreviewInheritsStagingBindings`, `TestFromBindingProjectsNamedKey`, `TestObserverTraffic`) are root-caused to a pre-existing k5p residual on main — `reconcileResolvedEnvSecrets` (git-preflight path) bypasses the #464 classifier, the 12th env-write call site (tracked as mo-tpe with operator-log evidence). The guards in this PR never fired in those runs: zero `not managed by Mortise` hits across 1340 operator log lines. This branch neither touches nor could fix that path.

Fixes mo-p2l. Ref #457, #464 (composes with the RBAC-race classifier in `envResourceError`).

Note for a follow-up (not this PR): recovery latency after the user deletes the foreign resource rides the error-backoff requeue — foreign resources carry no Mortise labels, so their deletion doesn't enqueue the App, and worst-case backoff is ~16 min. A `RequeueAfter`-style poll like `domainCollisionRequeueInterval` would bound it at a minute; noted on the bead.
