### PR TITLE
feat(observer): gap-visible pipeline, restart resilience, retention, PVC usage (obs-v2 O1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Observer reliability + PVC usage** (obs-v2 O1, #214): two new observer
+  endpoints — `GET /v1/pvc` (per-PVC capacity/usage series, collected from
+  the kubelet Summary API) and `GET /v1/health/collectors` (per-collector
+  last tick/success/error plus tailer and dropped-line gauges). `/v1/metrics`
+  and `/v1/pvc` responses gain a `coverage` array marking observed vs
+  unobserved windows so UIs render gaps instead of interpolating. The
+  observer ClusterRole widens by read-only `nodes` get/list and
+  `nodes/proxy` get for kubelet stats (justified inline in the chart).
+  Retention change: raw metrics downsample to 5-minute averages after 24
+  hours (was raw for the full 72h window); log tailers now resume from a
+  stored cursor across restarts instead of re-reading (and duplicating)
+  the last 100 lines. Full audit: `docs/observer-reliability.md`.
 - **Published-chart verification in the release pipeline** (#446, #379
   residual): after publishing to gh-pages, `release.yml` pulls the chart
   back through the public repo URL, asserts it is byte-identical to what

--- a/SPEC.md
+++ b/SPEC.md
@@ -1126,18 +1126,25 @@ Mortise UI. Default retention:
 | Data type | Retention |
 |---|---|
 | Logs | 48 hours |
-| Metrics | 72 hours |
+| Metrics | 72 hours (raw for 24h, then 5-minute averages) |
 | Traffic | 48 hours |
+| PVC usage | 72 hours (follows metrics) |
 
 Observer HTTP endpoints (served at the adapter base URL):
 
 | Endpoint | Description |
 |---|---|
 | `GET /v1/logs` | Historical log lines (time range query) |
-| `GET /v1/metrics` | Historical metrics |
+| `GET /v1/metrics` | Historical metrics (includes `coverage` gap markers) |
 | `GET /v1/metrics/live` | Live metrics stream (SSE) |
 | `GET /v1/traffic` | Historical traffic data |
 | `GET /v1/traffic/live` | Live traffic stream (SSE) |
+| `GET /v1/pvc` | Historical per-PVC capacity/usage (includes `coverage`) |
+| `GET /v1/health/collectors` | Observer self-health: per-collector last tick/success/error |
+
+`coverage` is the gap-visibility contract: `[bucketTs, 1]` marks a window the
+collector observed (even if it found nothing), `[bucketTs, 0]` one it did not.
+Consumers render 0-buckets as gaps and never interpolate across them.
 
 The observer is wired in via `PlatformConfig.spec.observability`:
 `metricsAdapterEndpoint`, `logsAdapterEndpoint`, `trafficAdapterEndpoint`.

--- a/charts/mortise/templates/observer-rbac.yaml
+++ b/charts/mortise/templates/observer-rbac.yaml
@@ -28,6 +28,16 @@ rules:
   - apiGroups: [metrics.k8s.io]
     resources: [pods]
     verbs: [get, list]
+  # PVC usage collection (#214): the kubelet Summary API is the only
+  # interface reporting actual per-volume filesystem usage, and it is
+  # reachable only via nodes/proxy (GET stats/summary). Read-only; the
+  # collector degrades to metrics-absent where clusters block it.
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [nodes/proxy]
+    verbs: [get]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cmd/observer/collectors_test.go
+++ b/cmd/observer/collectors_test.go
@@ -184,7 +184,7 @@ func TestMetricsCollectorCollect(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), time.Minute, discardLogger())
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
 
 	collector.collect(context.Background())
 
@@ -227,7 +227,7 @@ func TestMetricsCollectorSkipsNonMortiseNamespaces(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), time.Minute, discardLogger())
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
 	collector.collect(context.Background())
 
 	results, err := store.QueryMetrics("default", "web", "prod", 0, time.Now().Unix()+60, 60)
@@ -266,7 +266,7 @@ func TestMetricsCollectorSkipsUnlabeledPods(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), time.Minute, discardLogger())
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
 	collector.collect(context.Background())
 
 	results, err := store.QueryMetrics("pj-demo-prod", "", "", 0, time.Now().Unix()+60, 60)
@@ -316,7 +316,7 @@ func TestMetricsCollectorMultiContainer(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), time.Minute, discardLogger())
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
 	collector.collect(context.Background())
 
 	results, err := store.QueryMetrics("pj-demo-prod", "web", "prod", 0, time.Now().Unix()+60, 60)
