### PR TITLE
fix(controller): classify the git-preflight env-secret path and bound the missing-namespace phase

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -101,6 +101,22 @@ const rbacPropagationRequeue = 2 * time.Second
 // explain it.
 const appRBACForbiddenCondition = "RBACForbidden"
 
+// appNamespacePendingCondition is set while an env write is denied because the
+// env namespace does not exist yet (the authorizer rejects before existence is
+// checked, so a write racing namespace bootstrap surfaces as Forbidden). Its
+// LastTransitionTime is the bound: a namespace has no age of its own to bound
+// against, so the condition's first-set time stands in for it. Past
+// namespaceCreationBudget the App goes Failed — a namespace that never
+// appears means the Project controller cannot create it, which is a genuine
+// misconfiguration, not a race.
+const appNamespacePendingCondition = "NamespacePending"
+
+// namespaceCreationBudget bounds how long an App fast-requeues on
+// Forbidden-in-a-missing-namespace before escalating. Kept separate from
+// rbacPropagationWindow (same default) because it times a different thing:
+// namespace creation by the Project controller, not authorizer propagation.
+const namespaceCreationBudget = 2 * time.Minute
+
 // AppReconciler reconciles a App object
 type AppReconciler struct {
 	client.Client
@@ -219,11 +235,15 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if r.BuildClient != nil && !r.allEnvBuildsCurrentForRevision(&app, resolvedEnvs, previewBuildIdentities) {
 			result, proceed, err := r.prepareGitSource(ctx, &app)
 			if !proceed || err != nil {
-				if syncErr := r.reconcileResolvedEnvSecrets(ctx, &app, resolvedEnvs); syncErr != nil {
+				if syncRes, syncErr := r.reconcileResolvedEnvSecrets(ctx, &app, resolvedEnvs); syncErr != nil || syncRes.RequeueAfter > 0 {
+					// A preflight error still wins the return below; the env
+					// Secret outcome is logged so it isn't silently lost.
 					if err == nil {
-						return ctrl.Result{}, syncErr
+						return syncRes, syncErr
 					}
-					log.Error(syncErr, "reconcile env secrets after git preflight failure", "app", app.Name)
+					if syncErr != nil {
+						log.Error(syncErr, "reconcile env secrets after git preflight failure", "app", app.Name)
+					}
 				}
 			}
 			if err != nil {
@@ -409,14 +429,19 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		domainCollisionCleared = true
 	}
-	// Same for a stale RBACForbidden condition: writes into every env ns
-	// succeeded this pass, so the operator's access is live again.
+	// Same for stale RBACForbidden / NamespacePending conditions: writes into
+	// every env ns succeeded this pass, so the operator's access is live and
+	// every env namespace exists.
 	rbacForbiddenCleared := false
-	if meta.FindStatusCondition(app.Status.Conditions, appRBACForbiddenCondition) != nil {
+	for _, condType := range []string{appRBACForbiddenCondition, appNamespacePendingCondition} {
+		if meta.FindStatusCondition(app.Status.Conditions, condType) == nil {
+			continue
+		}
+		cleared := condType
 		if err := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
-			meta.RemoveStatusCondition(&status.Conditions, appRBACForbiddenCondition)
+			meta.RemoveStatusCondition(&status.Conditions, cleared)
 		}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("clear rbac forbidden condition: %w", err)
+			return ctrl.Result{}, fmt.Errorf("clear %s condition: %w", cleared, err)
 		}
 		rbacForbiddenCleared = true
 	}
@@ -466,7 +491,42 @@ func (r *AppReconciler) envResourceError(ctx context.Context, app *mortisev1alph
 			// that races the Project controller's namespace bootstrap (e.g.
 			// a preview env override landing on the App before the ns is
 			// created) surfaces as Forbidden-in-a-missing-namespace. That is
-			// the earliest phase of the same propagation race — fast requeue.
+			// the earliest phase of the same propagation race — fast requeue,
+			// bounded by the NamespacePending condition's transition time
+			// (the namespace itself has no age to bound against).
+			if cond := meta.FindStatusCondition(app.Status.Conditions, appNamespacePendingCondition); cond != nil &&
+				cond.Status == metav1.ConditionTrue &&
+				r.clock().Since(cond.LastTransitionTime.Time) >= namespaceCreationBudget {
+				if updateErr := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+					status.Phase = mortisev1alpha1.AppPhaseFailed
+					meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+						Type:               appNamespacePendingCondition,
+						Status:             metav1.ConditionTrue,
+						Reason:             "NamespaceCreationTimeout",
+						Message:            fmt.Sprintf("namespace %q still absent after %s; the Project controller cannot create it — check its status and operator RBAC (%s)", envNs, namespaceCreationBudget, wrapped.Error()),
+						ObservedGeneration: app.Generation,
+					})
+				}); updateErr != nil {
+					logf.FromContext(ctx).Error(updateErr, "update status after namespace-creation timeout", "namespace", envNs)
+				}
+				return ctrl.Result{}, wrapped
+			}
+			if updateErr := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+				// SetStatusCondition only advances LastTransitionTime when
+				// Status changes, so repeated hits keep the original
+				// timestamp — that is the escalation timer. Stamped from the
+				// injected clock so tests can drive it.
+				meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+					Type:               appNamespacePendingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "NamespaceNotFound",
+					Message:            fmt.Sprintf("waiting for namespace %q to be created (%s)", envNs, op),
+					ObservedGeneration: app.Generation,
+					LastTransitionTime: metav1.NewTime(r.clock().Now()),
+				})
+			}); updateErr != nil {
+				logf.FromContext(ctx).Error(updateErr, "update status while namespace pending", "namespace", envNs)
+			}
 			logf.FromContext(ctx).Info("forbidden before env namespace exists; fast requeue",
 				"namespace", envNs, "op", op, "cause", err.Error())
 			return ctrl.Result{RequeueAfter: rbacPropagationRequeue}, nil