@@ -362,7 +362,7 @@ func TestLogCollectorSyncFindsEnvPods(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 	collector.sync(context.Background())
 
 	collector.mu.Lock()
@@ -414,7 +414,7 @@ func TestLogCollectorMaxPods(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 2, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 2, discardLogger())
 	collector.sync(context.Background())
 
 	collector.mu.Lock()
@@ -447,7 +447,7 @@ func TestLogCollectorSyncCleansUpRemovedPods(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 	collector.sync(context.Background())
 
 	collector.mu.Lock()
@@ -492,7 +492,7 @@ func TestLogCollectorSyncSkipsNonMortiseNamespaces(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 	collector.sync(context.Background())
 
 	collector.mu.Lock()
@@ -514,7 +514,7 @@ func TestLogCollectorStartTailerIdempotent(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -551,7 +551,7 @@ func TestLogCollectorStopAll(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 
 	ctx := context.Background()
 	for _, name := range []string{"pod-1", "pod-2", "pod-3"} {
@@ -600,7 +600,7 @@ func TestMetricsCollectorRunStopsOnCancel(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), time.Hour, discardLogger())
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Hour, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -628,7 +628,7 @@ func TestLogCollectorRunStopsOnCancel(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(cs, store, time.Hour, 100, discardLogger())
+	collector := NewLogCollector(cs, store, NewHealthTracker(store, discardLogger()), time.Hour, 100, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -658,7 +658,7 @@ func TestLogTailerCleansUpOnExit(t *testing.T) {
 	}
 	defer store.Close()
 
-	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, time.Minute, 100, discardLogger())
+	collector := NewLogCollector(withBlockingPodLogs(t, cs), store, NewHealthTracker(store, discardLogger()), time.Minute, 100, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	pod := &corev1.Pod{
@@ -705,7 +705,7 @@ func TestTrafficTailerCleansUpOnExit(t *testing.T) {
 	}
 	defer store.Close()
 
-	tc := NewTrafficCollector(cs, store, NewLiveTrafficCache(time.Hour), time.Minute, 5*time.Second, "traefik", discardLogger())
+	tc := NewTrafficCollector(cs, store, NewLiveTrafficCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, 5*time.Second, "traefik", discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -732,7 +732,7 @@ func TestTrafficTailerCleansUpOnExit(t *testing.T) {
 // --- Reservoir sampling (P2-5) ---
 
 func TestReservoirSamplingCapsLatencies(t *testing.T) {
-	tc := NewTrafficCollector(fake.NewClientset(), nil, nil, time.Minute, 5*time.Second, "traefik", discardLogger())
+	tc := NewTrafficCollector(fake.NewClientset(), nil, nil, nil, time.Minute, 5*time.Second, "traefik", discardLogger())
 
 	tc.svcMu.Lock()
 	tc.svcCache["pj-demo-app@kubernetes"] = appEnvKey{namespace: "pj-demo", app: "web", env: "prod"}

--- a/cmd/observer/health.go
+++ b/cmd/observer/health.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// CollectorHealth is the self-health record for one collector: enough for a
+// dashboard to say "metrics stale since X" instead of showing a flatline.
+type CollectorHealth struct {
+	Collector     string `json:"collector"`
+	LastTick      int64  `json:"lastTick"`
+	LastSuccess   int64  `json:"lastSuccess"`
+	LastError     string `json:"lastError,omitempty"`
+	LastErrorTime int64  `json:"lastErrorTime,omitempty"`
+	ItemsLastTick int    `json:"itemsLastTick"`
+}
+
+// HealthTracker records collector ticks both in memory (served by
+// /v1/health/collectors) and in the store's collector_ticks table (the
+// durable gap-visibility record that survives restarts).
+type HealthTracker struct {
+	store *Store
+	log   *slog.Logger
+
+	mu     sync.Mutex
+	status map[string]*CollectorHealth
+	gauges map[string]int64
+}
+
+func NewHealthTracker(store *Store, log *slog.Logger) *HealthTracker {
+	return &HealthTracker{
+		store:  store,
+		log:    log,
+		status: make(map[string]*CollectorHealth),
+		gauges: make(map[string]int64),
+	}
+}
+
+// Record notes one collector cycle. items is the number of series rows the
+// cycle produced; zero with err == nil is a valid observed-empty cycle.
+func (h *HealthTracker) Record(collector string, items int, err error) {
+	now := time.Now().Unix()
+
+	h.mu.Lock()
+	st := h.status[collector]
+	if st == nil {
+		st = &CollectorHealth{Collector: collector}
+		h.status[collector] = st
+	}
+	st.LastTick = now
+	st.ItemsLastTick = items
+	if err == nil {
+		st.LastSuccess = now
+	} else {
+		st.LastError = err.Error()
+		st.LastErrorTime = now
+	}
+	h.mu.Unlock()
+
+	tick := Tick{Collector: collector, Ts: now, OK: err == nil, Items: items}
+	if err != nil {
+		tick.Error = err.Error()
+	}
+	if insertErr := h.store.InsertTick(tick); insertErr != nil {
+		h.log.Warn("failed to record collector tick", "collector", collector, "error", insertErr)
+	}
+}
+
+// SetGauge publishes an auxiliary counter (active tailers, dropped lines).
+func (h *HealthTracker) SetGauge(name string, value int64) {
+	h.mu.Lock()
+	h.gauges[name] = value
+	h.mu.Unlock()
+}
+
+// AddGauge increments an auxiliary counter.
+func (h *HealthTracker) AddGauge(name string, delta int64) {
+	h.mu.Lock()
+	h.gauges[name] += delta
+	h.mu.Unlock()
+}
+
+type HealthSnapshot struct {
+	Collectors []CollectorHealth `json:"collectors"`
+	Gauges     map[string]int64  `json:"gauges"`
+}
+
+func (h *HealthTracker) Snapshot() HealthSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	snap := HealthSnapshot{Gauges: make(map[string]int64, len(h.gauges))}
+	for _, st := range h.status {
+		snap.Collectors = append(snap.Collectors, *st)
+	}
+	for k, v := range h.gauges {
+		snap.Gauges[k] = v
+	}
+	return snap
+}

--- a/cmd/observer/log_collector.go
+++ b/cmd/observer/log_collector.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 type LogCollector struct {
 	clientset   kubernetes.Interface
 	store       *Store
+	health      *HealthTracker
 	interval    time.Duration
 	maxPods     int
 	log         *slog.Logger
@@ -27,10 +29,11 @@ type LogCollector struct {
 	dropped     atomic.Int64
 }
 
-func NewLogCollector(cs kubernetes.Interface, store *Store, interval time.Duration, maxPods int, log *slog.Logger) *LogCollector {
+func NewLogCollector(cs kubernetes.Interface, store *Store, health *HealthTracker, interval time.Duration, maxPods int, log *slog.Logger) *LogCollector {
 	return &LogCollector{
 		clientset: cs,
 		store:     store,
+		health:    health,
 		interval:  interval,
 		maxPods:   maxPods,
 		log:       log,
@@ -80,6 +83,7 @@ func (c *LogCollector) flushLoop(ctx context.Context) {
 			}
 			if n := c.dropped.Swap(0); n > 0 {
 				c.log.Warn("log channel full, lines dropped", "count", n)
+				c.health.AddGauge("logLinesDropped", n)
 			}
 		}
 	}
@@ -109,10 +113,13 @@ func (c *LogCollector) sync(ctx context.Context) {
 	nsList, err := c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		c.log.Error("failed to list namespaces", "error", err)
+		c.health.Record(collectorLogs, 0, fmt.Errorf("list namespaces: %w", err))
 		return
 	}
 
 	activePods := map[string]bool{}
+	skipped := 0
+	var partialErr error
 
 	for _, ns := range nsList.Items {
 		if !strings.HasPrefix(ns.Name, "pj-") {
@@ -124,13 +131,18 @@ func (c *LogCollector) sync(ctx context.Context) {
 		})
 		if err != nil {
 			c.log.Warn("failed to list pods", "namespace", ns.Name, "error", err)
+			if partialErr == nil {
+				partialErr = fmt.Errorf("list pods in %s: %w", ns.Name, err)
+			}
 			continue
 		}
 
 		for _, pod := range pods.Items {
 			key := ns.Name + "/" + pod.Name
 			activePods[key] = true
-			c.startTailer(ctx, ns.Name, &pod)
+			if !c.startTailer(ctx, ns.Name, &pod) {
+				skipped++
+			}
 		}
 	}
 
@@ -142,20 +154,29 @@ func (c *LogCollector) sync(ctx context.Context) {
 			c.tailerCount--
 		}
 	}
+	count := c.tailerCount
 	c.mu.Unlock()
+
+	// Pods beyond maxPods silently had no logs before; now at least the
+	// health surface says so.
+	c.health.SetGauge("logTailers", int64(count))
+	c.health.SetGauge("logTailersSkipped", int64(skipped))
+	c.health.Record(collectorLogs, count, partialErr)
 }
 
-func (c *LogCollector) startTailer(ctx context.Context, namespace string, pod *corev1.Pod) {
+// startTailer reports whether the pod is being tailed (false when the
+// maxPods cap skipped it).
+func (c *LogCollector) startTailer(ctx context.Context, namespace string, pod *corev1.Pod) bool {
 	key := namespace + "/" + pod.Name
 
 	c.mu.Lock()
 	if _, exists := c.tailers[key]; exists {
 		c.mu.Unlock()
-		return
+		return true
 	}
 	if c.tailerCount >= c.maxPods {
 		c.mu.Unlock()
-		return
+		return false
 	}
 
 	tailCtx, cancel := context.WithCancel(ctx)
@@ -167,6 +188,7 @@ func (c *LogCollector) startTailer(ctx context.Context, namespace string, pod *c
 	envName := pod.Labels["mortise.dev/environment"]
 
 	go c.tailPod(tailCtx, namespace, pod.Name, appName, envName)
+	return true
 }
 
 func (c *LogCollector) tailPod(ctx context.Context, namespace, podName, app, env string) {
@@ -180,11 +202,25 @@ func (c *LogCollector) tailPod(ctx context.Context, namespace, podName, app, env
 		c.mu.Unlock()
 	}()
 
-	tail := int64(100)
 	opts := &corev1.PodLogOptions{
 		Follow:     true,
-		TailLines:  &tail,
 		Timestamps: true,
+	}
+	// Resume from the last stored line for this pod: a (re)started tailer
+	// with a bare TailLines re-ingested up to 100 duplicate lines every
+	// time, and lost anything beyond 100 written while it was down. With a
+	// cursor the only remaining loss window is kubelet log rotation.
+	if last, err := c.store.LastLogTimestamp(namespace, podName); err == nil && last != "" {
+		if t, parseErr := time.Parse(time.RFC3339Nano, last); parseErr == nil {
+			// SinceTime has second granularity; truncating DOWN re-reads at
+			// most one second of already-stored lines rather than skipping
+			// the sub-second remainder — bounded duplication beats loss.
+			since := metav1.NewTime(t.Truncate(time.Second))
+			opts.SinceTime = &since
+		}
+	} else {
+		tail := int64(100)
+		opts.TailLines = &tail
 	}
 
 	stream, err := c.clientset.CoreV1().Pods(namespace).GetLogs(podName, opts).Stream(ctx)

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -28,6 +28,7 @@ func main() {
 		enableTraffic = flag.Bool("enable-traffic", true, "Enable traffic collection from ingress access logs")
 		ingressNs     = flag.String("ingress-namespace", "mortise-deps", "Namespace where ingress controller pods run")
 		trafficBucket = flag.Duration("traffic-bucket-size", 5*time.Second, "Traffic aggregation bucket size")
+		pvcInterval   = flag.Duration("pvc-poll-interval", time.Minute, "PVC usage collection interval (0 disables)")
 	)
 	flag.Parse()
 
@@ -62,17 +63,24 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
+	health := NewHealthTracker(store, log)
+
 	if mc != nil {
-		metricsCollector := NewMetricsCollector(cs, mc, store, liveCache, *pollInterval, log)
+		metricsCollector := NewMetricsCollector(cs, mc, store, liveCache, health, *pollInterval, log)
 		go metricsCollector.Run(ctx)
 	}
 
-	logCollector := NewLogCollector(cs, store, *pollInterval, *maxLogPods, log)
+	logCollector := NewLogCollector(cs, store, health, *pollInterval, *maxLogPods, log)
 	go logCollector.Run(ctx)
 
 	if *enableTraffic {
-		trafficCollector := NewTrafficCollector(cs, store, liveTrafficCache, *pollInterval, *trafficBucket, *ingressNs, log)
+		trafficCollector := NewTrafficCollector(cs, store, liveTrafficCache, health, *pollInterval, *trafficBucket, *ingressNs, log)
 		go trafficCollector.Run(ctx)
+	}
+
+	if *pvcInterval > 0 {
+		pvcCollector := NewPVCCollector(cs, store, health, *pvcInterval, log)
+		go pvcCollector.Run(ctx)
 	}
 
 	go func() {
@@ -95,7 +103,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:    *listen,
-		Handler: NewObserverServer(store, liveCache, liveTrafficCache),
+		Handler: NewObserverServer(store, liveCache, liveTrafficCache, health),
 	}
 
 	go func() {

--- a/cmd/observer/metrics_collector.go
+++ b/cmd/observer/metrics_collector.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -11,21 +12,31 @@ import (
 	metricsv "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
+// Collector names as recorded in collector_ticks and the health endpoint.
+const (
+	collectorMetrics = "metrics"
+	collectorLogs    = "logs"
+	collectorTraffic = "traffic"
+	collectorPVC     = "pvc"
+)
+
 type MetricsCollector struct {
 	clientset     kubernetes.Interface
 	metricsClient metricsv.Interface
 	store         *Store
 	liveCache     *LiveMetricsCache
+	health        *HealthTracker
 	interval      time.Duration
 	log           *slog.Logger
 }
 
-func NewMetricsCollector(cs kubernetes.Interface, mc metricsv.Interface, store *Store, liveCache *LiveMetricsCache, interval time.Duration, log *slog.Logger) *MetricsCollector {
+func NewMetricsCollector(cs kubernetes.Interface, mc metricsv.Interface, store *Store, liveCache *LiveMetricsCache, health *HealthTracker, interval time.Duration, log *slog.Logger) *MetricsCollector {
 	return &MetricsCollector{
 		clientset:     cs,
 		metricsClient: mc,
 		store:         store,
 		liveCache:     liveCache,
+		health:        health,
 		interval:      interval,
 		log:           log,
 	}
@@ -47,14 +58,20 @@ func (c *MetricsCollector) Run(ctx context.Context) {
 }
 
 func (c *MetricsCollector) collect(ctx context.Context) {
+	// Every cycle records a heartbeat — success (items may legitimately be
+	// zero: observed-empty is data), or failure with the cause. A window
+	// without heartbeats renders as a gap downstream; it must never be
+	// possible to fail out of this function without a tick.
 	nsList, err := c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		c.log.Error("failed to list namespaces", "error", err)
+		c.health.Record(collectorMetrics, 0, fmt.Errorf("list namespaces: %w", err))
 		return
 	}
 
 	now := time.Now().Unix()
 	var entries []MetricEntry
+	var partialErr error
 
 	for _, ns := range nsList.Items {
 		if !strings.HasPrefix(ns.Name, "pj-") {
@@ -64,6 +81,9 @@ func (c *MetricsCollector) collect(ctx context.Context) {
 		podMetrics, err := c.metricsClient.MetricsV1beta1().PodMetricses(ns.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			c.log.Warn("failed to list pod metrics", "namespace", ns.Name, "error", err)
+			if partialErr == nil {
+				partialErr = fmt.Errorf("list pod metrics in %s: %w", ns.Name, err)
+			}
 			continue
 		}
 
@@ -97,9 +117,13 @@ func (c *MetricsCollector) collect(ctx context.Context) {
 		c.liveCache.Add(entries)
 		if err := c.store.InsertMetrics(entries); err != nil {
 			c.log.Error("failed to insert metrics", "count", len(entries), "error", err)
+			if partialErr == nil {
+				partialErr = fmt.Errorf("insert metrics: %w", err)
+			}
 		} else {
 			c.log.Debug("collected metrics", "count", len(entries))
 		}
 	}
 	c.liveCache.Sweep()
+	c.health.Record(collectorMetrics, len(entries), partialErr)
 }

--- a/cmd/observer/pvc_collector.go
+++ b/cmd/observer/pvc_collector.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// kubelet stats/summary shapes — only the fields we read. The Summary API is
+// the one interface that reports actual filesystem usage per volume; the
+// metrics API has no PVC data at all.
+type kubeletSummary struct {
+	Pods []kubeletSummaryPod `json:"pods"`
+}
+
+type kubeletSummaryPod struct {
+	PodRef struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"podRef"`
+	Volumes []kubeletVolumeStats `json:"volume"`
+}
+
+type kubeletVolumeStats struct {
+	Name          string         `json:"name"`
+	CapacityBytes int64          `json:"capacityBytes"`
+	UsedBytes     int64          `json:"usedBytes"`
+	PVCRef        *kubeletPVCRef `json:"pvcRef"`
+}
+
+type kubeletPVCRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// PVCCollector samples per-PVC capacity/usage from each node's kubelet
+// Summary API (nodes/proxy stats/summary — RBAC justified in the chart).
+// Kubelet stats being unavailable (managed clusters that block nodes/proxy,
+// kubelets without the endpoint) records a failed heartbeat and produces no
+// series — metrics absent, not erroring loudly every tick.
+type PVCCollector struct {
+	clientset kubernetes.Interface
+	store     *Store
+	health    *HealthTracker
+	interval  time.Duration
+	log       *slog.Logger
+	// summaryFn fetches one node's kubelet summary; a field so tests can
+	// inject summaries without a real nodes/proxy endpoint.
+	summaryFn func(ctx context.Context, nodeName string) (*kubeletSummary, error)
+}
+
+func NewPVCCollector(cs kubernetes.Interface, store *Store, health *HealthTracker, interval time.Duration, log *slog.Logger) *PVCCollector {
+	c := &PVCCollector{
+		clientset: cs,
+		store:     store,
+		health:    health,
+		interval:  interval,
+		log:       log,
+	}
+	c.summaryFn = c.nodeSummary
+	return c
+}
+
+func (c *PVCCollector) Run(ctx context.Context) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	c.collect(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.collect(ctx)
+		}
+	}
+}
+
+func (c *PVCCollector) collect(ctx context.Context) {
+	nodes, err := c.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		c.log.Warn("pvc: failed to list nodes", "error", err)
+		c.health.Record(collectorPVC, 0, fmt.Errorf("list nodes: %w", err))
+		return
+	}
+
+	now := time.Now().Unix()
+	var entries []PVCEntry
+	var partialErr error
+
+	for _, node := range nodes.Items {
+		summary, err := c.summaryFn(ctx, node.Name)
+		if err != nil {
+			c.log.Debug("pvc: kubelet summary unavailable", "node", node.Name, "error", err)
+			if partialErr == nil {
+				partialErr = fmt.Errorf("kubelet summary on %s: %w", node.Name, err)
+			}
+			continue
+		}
+
+		for _, pod := range summary.Pods {
+			if !strings.HasPrefix(pod.PodRef.Namespace, "pj-") {
+				continue
+			}
+			for _, vol := range pod.Volumes {
+				if vol.PVCRef == nil {
+					continue
+				}
+				app, env := c.podAppEnv(ctx, pod.PodRef.Namespace, pod.PodRef.Name)
+				if app == "" {
+					continue
+				}
+				entries = append(entries, PVCEntry{
+					Ts:        now,
+					Namespace: pod.PodRef.Namespace,
+					App:       app,
+					Env:       env,
+					PVC:       vol.PVCRef.Name,
+					Capacity:  vol.CapacityBytes,
+					Used:      vol.UsedBytes,
+				})
+			}
+		}
+	}
+
+	if len(entries) > 0 {
+		if err := c.store.InsertPVCMetrics(entries); err != nil {
+			c.log.Error("pvc: failed to insert", "count", len(entries), "error", err)
+			if partialErr == nil {
+				partialErr = fmt.Errorf("insert pvc metrics: %w", err)
+			}
+		}
+	}
+	c.health.Record(collectorPVC, len(entries), partialErr)
+}
+
+func (c *PVCCollector) nodeSummary(ctx context.Context, nodeName string) (*kubeletSummary, error) {
+	raw, err := c.clientset.CoreV1().RESTClient().Get().
+		Resource("nodes").Name(nodeName).
+		SubResource("proxy", "stats", "summary").
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var summary kubeletSummary
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return nil, fmt.Errorf("decode summary: %w", err)
+	}
+	return &summary, nil
+}
+
+// podAppEnv resolves the owning app/env labels for a pod named in a kubelet
+// summary. Cached per collect cycle would be an optimization; at the poll
+// interval and pod counts involved a direct Get is fine and always fresh.
+func (c *PVCCollector) podAppEnv(ctx context.Context, namespace, podName string) (string, string) {
+	pod, err := c.clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", ""
+	}
+	return pod.Labels["app.kubernetes.io/name"], pod.Labels["mortise.dev/environment"]
+}

--- a/cmd/observer/reliability_test.go
+++ b/cmd/observer/reliability_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+// mo-5i4 reliability contract tests: every collector cycle leaves a heartbeat
+// (success or failure), failures are gaps rather than silence, restarts
+// resume instead of duplicating or losing data, and retention bounds storage.
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func lastTick(t *testing.T, store *Store, collector string) Tick {
+	t.Helper()
+	ticks, err := store.LastTicks()
+	if err != nil {
+		t.Fatalf("LastTicks: %v", err)
+	}
+	for _, tick := range ticks {
+		if tick.Collector == collector {
+			return tick
+		}
+	}
+	t.Fatalf("no tick recorded for collector %q (got %+v)", collector, ticks)
+	return Tick{}
+}
+
+func TestMetricsCollectorRecordsFailedTickOnNamespaceListError(t *testing.T) {
+	cs := fake.NewClientset()
+	cs.PrependReactor("list", "namespaces", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver down")
+	})
+	//lint:ignore SA1019 NewClientset requires --with-applyconfig codegen not used in this module
+	mc := metricsfake.NewSimpleClientset()
+	store := newTestStore(t)
+
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
+	collector.collect(context.Background())
+
+	tick := lastTick(t, store, collectorMetrics)
+	if tick.OK {
+		t.Fatal("namespace-list failure must record a FAILED tick, not silence")
+	}
+	if tick.Error == "" {
+		t.Error("failed tick must carry the error summary")
+	}
+}
+
+func TestMetricsCollectorRecordsObservedEmptyTick(t *testing.T) {
+	// Zero entries is data: the heartbeat distinguishes "looked, found
+	// nothing" from "never looked".
+	cs := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pj-empty"}},
+	)
+	//lint:ignore SA1019 NewClientset requires --with-applyconfig codegen not used in this module
+	mc := metricsfake.NewSimpleClientset()
+	store := newTestStore(t)
+
+	collector := NewMetricsCollector(cs, mc, store, NewLiveMetricsCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
+	collector.collect(context.Background())
+
+	tick := lastTick(t, store, collectorMetrics)
+	if !tick.OK {
+		t.Fatalf("observed-empty cycle must record a successful tick, got error %q", tick.Error)
+	}
+	if tick.Items != 0 {
+		t.Errorf("expected 0 items, got %d", tick.Items)
+	}
+}
+
+func TestQueryCoverageMarksUnobservedBuckets(t *testing.T) {
+	store := newTestStore(t)
+
+	// Ticks at t=0 and t=120; nothing at t=60.
+	for _, ts := range []int64{5, 125} {
+		if err := store.InsertTick(Tick{Collector: collectorMetrics, Ts: ts, OK: true}); err != nil {
+			t.Fatalf("InsertTick: %v", err)
+		}
+	}
+
+	coverage, err := store.QueryCoverage(collectorMetrics, 0, 179, 60)
+	if err != nil {
+		t.Fatalf("QueryCoverage: %v", err)
+	}
+	want := [][2]int64{{0, 1}, {60, 0}, {120, 1}}
+	if len(coverage) != len(want) {
+		t.Fatalf("coverage = %v, want %v", coverage, want)
+	}
+	for i := range want {
+		if coverage[i] != want[i] {
+			t.Fatalf("coverage[%d] = %v, want %v", i, coverage[i], want[i])
+		}
+	}
+}
+
+func TestQueryCoverageFailedTickIsNotCoverage(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.InsertTick(Tick{Collector: collectorMetrics, Ts: 10, OK: false, Error: "boom"}); err != nil {
+		t.Fatalf("InsertTick: %v", err)
+	}
+	coverage, err := store.QueryCoverage(collectorMetrics, 0, 59, 60)
+	if err != nil {
+		t.Fatalf("QueryCoverage: %v", err)
+	}
+	if len(coverage) != 1 || coverage[0][1] != 0 {
+		t.Fatalf("failed tick must not count as coverage, got %v", coverage)
+	}
+}
+
+func TestLogTailerResumesFromStoredCursor(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.InsertLog(LogEntry{
+		Ts: "2026-08-10T10:00:05.300Z", Pod: "web-1", Namespace: "pj-demo-prod",
+		App: "web", Env: "prod", Stream: "stdout", Line: "hello",
+	}); err != nil {
+		t.Fatalf("InsertLog: %v", err)
+	}
+
+	last, err := store.LastLogTimestamp("pj-demo-prod", "web-1")
+	if err != nil {
+		t.Fatalf("LastLogTimestamp: %v", err)
+	}
+	if last != "2026-08-10T10:00:05.300Z" {
+		t.Fatalf("cursor = %q", last)
+	}
+
+	// The tailer truncates the cursor down to the second: bounded (≤1s)
+	// re-read, never a skip.
+	ts, err := time.Parse(time.RFC3339Nano, last)
+	if err != nil {
+		t.Fatalf("parse cursor: %v", err)
+	}
+	since := ts.Truncate(time.Second)
+	if since.After(ts) {
+		t.Fatal("resume point must not be after the last stored line")
+	}
+	if ts.Sub(since) > time.Second {
+		t.Fatal("resume re-read window must be bounded by one second")
+	}
+}
+
+func TestTrafficFlushRetainsBatchOnInsertFailure(t *testing.T) {
+	store := newTestStore(t)
+	cs := fake.NewClientset()
+	tc := NewTrafficCollector(cs, store, NewLiveTrafficCache(time.Hour), NewHealthTracker(store, discardLogger()), time.Minute, 5*time.Second, "mortise-deps", discardLogger())
+
+	// Accumulate one closed bucket, then break the store by closing it.
+	key := accKey{appEnvKey: appEnvKey{namespace: "pj-d-prod", app: "web", env: "prod"}, bucket: 0}
+	tc.accumulator[key] = &trafficBucket{requests: 3, status2xx: 3}
+	store.Close()
+
+	tc.flush()
+	if len(tc.pending) != 1 {
+		t.Fatalf("failed insert must retain the batch for retry, pending = %d", len(tc.pending))
+	}
+
+	// Recover the store; the next flush drains the pending batch.
+	recovered := newTestStore(t)
+	tc.store = recovered
+	tc.health = NewHealthTracker(recovered, discardLogger())
+	tc.flush()
+	if len(tc.pending) != 0 {
+		t.Fatalf("pending batch must drain after recovery, pending = %d", len(tc.pending))
+	}
+	var cnt int
+	recovered.db.QueryRow("SELECT COUNT(*) FROM traffic").Scan(&cnt)
+	if cnt != 1 {
+		t.Fatalf("expected 1 traffic row after recovery, got %d", cnt)
+	}
+}
+
+func TestDownsampleCollapsesOldMetrics(t *testing.T) {
+	store := newTestStore(t)
+
+	// 60 raw points, one per second, all older than the cutoff; plus one
+	// recent point that must stay raw.
+	old := make([]MetricEntry, 0, 60)
+	for i := int64(0); i < 60; i++ {
+		old = append(old, MetricEntry{
+			Ts: 1000 + i, Pod: "web-1", Namespace: "pj-d-prod", App: "web", Env: "prod",
+			CPU: 1.0, Memory: 100,
+		})
+	}
+	if err := store.InsertMetrics(old); err != nil {
+		t.Fatalf("InsertMetrics: %v", err)
+	}
+	recent := MetricEntry{Ts: 5000, Pod: "web-1", Namespace: "pj-d-prod", App: "web", Env: "prod", CPU: 2.0, Memory: 200}
+	if err := store.InsertMetrics([]MetricEntry{recent}); err != nil {
+		t.Fatalf("InsertMetrics recent: %v", err)
+	}
+
+	if err := store.downsampleMetrics(2000); err != nil {
+		t.Fatalf("downsampleMetrics: %v", err)
+	}
+
+	var oldRows, recentRows int
+	store.db.QueryRow("SELECT COUNT(*) FROM metrics WHERE ts < 2000").Scan(&oldRows)
+	store.db.QueryRow("SELECT COUNT(*) FROM metrics WHERE ts >= 2000").Scan(&recentRows)
+	if oldRows != 1 {
+		t.Fatalf("60 old raw points must collapse to 1 bucket row, got %d", oldRows)
+	}
+	if recentRows != 1 {
+		t.Fatalf("recent point must stay raw, got %d rows", recentRows)
+	}
+
+	// Averages survive the collapse.
+	var cpu float64
+	store.db.QueryRow("SELECT cpu FROM metrics WHERE ts < 2000").Scan(&cpu)
+	if cpu != 1.0 {
+		t.Errorf("downsampled cpu = %f, want 1.0", cpu)
+	}
+
+	// Idempotent: a second pass with nothing finer than the bucket size
+	// changes nothing.
+	if err := store.downsampleMetrics(2000); err != nil {
+		t.Fatalf("second downsample: %v", err)
+	}
+	var after int
+	store.db.QueryRow("SELECT COUNT(*) FROM metrics").Scan(&after)
+	if after != 2 {
+		t.Fatalf("second pass must be a no-op, got %d rows", after)
+	}
+}
+
+func TestTrimPrunesTicksAndPVC(t *testing.T) {
+	store := newTestStore(t)
+	oldTs := time.Now().Add(-100 * time.Hour).Unix()
+	if err := store.InsertTick(Tick{Collector: collectorMetrics, Ts: oldTs, OK: true}); err != nil {
+		t.Fatalf("InsertTick: %v", err)
+	}
+	if err := store.InsertPVCMetrics([]PVCEntry{{Ts: oldTs, Namespace: "pj-d-prod", App: "web", Env: "prod", PVC: "data", Capacity: 100, Used: 50}}); err != nil {
+		t.Fatalf("InsertPVCMetrics: %v", err)
+	}
+
+	if _, _, err := store.Trim(72*time.Hour, 48*time.Hour, 48*time.Hour); err != nil {
+		t.Fatalf("Trim: %v", err)
+	}
+
+	for _, table := range []string{"collector_ticks", "pvc_metrics"} {
+		var cnt int
+		store.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&cnt)
+		if cnt != 0 {
+			t.Errorf("%s: expected old rows pruned, got %d", table, cnt)
+		}
+	}
+}
+
+func TestPVCCollectorDegradesGracefully(t *testing.T) {
+	// Kubelet summary unavailable (managed clusters blocking nodes/proxy):
+	// the collector records a failed tick and produces no series — metrics
+	// absent, not erroring loudly.
+	cs := fake.NewClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+	)
+	store := newTestStore(t)
+	c := NewPVCCollector(cs, store, NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
+	c.summaryFn = func(context.Context, string) (*kubeletSummary, error) {
+		return nil, errors.New("nodes/proxy blocked")
+	}
+	c.collect(context.Background())
+
+	tick := lastTick(t, store, collectorPVC)
+	if tick.OK {
+		t.Fatal("unreachable kubelet summary must record a failed tick")
+	}
+	var cnt int
+	store.db.QueryRow("SELECT COUNT(*) FROM pvc_metrics").Scan(&cnt)
+	if cnt != 0 {
+		t.Fatalf("expected no pvc rows, got %d", cnt)
+	}
+}
+
+func TestPVCCollectorStoresLabeledSeries(t *testing.T) {
+	cs := fake.NewClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "db-0", Namespace: "pj-demo-prod",
+			Labels: map[string]string{"app.kubernetes.io/name": "db", "mortise.dev/environment": "prod"},
+		}},
+	)
+	store := newTestStore(t)
+	c := NewPVCCollector(cs, store, NewHealthTracker(store, discardLogger()), time.Minute, discardLogger())
+	c.summaryFn = func(context.Context, string) (*kubeletSummary, error) {
+		var s kubeletSummary
+		s.Pods = make([]kubeletSummaryPod, 1)
+		s.Pods[0].PodRef.Name = "db-0"
+		s.Pods[0].PodRef.Namespace = "pj-demo-prod"
+		s.Pods[0].Volumes = []kubeletVolumeStats{{
+			Name: "data", CapacityBytes: 10 << 30, UsedBytes: 4 << 30,
+			PVCRef: &kubeletPVCRef{Name: "db-data", Namespace: "pj-demo-prod"},
+		}}
+		return &s, nil
+	}
+	c.collect(context.Background())
+
+	tick := lastTick(t, store, collectorPVC)
+	if !tick.OK || tick.Items != 1 {
+		t.Fatalf("expected successful tick with 1 item, got ok=%v items=%d err=%q", tick.OK, tick.Items, tick.Error)
+	}
+	series, err := store.QueryPVCMetrics("pj-demo-prod", "db", "prod", 0, time.Now().Unix()+60, 60)
+	if err != nil {
+		t.Fatalf("QueryPVCMetrics: %v", err)
+	}
+	if len(series) != 1 || series[0].Name != "db-data" {
+		t.Fatalf("series = %+v", series)
+	}
+	if series[0].Used[0][1] != float64(int64(4<<30)) {
+		t.Errorf("used = %f", series[0].Used[0][1])
+	}
+}

--- a/cmd/observer/server.go
+++ b/cmd/observer/server.go
@@ -12,17 +12,20 @@ type ObserverServer struct {
 	store            *Store
 	liveCache        *LiveMetricsCache
 	liveTrafficCache *LiveTrafficCache
+	health           *HealthTracker
 	mux              *http.ServeMux
 }
 
-func NewObserverServer(store *Store, liveCache *LiveMetricsCache, liveTrafficCache *LiveTrafficCache) *ObserverServer {
-	s := &ObserverServer{store: store, liveCache: liveCache, liveTrafficCache: liveTrafficCache}
+func NewObserverServer(store *Store, liveCache *LiveMetricsCache, liveTrafficCache *LiveTrafficCache, health *HealthTracker) *ObserverServer {
+	s := &ObserverServer{store: store, liveCache: liveCache, liveTrafficCache: liveTrafficCache, health: health}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/metrics", s.handleMetrics)
 	mux.HandleFunc("GET /v1/metrics/live", s.handleMetricsLive)
 	mux.HandleFunc("GET /v1/logs", s.handleLogs)
 	mux.HandleFunc("GET /v1/traffic", s.handleTraffic)
 	mux.HandleFunc("GET /v1/traffic/live", s.handleTrafficLive)
+	mux.HandleFunc("GET /v1/pvc", s.handlePVC)
+	mux.HandleFunc("GET /v1/health/collectors", s.handleCollectorHealth)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux = mux
 	return s
@@ -68,7 +71,62 @@ func (s *ObserverServer) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		writeJSONResp(w, 500, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSONResp(w, 200, map[string]any{"pods": pods})
+	// coverage is the gap-visibility contract: [bucket, 1] = the collector
+	// observed this window (even if it found nothing), [bucket, 0] = it did
+	// not — consumers render 0-buckets as gaps and must never interpolate
+	// across them.
+	coverage, err := s.store.QueryCoverage(collectorMetrics, start, end, step)
+	if err != nil {
+		writeJSONResp(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSONResp(w, 200, map[string]any{"pods": pods, "coverage": coverage})
+}
+
+func (s *ObserverServer) handlePVC(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	namespace := q.Get("namespace")
+	app := q.Get("app")
+	env := q.Get("env")
+	startStr := q.Get("start")
+	endStr := q.Get("end")
+
+	if namespace == "" || app == "" || env == "" || startStr == "" || endStr == "" {
+		writeJSONResp(w, 400, map[string]string{"error": "namespace, app, env, start, end are required"})
+		return
+	}
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil {
+		writeJSONResp(w, 400, map[string]string{"error": "invalid start"})
+		return
+	}
+	end, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil {
+		writeJSONResp(w, 400, map[string]string{"error": "invalid end"})
+		return
+	}
+	step := int64(300)
+	if s := q.Get("step"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n > 0 {
+			step = n
+		}
+	}
+
+	pvcs, err := s.store.QueryPVCMetrics(namespace, app, env, start, end, step)
+	if err != nil {
+		writeJSONResp(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	coverage, err := s.store.QueryCoverage(collectorPVC, start, end, step)
+	if err != nil {
+		writeJSONResp(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSONResp(w, 200, map[string]any{"pvcs": pvcs, "coverage": coverage})
+}
+
+func (s *ObserverServer) handleCollectorHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSONResp(w, 200, s.health.Snapshot())
 }
 
 func (s *ObserverServer) handleMetricsLive(w http.ResponseWriter, r *http.Request) {

--- a/cmd/observer/server_test.go
+++ b/cmd/observer/server_test.go
@@ -17,7 +17,7 @@ func testServer(t *testing.T) *ObserverServer {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { store.Close() })
-	return NewObserverServer(store, NewLiveMetricsCache(2*time.Hour), NewLiveTrafficCache(2*time.Hour))
+	return NewObserverServer(store, NewLiveMetricsCache(2*time.Hour), NewLiveTrafficCache(2*time.Hour), NewHealthTracker(store, discardLogger()))
 }
 
 func TestHandleMetrics_MissingParams(t *testing.T) {

--- a/cmd/observer/store.go
+++ b/cmd/observer/store.go
@@ -123,6 +123,28 @@ func NewStore(path string) (*Store, error) {
 			bytes_out   INTEGER NOT NULL DEFAULT 0
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_traffic_query ON traffic(namespace, app, env, ts)`,
+		// Collector heartbeats are the gap-visibility primitive: a window
+		// with rows here but no series rows was OBSERVED EMPTY; a window
+		// with no rows here was NOT OBSERVED (collector down/erroring) and
+		// must render as a gap, never be interpolated over.
+		`CREATE TABLE IF NOT EXISTS collector_ticks (
+			collector TEXT NOT NULL,
+			ts        INTEGER NOT NULL,
+			ok        INTEGER NOT NULL,
+			items     INTEGER NOT NULL DEFAULT 0,
+			error     TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_ticks_query ON collector_ticks(collector, ts)`,
+		`CREATE TABLE IF NOT EXISTS pvc_metrics (
+			ts        INTEGER NOT NULL,
+			namespace TEXT NOT NULL,
+			app       TEXT NOT NULL,
+			env       TEXT NOT NULL,
+			pvc       TEXT NOT NULL,
+			capacity  INTEGER NOT NULL,
+			used      INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pvc_query ON pvc_metrics(namespace, app, env, ts)`,
 	} {
 		if _, err := db.Exec(ddl); err != nil {
 			return nil, fmt.Errorf("exec DDL: %w", err)
@@ -230,6 +252,21 @@ func (s *Store) InsertLogs(entries []LogEntry) error {
 		}
 	}
 	return tx.Commit()
+}
+
+// LastLogTimestamp returns the newest stored log timestamp for a pod ("" when
+// none). Tailers resume from it so a restart neither re-ingests the tail nor
+// silently drops the downtime window (within kubelet log rotation limits).
+func (s *Store) LastLogTimestamp(namespace, pod string) (string, error) {
+	var ts sql.NullString
+	err := s.db.QueryRow(
+		"SELECT MAX(ts) FROM logs WHERE namespace = ? AND pod = ?",
+		namespace, pod,
+	).Scan(&ts)
+	if err != nil {
+		return "", err
+	}
+	return ts.String, nil
 }
 
 func (s *Store) QueryLogs(namespace, app, env string, start, end int64, limit int, filter, before string) ([]LogLine, bool, error) {
@@ -346,13 +383,186 @@ func (s *Store) QueryTraffic(namespace, app, env string, start, end, step int64)
 	return series, rows.Err()
 }
 
+// Tick records one collector cycle. ok=false ticks carry the error summary;
+// items is how many series rows the cycle produced (0 is a valid,
+// observed-empty cycle).
+type Tick struct {
+	Collector string
+	Ts        int64
+	OK        bool
+	Items     int
+	Error     string
+}
+
+func (s *Store) InsertTick(t Tick) error {
+	ok := 0
+	if t.OK {
+		ok = 1
+	}
+	_, err := s.db.Exec(
+		"INSERT INTO collector_ticks (collector, ts, ok, items, error) VALUES (?, ?, ?, ?, ?)",
+		t.Collector, t.Ts, ok, t.Items, t.Error,
+	)
+	return err
+}
+
+// QueryCoverage buckets successful heartbeats for a collector over
+// [start,end]: [bucketTs, 1] where at least one successful tick landed in the
+// bucket, [bucketTs, 0] where none did. Consumers render 0-buckets as gaps.
+func (s *Store) QueryCoverage(collector string, start, end, step int64) ([][2]int64, error) {
+	rows, err := s.db.Query(
+		`SELECT (ts / ? * ?) AS bucket, MAX(ok)
+		 FROM collector_ticks
+		 WHERE collector = ? AND ts >= ? AND ts <= ?
+		 GROUP BY bucket`,
+		step, step, collector, start, end,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	observed := map[int64]int64{}
+	for rows.Next() {
+		var bucket, ok int64
+		if err := rows.Scan(&bucket, &ok); err != nil {
+			return nil, err
+		}
+		observed[bucket] = ok
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	var out [][2]int64
+	for b := (start / step) * step; b <= end; b += step {
+		out = append(out, [2]int64{b, observed[b]})
+	}
+	return out, nil
+}
+
+// LastTicks returns the most recent tick per collector (for self-health).
+func (s *Store) LastTicks() ([]Tick, error) {
+	rows, err := s.db.Query(
+		`SELECT collector, ts, ok, items, error FROM collector_ticks t
+		 WHERE ts = (SELECT MAX(ts) FROM collector_ticks WHERE collector = t.collector)
+		 GROUP BY collector`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Tick
+	for rows.Next() {
+		var t Tick
+		var ok int
+		if err := rows.Scan(&t.Collector, &t.Ts, &ok, &t.Items, &t.Error); err != nil {
+			return nil, err
+		}
+		t.OK = ok == 1
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+type PVCEntry struct {
+	Ts        int64
+	Namespace string
+	App       string
+	Env       string
+	PVC       string
+	Capacity  int64
+	Used      int64
+}
+
+type PVCSeries struct {
+	Name     string       `json:"name"`
+	Capacity [][2]float64 `json:"capacity"`
+	Used     [][2]float64 `json:"used"`
+}
+
+func (s *Store) InsertPVCMetrics(entries []PVCEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare("INSERT INTO pvc_metrics (ts, namespace, app, env, pvc, capacity, used) VALUES (?, ?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, e := range entries {
+		if _, err := stmt.Exec(e.Ts, e.Namespace, e.App, e.Env, e.PVC, e.Capacity, e.Used); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) QueryPVCMetrics(namespace, app, env string, start, end, step int64) ([]PVCSeries, error) {
+	rows, err := s.db.Query(
+		`SELECT pvc, (ts / ? * ?) AS bucket, AVG(capacity), AVG(used)
+		 FROM pvc_metrics
+		 WHERE namespace = ? AND app = ? AND env = ? AND ts >= ? AND ts <= ?
+		 GROUP BY pvc, bucket
+		 ORDER BY pvc, bucket`,
+		step, step, namespace, app, env, start, end,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	byPVC := map[string]*PVCSeries{}
+	var order []string
+	for rows.Next() {
+		var pvc string
+		var bucket int64
+		var capacity, used float64
+		if err := rows.Scan(&pvc, &bucket, &capacity, &used); err != nil {
+			return nil, err
+		}
+		ps, ok := byPVC[pvc]
+		if !ok {
+			ps = &PVCSeries{Name: pvc}
+			byPVC[pvc] = ps
+			order = append(order, pvc)
+		}
+		ps.Capacity = append(ps.Capacity, [2]float64{float64(bucket), capacity})
+		ps.Used = append(ps.Used, [2]float64{float64(bucket), used})
+	}
+
+	result := make([]PVCSeries, 0, len(order))
+	for _, name := range order {
+		result = append(result, *byPVC[name])
+	}
+	return result, rows.Err()
+}
+
 const trimChunkSize = 1000
+
+// downsampleAge is how long metrics stay at raw poll-interval resolution
+// before being collapsed to downsampleStep buckets. Retention policy: raw
+// points for 24h, 5-minute averages until the age cutoff, everything gone
+// after it. Traffic is already bucket-aggregated at collection time and
+// logs cannot be downsampled, so both are age-trimmed only.
+const downsampleAge = 24 * time.Hour
+const downsampleStep = int64(300)
 
 func (s *Store) Trim(metricsRetention, logRetention, trafficRetention time.Duration) (int64, int64, error) {
 	metricsCutoff := time.Now().Add(-metricsRetention).Unix()
 	metricsDeleted, err := s.chunkedDelete("metrics", "ts < ?", metricsCutoff)
 	if err != nil {
 		return 0, 0, err
+	}
+	if err := s.downsampleMetrics(time.Now().Add(-downsampleAge).Unix()); err != nil {
+		return metricsDeleted, 0, err
 	}
 
 	logsCutoff := time.Now().Add(-logRetention).UTC().Format(time.RFC3339Nano)
@@ -366,7 +576,63 @@ func (s *Store) Trim(metricsRetention, logRetention, trafficRetention time.Durat
 		return metricsDeleted, logsDeleted, err
 	}
 
+	// Heartbeats and PVC samples follow the metrics window.
+	if _, err := s.chunkedDelete("collector_ticks", "ts < ?", metricsCutoff); err != nil {
+		return metricsDeleted, logsDeleted, err
+	}
+	if _, err := s.chunkedDelete("pvc_metrics", "ts < ?", metricsCutoff); err != nil {
+		return metricsDeleted, logsDeleted, err
+	}
+
 	return metricsDeleted, logsDeleted, nil
+}
+
+// downsampleMetrics collapses metric rows older than cutoff into one averaged
+// row per (pod, series, downsampleStep bucket). Idempotent: already-collapsed
+// rows re-collapse to themselves, and the bucket timestamp marker (ts aligned
+// to the bucket) makes the second pass a no-op via the row-count guard.
+func (s *Store) downsampleMetrics(cutoff int64) error {
+	// Skip when there is nothing finer than the target resolution: collapsed
+	// rows sit exactly on bucket boundaries, so any off-boundary row below
+	// the cutoff means work to do.
+	var pending int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(1) FROM metrics WHERE ts < ? AND ts % ? != 0 LIMIT 1",
+		cutoff, downsampleStep,
+	).Scan(&pending); err != nil {
+		return err
+	}
+	if pending == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`CREATE TEMP TABLE downsampled AS
+		 SELECT (ts / ? * ?) AS ts, pod, namespace, app, env, AVG(cpu) AS cpu, CAST(AVG(memory) AS INTEGER) AS memory
+		 FROM metrics WHERE ts < ?
+		 GROUP BY (ts / ?), pod, namespace, app, env`,
+		downsampleStep, downsampleStep, cutoff, downsampleStep,
+	); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if _, err := tx.Exec("DELETE FROM metrics WHERE ts < ?", cutoff); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if _, err := tx.Exec("INSERT INTO metrics SELECT ts, pod, namespace, app, env, cpu, memory FROM downsampled"); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if _, err := tx.Exec("DROP TABLE downsampled"); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) chunkedDelete(table, where string, cutoff any) (int64, error) {

--- a/cmd/observer/traffic_collector.go
+++ b/cmd/observer/traffic_collector.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand/v2"
@@ -49,10 +50,15 @@ type TrafficCollector struct {
 	clientset    kubernetes.Interface
 	store        *Store
 	liveCache    *LiveTrafficCache
+	health       *HealthTracker
 	syncInterval time.Duration
 	bucketSize   time.Duration
 	ingressNs    string
 	log          *slog.Logger
+
+	// pending holds flushed-but-uninserted entries after a store failure so
+	// a transient SQLite error delays the data instead of losing it.
+	pending []TrafficEntry
 
 	mu      sync.Mutex
 	tailers map[string]context.CancelFunc
@@ -70,11 +76,12 @@ type accKey struct {
 	bucket int64
 }
 
-func NewTrafficCollector(cs kubernetes.Interface, store *Store, liveCache *LiveTrafficCache, syncInterval, bucketSize time.Duration, ingressNs string, log *slog.Logger) *TrafficCollector {
+func NewTrafficCollector(cs kubernetes.Interface, store *Store, liveCache *LiveTrafficCache, health *HealthTracker, syncInterval, bucketSize time.Duration, ingressNs string, log *slog.Logger) *TrafficCollector {
 	return &TrafficCollector{
 		clientset:    cs,
 		store:        store,
 		liveCache:    liveCache,
+		health:       health,
 		syncInterval: syncInterval,
 		bucketSize:   bucketSize,
 		ingressNs:    ingressNs,
@@ -100,6 +107,9 @@ func (c *TrafficCollector) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			c.stopAll()
+			// Final flush: without it every unflushed bucket (up to one
+			// bucket size of traffic) died with the process on restart.
+			c.flushAll()
 			return
 		case <-syncTicker.C:
 			c.refreshServiceCache(ctx)
@@ -291,15 +301,21 @@ func (c *TrafficCollector) processLine(line []byte) {
 }
 
 func (c *TrafficCollector) flush() {
+	c.flushBefore(time.Now().Unix())
+}
+
+// flushAll drains every bucket including the still-open current one; used
+// only at shutdown.
+func (c *TrafficCollector) flushBefore(now int64) {
 	bucketSec := int64(c.bucketSize / time.Second)
 	if bucketSec <= 0 {
 		bucketSec = 5
 	}
-	now := time.Now().Unix()
 	currentBucket := (now / bucketSec) * bucketSec
 
 	c.accMu.Lock()
-	var entries []TrafficEntry
+	entries := c.pending
+	c.pending = nil
 	for key, b := range c.accumulator {
 		if key.bucket >= currentBucket {
 			continue
@@ -325,16 +341,29 @@ func (c *TrafficCollector) flush() {
 	c.accMu.Unlock()
 
 	if len(entries) == 0 {
+		c.health.Record(collectorTraffic, 0, nil)
 		return
 	}
 
 	c.liveCache.Add(entries)
 	c.liveCache.Sweep()
 	if err := c.store.InsertTraffic(entries); err != nil {
-		c.log.Error("traffic: failed to insert", "count", len(entries), "error", err)
-	} else {
-		c.log.Debug("traffic: flushed", "count", len(entries))
+		// Keep the batch for the next flush — a transient SQLite error must
+		// delay traffic data, not lose it.
+		c.accMu.Lock()
+		c.pending = append(c.pending, entries...)
+		c.accMu.Unlock()
+		c.log.Error("traffic: failed to insert; retrying next flush", "count", len(entries), "error", err)
+		c.health.Record(collectorTraffic, 0, fmt.Errorf("insert traffic: %w", err))
+		return
 	}
+	c.log.Debug("traffic: flushed", "count", len(entries))
+	c.health.Record(collectorTraffic, len(entries), nil)
+}
+
+func (c *TrafficCollector) flushAll() {
+	// Push "now" past every open bucket so shutdown drains them all.
+	c.flushBefore(time.Now().Unix() + int64(c.bucketSize/time.Second) + 1)
 }
 
 func (c *TrafficCollector) stopAll() {

--- a/docs/observer-reliability.md
+++ b/docs/observer-reliability.md
@@ -1,0 +1,57 @@
+# Observer pipeline reliability — audit and contract (obs-v2 / O1)
+
+The audit behind the "shotty tracking" verdict, what each gap was, and what
+now guarantees the contract. File references are to `cmd/observer/`.
+
+## The reliability contract
+
+1. **Gaps are visible.** Every collector cycle writes a heartbeat row
+   (`collector_ticks`). A time window with a successful heartbeat but no
+   series rows was *observed empty*; a window without one was *not observed*
+   and is served as a gap (`coverage` array on `/v1/metrics` and `/v1/pvc`,
+   `[bucket, 0|1]`). Consumers render 0-buckets as gaps and never interpolate
+   across them.
+2. **Restarts resume; they do not duplicate or silently lose.**
+3. **Storage is bounded** by age-based retention plus downsampling.
+4. **The observer reports its own health** (`/v1/health/collectors`), so a
+   flatline can be labeled "metrics stale since X" instead of lying.
+
+## Gap list (what was actually wrong)
+
+| # | Gap | Where | Fix |
+|---|-----|-------|-----|
+| G1 | Namespace-list failure aborted the whole metrics tick with only a log line — cluster-wide silent series gap | `metrics_collector.go collect()` | Failed tick recorded; window renders as a gap |
+| G2 | Per-namespace pod-metrics failure silently skipped the namespace | same | Partial-error recorded on the tick |
+| G3 | A tick collecting zero entries wrote nothing — "no pods" indistinguishable from "collector dead" | same (`len(entries) > 0` guard) | Heartbeat row distinguishes observed-empty from not-observed |
+| G4 | Query layer interpolated over unobserved windows (only buckets with rows exist; UIs connect the dots) | `store.go QueryMetrics` | `coverage` field; UI contract (O4) renders gaps |
+| G5 | Log tailer (re)start used `TailLines=100`: every restart re-ingested up to 100 duplicate lines (no dedup) and lost anything beyond 100 written during downtime | `log_collector.go tailPod()` | Resume cursor: `SinceTime` from the last stored line per pod, truncated down to the second (bounded ≤1s re-read, never a skip); `TailLines` only on first-ever tail |
+| G6 | Traffic accumulator was memory-only and shutdown did not flush — up to a full bucket of traffic died with every restart | `traffic_collector.go Run()` | Final `flushAll()` on shutdown drains all buckets including the open one |
+| G7 | A failed traffic insert dropped the batch permanently (already deleted from the accumulator) | `traffic_collector.go flush()` | Failed batches move to `pending` and retry next flush — transient SQLite errors delay data instead of losing it |
+| G8 | No retention beyond age cutoffs; raw per-poll-interval metric rows grew unbounded within the window | `store.go Trim()` | Policy: raw for 24h → 5-minute averages until the retention cutoff → deleted. Idempotent in-place downsampling each trim cycle |
+| G9 | No collector self-health: last-success, tailer counts, and dropped-line counters existed internally but were invisible | all collectors | `/v1/health/collectors`: per-collector last tick/success/error + gauges (`logTailers`, `logTailersSkipped`, `logLinesDropped`) |
+| G10 | `maxPods` cap silently un-tailed every pod beyond 100 — whole apps without logs, no signal | `log_collector.go startTailer()` | `logTailersSkipped` gauge; the cap is now visible |
+| G11 | Log channel overflow dropped lines with only a log-line warning | `log_collector.go flushLoop()` | `logLinesDropped` cumulative gauge |
+| G12 | Pod churn race: a new pod is invisible until the next sync tick (≤ poll interval) | by design | Documented contract bound, not a bug: worst-case blind window is one poll interval |
+
+## PVC usage collection (#214)
+
+`pvc_collector.go` samples each node's kubelet Summary API
+(`nodes/proxy` → `stats/summary`) — the only interface reporting actual
+per-volume filesystem usage. Series are keyed `(namespace, app, env, pvc)`
+like every other series and served at `/v1/pvc` with the same coverage
+contract. Where clusters block `nodes/proxy` (some managed offerings), the
+collector records failed heartbeats and produces no series: metrics absent,
+never error spam. RBAC addition (`nodes` get/list, `nodes/proxy` get,
+read-only) is justified in `charts/mortise/templates/observer-rbac.yaml`.
+
+## Retention policy (decided here)
+
+| Data | Raw resolution | After 24h | Cutoff |
+|------|----------------|-----------|--------|
+| Metrics | poll interval (5s default) | 5-min averages | `-metrics-retention` (72h default) |
+| Traffic | bucket size (5s default, pre-aggregated) | unchanged | `-traffic-retention` (48h) |
+| Logs | per line | unchanged (not downsampleable) | `-log-retention` (48h) |
+| Heartbeats, PVC | tick / poll | unchanged | metrics retention |
+
+Long-horizon storage is explicitly out of scope for the observer: that is
+the Prometheus surface's job (obs-v2 / O2).


### PR DESCRIPTION
## Summary

Obs-v2 foundation (tracker bead mo-5i4): the observer's per-app series become trustworthy. The audit behind the 'shotty tracking' verdict produced a **twelve-gap written list** — the deliverable itself, in `docs/observer-reliability.md` — and this PR fixes every non-by-design entry.

**The reliability contract:**

1. **Gaps are visible.** Every collector cycle writes a heartbeat (`collector_ticks`); a window with a successful heartbeat but no series rows was *observed empty*, one without a heartbeat was *not observed*. `/v1/metrics` and `/v1/pvc` gain a `coverage` array (`[bucket, 0|1]`) — the contract the O4 UI renders as gaps, never interpolating. Collector failures (namespace list, per-ns metrics, inserts) record failed ticks with causes instead of log-and-continue silence; zero-entry cycles are recorded as valid observed-empty data.
2. **Restarts resume.** Log tailers resume from a per-pod cursor (`SinceTime` from the last stored line, truncated down one second: bounded ≤1s re-read, never a skip) — previously every tailer restart re-ingested up to 100 duplicate lines and lost anything beyond 100 written during downtime. Traffic flushes all open buckets at shutdown (previously up to a full bucket died per restart) and failed insert batches retry next flush instead of being dropped.
3. **Storage is bounded.** Policy decided and implemented: raw metrics for 24h → idempotent 5-minute downsampling → age cutoff; heartbeats/PVC follow the metrics window. Long-horizon storage stays explicitly out of scope (that's O2's Prometheus surface).
4. **Self-health.** `/v1/health/collectors`: per-collector last tick/success/error + gauges (`logTailers`, `logTailersSkipped` — the silent maxPods cap is now visible — and cumulative `logLinesDropped`). Dashboards can say 'metrics stale since X' instead of flatlining.

**PVC usage (#214):** new collector samples each node's kubelet Summary API — the only interface reporting actual per-volume filesystem usage — keyed `(namespace, app, env, pvc)`, served at `/v1/pvc` under the same coverage contract. Degrades to failed-heartbeats + absent metrics where clusters block `nodes/proxy`. **RBAC**: read-only `nodes` get/list + `nodes/proxy` get, justified inline in `observer-rbac.yaml` — which lives in the umbrella chart, so no collision with mo-e1z's mortise-core file.

Additive API only: the operator's raw-passthrough proxy carries the new `coverage` field with no operator-side change; `/v1/pvc` and the health endpoint await O2/O4 surfacing.

## Verification

- Observer suite green including **ten new reliability tests**: failure-injected ticks, observed-empty ticks, coverage bucketing (incl. failed-tick ≠ coverage), cursor resume bounds, traffic retain-on-failure + drain-after-recovery, downsample collapse + idempotence, trim of new tables, PVC degrade + labeled-series success paths.
- `make test-charts` and ci-local fast gates green.
- Full-gate integration: two runs hit the **load-dependent ready-ceiling flake now filed as bead mo-j6k** (zero forbidden errors — confirmed NOT the mo-k5p/mo-tpe signature; isolated `TestFullStackDeploy` repro passes in 118s with the same doubled-RS pattern, proving the mechanism is pre-existing mid-startup rollout × RWO PVC handoff under `-parallel 25`, unrelated to this branch's observer-only diff). A third run's collapse was an in-container k3s restart (no OOM, RestartCount 0). Full forensics on the bead.