@@ -1450,18 +1510,26 @@ func (r *AppReconciler) setBuildFailureCondition(ctx context.Context, app *morti
 	return nil
 }
 
-func (r *AppReconciler) reconcileResolvedEnvSecrets(ctx context.Context, app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment) error {
+// reconcileResolvedEnvSecrets syncs every resolved env's Secret. It runs on
+// the git-source preflight path (bindings and shared vars must materialize
+// even when prepareGitSource says don't-proceed), which means it writes into
+// freshly bootstrapped env namespaces and races the same RBAC propagation as
+// the main env loop — so its errors route through envResourceError instead of
+// feeding the workqueue's exponential rate limiter (the 12th env-write call
+// site; the other eleven were classified when the classifier landed). A
+// non-zero RequeueAfter on the returned Result means "requeue, no error".
+func (r *AppReconciler) reconcileResolvedEnvSecrets(ctx context.Context, app *mortisev1alpha1.App, resolvedEnvs []mortisev1alpha1.Environment) (ctrl.Result, error) {
 	for i := range resolvedEnvs {
 		env := &resolvedEnvs[i]
 		envNs, err := appEnvNs(app, env.Name)
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 		if err := r.reconcileEnvSecret(ctx, app, env, envNs); err != nil {
-			return fmt.Errorf("reconcile env secret for env %s: %w", env.Name, err)
+			return r.envResourceError(ctx, app, envNs, env.Name, "reconcile env secret", err)
 		}
 	}
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, image, credentialsHash string, autoRedeploy bool) error {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -2272,6 +2272,44 @@ var _ = Describe("App Controller", func() {
 		})
 	})
 
+	Context("NamespacePending condition clearing", func() {
+		ctx := context.Background()
+
+		It("clears a stale NamespacePending condition on a clean pass", func() {
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: "ns-pending-clear", Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+					Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			// Simulate a resolved bootstrap race: the condition was set while
+			// the env namespace was missing; the namespace now exists (envtest
+			// pre-creates it), so the next pass must clear the condition.
+			app.Status.Conditions = []metav1.Condition{{
+				Type:               appNamespacePendingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "NamespaceNotFound",
+				Message:            "waiting for namespace to be created",
+				LastTransitionTime: metav1.Now(),
+			}}
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+			r := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: app.Name, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, &fresh)).To(Succeed())
+			Expect(meta.FindStatusCondition(fresh.Status.Conditions, appNamespacePendingCondition)).To(BeNil())
+		})
+	})
+
 	Context("domain collision recovery", func() {
 		ctx := context.Background()
 		const envNsStaging = "pj-default-project-staging"

--- a/internal/controller/app_forbidden_test.go
+++ b/internal/controller/app_forbidden_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 )
@@ -191,5 +193,163 @@ func TestForbiddenFastRequeueClassification(t *testing.T) {
 				t.Fatalf("RequeueAfter = %v, want %v", res.RequeueAfter, rbacPropagationRequeue)
 			}
 		})
+	}
+}
+
+// ── Phase C bound (NamespacePending) ─────────────────────────────────────
+
+func TestEnvResourceErrorMissingNamespaceSetsPendingCondition(t *testing.T) {
+	r, app, _ := forbiddenTestFixtures(t, 30*time.Second)
+
+	res, err := r.envResourceError(context.Background(), app, "pj-demo-gone", "staging", "reconcile PVCs", newForbiddenErr())
+	if err != nil {
+		t.Fatalf("expected nil error on first missing-namespace hit, got %v", err)
+	}
+	if res.RequeueAfter != rbacPropagationRequeue {
+		t.Fatalf("expected RequeueAfter %v, got %v", rbacPropagationRequeue, res.RequeueAfter)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(app), &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, appNamespacePendingCondition)
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != "NamespaceNotFound" {
+		t.Fatalf("expected NamespacePending=True/NamespaceNotFound, got %+v", cond)
+	}
+	if fresh.Status.Phase == mortisev1alpha1.AppPhaseFailed {
+		t.Fatal("first missing-namespace hit must not mark the app Failed")
+	}
+}
+
+func TestEnvResourceErrorMissingNamespaceEscalatesPastBudget(t *testing.T) {
+	r, app, _ := forbiddenTestFixtures(t, 30*time.Second)
+	ctx := context.Background()
+
+	// First hit stamps the condition.
+	if _, err := r.envResourceError(ctx, app, "pj-demo-gone", "staging", "reconcile PVCs", newForbiddenErr()); err != nil {
+		t.Fatalf("first hit: %v", err)
+	}
+	// Re-read so the reconciler sees its own condition (as a fresh reconcile would).
+	if err := r.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
+		t.Fatalf("refresh app: %v", err)
+	}
+
+	// Within budget: still a fast requeue, and the transition time survives.
+	r.Clock.(*testclock.FakeClock).Step(namespaceCreationBudget / 2)
+	res, err := r.envResourceError(ctx, app, "pj-demo-gone", "staging", "reconcile PVCs", newForbiddenErr())
+	if err != nil || res.RequeueAfter != rbacPropagationRequeue {
+		t.Fatalf("within budget: expected fast requeue, got res=%v err=%v", res, err)
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
+		t.Fatalf("refresh app: %v", err)
+	}
+
+	// Past budget: Failed + NamespaceCreationTimeout + real error.
+	r.Clock.(*testclock.FakeClock).Step(namespaceCreationBudget)
+	res, err = r.envResourceError(ctx, app, "pj-demo-gone", "staging", "reconcile PVCs", newForbiddenErr())
+	if err == nil {
+		t.Fatal("expected error once the namespace-creation budget is exhausted")
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no fast requeue past budget, got %v", res.RequeueAfter)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := r.Get(ctx, client.ObjectKeyFromObject(app), &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		t.Fatalf("expected phase Failed, got %q", fresh.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, appNamespacePendingCondition)
+	if cond == nil || cond.Reason != "NamespaceCreationTimeout" {
+		t.Fatalf("expected NamespaceCreationTimeout reason, got %+v", cond)
+	}
+}
+
+// ── mo-tpe: git-preflight env-secret path routes through the classifier ──
+
+func preflightTestFixtures(t *testing.T, nsAge time.Duration, secretErr error) (*AppReconciler, *mortisev1alpha1.App) {
+	t.Helper()
+	scheme := newForbiddenTestScheme(t)
+	now := time.Unix(1_700_000_000, 0)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "pj-demo-production",
+		CreationTimestamp: metav1.NewTime(now.Add(-nsAge)),
+	}}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "pj-demo"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeGit, Repo: "https://example.com/repo.git"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ns, app).
+		WithStatusSubresource(&mortisev1alpha1.App{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok && secretErr != nil {
+					return secretErr
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme, Clock: testclock.NewFakeClock(now)}
+	return r, app
+}
+
+func TestReconcileResolvedEnvSecretsForbiddenInYoungNamespaceFastRequeues(t *testing.T) {
+	r, app := preflightTestFixtures(t, 30*time.Second, newForbiddenErr())
+
+	res, err := r.reconcileResolvedEnvSecrets(context.Background(), app, app.Spec.Environments)
+	if err != nil {
+		t.Fatalf("expected nil error (fast requeue), got %v", err)
+	}
+	if res.RequeueAfter != rbacPropagationRequeue {
+		t.Fatalf("expected RequeueAfter %v, got %v", rbacPropagationRequeue, res.RequeueAfter)
+	}
+}
+
+func TestReconcileResolvedEnvSecretsForbiddenInOldNamespaceFailsApp(t *testing.T) {
+	r, app := preflightTestFixtures(t, rbacPropagationWindow+time.Minute, newForbiddenErr())
+
+	res, err := r.reconcileResolvedEnvSecrets(context.Background(), app, app.Spec.Environments)
+	if err == nil {
+		t.Fatal("expected error for old-namespace forbidden on the preflight path")
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no fast requeue, got %v", res.RequeueAfter)
+	}
+
+	var fresh mortisev1alpha1.App
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(app), &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseFailed {
+		t.Fatalf("expected phase Failed, got %q", fresh.Status.Phase)
+	}
+	if cond := meta.FindStatusCondition(fresh.Status.Conditions, appRBACForbiddenCondition); cond == nil {
+		t.Fatal("expected RBACForbidden condition on persistent preflight forbidden")
+	}
+}
+
+func TestReconcileResolvedEnvSecretsNonForbiddenPassesThrough(t *testing.T) {
+	cause := apierrors.NewServiceUnavailable("etcd down")
+	r, app := preflightTestFixtures(t, 30*time.Second, cause)
+
+	res, err := r.reconcileResolvedEnvSecrets(context.Background(), app, app.Spec.Environments)
+	if err == nil || !errors.Is(err, cause) {
+		t.Fatalf("expected wrapped original error, got %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no fast requeue, got %v", res.RequeueAfter)
+	}
+	// The classifier's message shape is part of the operator's log contract.
+	if !strings.Contains(err.Error(), "reconcile env secret for env production") {
+		t.Fatalf("expected preflight wrap preserved, got %q", err.Error())
 	}
 }

--- a/internal/controller/forbidden.go
+++ b/internal/controller/forbidden.go
@@ -45,7 +45,12 @@ func forbiddenFastRequeue(ctx context.Context, c client.Reader, clk clock.Clock,
 		// A Forbidden write into a namespace that doesn't exist yet is the
 		// earliest phase of the same bootstrap race: the authorizer denies
 		// before existence is checked, so this races namespace creation
-		// itself. Fast-requeue; the namespace is on its way.
+		// itself. This arm is deliberately unbounded HERE: the App
+		// controller bounds it via the NamespacePending condition in
+		// envResourceError, and the remaining callers cannot loop on it —
+		// the PE controller checks previewNamespaceNotReadyError before this
+		// classifier, and the Project controller passes a namespace it
+		// ensured earlier in the same reconcile.
 		if errors.IsNotFound(getErr) {
 			return ctrl.Result{RequeueAfter: rbacPropagationRequeue}, true
 		}


### PR DESCRIPTION
Kills the last known k5p residual and bounds the classifier's missing-namespace phase. Fixes mo-tpe. Fixes mo-4po. Ref mo-k5p.

## The 12th call site (mo-tpe)

`reconcileResolvedEnvSecrets` runs on the git-source **preflight** path — bindings and shared vars must materialize even when `prepareGitSource` says don't-proceed — which means it writes into freshly bootstrapped env namespaces and races the same RBAC propagation as the main env loop. Its errors returned plain, feeding the workqueue's exponential rate limiter: the mo-k5p compounding, alive on trees that already carried the #464 classifier (field evidence: 31 forbidden / 3 timeouts on the mo-p2l gate run, archived under `audit-2026-08-09/mo-p2l-gate/`). Its errors now route through `envResourceError` like the other eleven sites; the helper returns `(ctrl.Result, error)` and the caller preserves preflight-error-wins semantics. The existing `reconcile env secret for env X` message shape is preserved.

## Bounding phase C (mo-4po)

The missing-namespace arm fast-requeued forever: a namespace that never exists has no age to bound against, so a genuinely broken bootstrap became a silent 0.5 Hz poll with the App never reaching Failed. Now the first missing-namespace hit stamps a `NamespacePending` condition (`LastTransitionTime` from the injected clock — `meta.SetStatusCondition` otherwise stamps wall-clock, which a fake-clock test catches as a negative duration); repeated hits keep the original timestamp, which *is* the escalation timer; past `namespaceCreationBudget` (2 min — deliberately a separate constant from `rbacPropagationWindow`: it times namespace creation by the Project controller, not authorizer propagation) the App goes `Failed` with `NamespaceCreationTimeout` and an actionable message. The condition clears on the next clean pass alongside `RBACForbidden`. The shared `forbiddenFastRequeue` keeps its unbounded NotFound arm with a comment proving its remaining callers cannot loop on it (the PE controller checks `previewNamespaceNotReadyError` first; the Project controller passes a namespace it ensured in the same reconcile).

## Tests

Five new unit tests (phase-C condition set, within-budget requeue with surviving transition time, past-budget escalation, preflight young-ns fast-requeue, preflight old-ns `Failed` + `RBACForbidden`, non-forbidden passthrough pinning the message shape) plus an envtest spec for clean-pass condition clearing.

## Gates (full `make ci-local`)

unit+envtest 68s, helm lint, vet+staticcheck, ui build, **ui-e2e 137s** — all pass. Integration: 55/57, with **the fix's own signature provably dead**: all 21 forbidden events in the operator log are INFO fast-requeues (including the new preflight classification firing on a preview app), zero error-path forbidden, zero rate-limiter feeding. The two failures are pre-existing filed flakes — the known preview-webhook flake (mo-24b) and the zero-forbidden load flake crew1 just root-caused (mid-startup env-hash rollout × RWO PVC handoff under `-parallel 25`) — and **both pass in an isolated rerun (81s) on the same tree and cluster**. Gate log + forbidden-line extract archived under `audit-2026-08-09/tpe-gate/`.

Merge note: touches `envResourceError` and the clean-pass clearing block — the same regions PR #466 extends (`ResourceConflict` branch). Whichever merges second rebases trivially; the hunks are adjacent, not overlapping.
