### PR TITLE
feat(activity): measured cap raise, cursor pagination, time pruning (obs-v2 O3)

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -18,6 +18,13 @@ definitions:
         type: string
       resource:
         type: string
+      seq:
+        description: |-
+          Seq is a per-project monotonically increasing sequence number assigned
+          at append time. It makes pagination cursors stable when timestamps
+          collide. Entries written before pagination existed carry Seq 0 until
+          the one-time backfill in appendOnce assigns them positions.
+        type: integer
       ts:
         type: string
     type: object
@@ -3132,22 +3139,32 @@ paths:
       - projects
   /projects/{project}/activity:
     get:
-      description: Returns recent activity events for a project, newest first
+      description: Returns recent activity events for a project, newest first. The
+        X-Next-Cursor response header carries the cursor for the next page; pass it
+        back via the cursor query parameter. No header means no further pages.
       parameters:
       - description: Project name
         in: path
         name: project
         required: true
         type: string
-      - description: 'Max number of events (default: 100)'
+      - description: 'Max number of events per page (default: 100, max: 500)'
         in: query
         name: limit
         type: integer
+      - description: Opaque cursor from a previous page's X-Next-Cursor header
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          headers:
+            X-Next-Cursor:
+              description: Cursor for the next page; absent on the last page
+              type: string
           schema:
             items:
               $ref: '#/definitions/activity.Event'

--- a/internal/activity/configmap_store.go
+++ b/internal/activity/configmap_store.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +18,28 @@ import (
 )
 
 // Cap is the ring-buffer size: the maximum number of events kept per project.
-const Cap = 500
+//
+// The bound is the etcd object-size limit (1 MiB per ConfigMap, including
+// metadata and managedFields). Measured marshaled entry sizes (see
+// TestCapFitsEtcdBudget): a typical event is ~260 B and a worst-case entry
+// (long message, several metadata pairs) ~600 B. 2000 × 600 B ≈ 1.15 MiB
+// would not fit, so the count cap alone is not the guarantee — MaxBytes
+// below is. 2000 × ~260 B ≈ 500 KiB of typical events sits comfortably
+// under the byte budget; the count cap exists to keep pagination and
+// full-list responses bounded and predictable.
+const Cap = 2000
+
+// MaxBytes is the hard budget for the marshaled events payload: 768 KiB,
+// leaving ≥256 KiB of the 1 MiB etcd object limit for ConfigMap metadata,
+// managedFields, and future keys. Append trims oldest entries until the
+// payload fits, so pathological entry sizes degrade capacity, never writes.
+const MaxBytes = 768 * 1024
+
+// Retention is the time-based prune horizon: entries older than this are
+// dropped on append. Thirty days of history comfortably exceeds what the
+// UI rail and dashboards consume; the stdout audit stream (emitAudit)
+// remains the unbounded system of record.
+const Retention = 30 * 24 * time.Hour
 
 const (
 	configMapNamePrefix    = "activity-"
@@ -43,11 +65,20 @@ func projectNamespace(project string) string {
 // line so external log pipelines remain authoritative.
 type ConfigMapStore struct {
 	Client client.Client
+	// now is injectable for retention tests; nil means time.Now.
+	now func() time.Time
 }
 
 // NewConfigMapStore returns a ConfigMapStore backed by c.
 func NewConfigMapStore(c client.Client) *ConfigMapStore {
 	return &ConfigMapStore{Client: c}
+}
+
+func (s *ConfigMapStore) nowTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 var _ Store = (*ConfigMapStore)(nil)
@@ -65,7 +96,7 @@ func (s *ConfigMapStore) Append(ctx context.Context, e Event) error {
 		if err == nil {
 			return nil
 		}
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Namespace missing — project is mid-teardown. Not an error
 			// for the caller; stdout audit line already emitted above.
 			slog.Warn("activity: project namespace missing, skipping ConfigMap write",
@@ -74,7 +105,7 @@ func (s *ConfigMapStore) Append(ctx context.Context, e Event) error {
 			)
 			return nil
 		}
-		if !errors.IsConflict(err) {
+		if !k8serrors.IsConflict(err) {
 			return err
 		}
 		select {
@@ -95,7 +126,7 @@ func (s *ConfigMapStore) appendOnce(ctx context.Context, e Event) error {
 
 	var cm corev1.ConfigMap
 	err := s.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &cm)
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		data, mErr := marshalEvents([]Event{e})
 		if mErr != nil {
 			return mErr
@@ -121,10 +152,16 @@ func (s *ConfigMapStore) appendOnce(ctx context.Context, e Event) error {
 	if err != nil {
 		return err
 	}
+	// One-time backfill: entries from before pagination existed carry Seq 0.
+	// Assign positions once so cursors are stable across the whole buffer.
+	// Cheap (only fires while zero-seq entries exist) and idempotent.
+	backfillSeq(events)
+	e.Seq = nextSeq(events)
+	// Retention prunes only pre-existing entries: the event being appended
+	// is never dropped, whatever its stamp.
+	events = trimRetention(events, s.nowTime())
 	events = append(events, e)
-	if len(events) > Cap {
-		events = events[len(events)-Cap:]
-	}
+	events = trimSize(events)
 	data, err := marshalEvents(events)
 	if err != nil {
 		return err
@@ -134,6 +171,71 @@ func (s *ConfigMapStore) appendOnce(ctx context.Context, e Event) error {
 	}
 	cm.Data[eventsKey] = data
 	return s.Client.Update(ctx, &cm)
+}
+
+// backfillSeq assigns 1..n positions to legacy zero-seq entries, preserving
+// order and staying below any already-assigned seq.
+func backfillSeq(events []Event) {
+	needsBackfill := false
+	for i := range events {
+		if events[i].Seq == 0 {
+			needsBackfill = true
+			break
+		}
+	}
+	if !needsBackfill {
+		return
+	}
+	for i := range events {
+		if events[i].Seq == 0 {
+			events[i].Seq = int64(i + 1)
+		}
+	}
+}
+
+// nextSeq returns one past the highest seq in events (1 for an empty buffer).
+func nextSeq(events []Event) int64 {
+	var max int64
+	for i := range events {
+		if events[i].Seq > max {
+			max = events[i].Seq
+		}
+	}
+	return max + 1
+}
+
+// trimRetention drops entries older than the Retention horizon.
+func trimRetention(events []Event, now time.Time) []Event {
+	cutoff := now.Add(-Retention)
+	firstKept := 0
+	for firstKept < len(events) && events[firstKept].Timestamp.Before(cutoff) {
+		firstKept++
+	}
+	return events[firstKept:]
+}
+
+// trimSize applies the count cap, then the byte budget. Byte-trim drops
+// oldest-first until the marshaled payload fits MaxBytes, so entry size can
+// degrade capacity but never block a write.
+func trimSize(events []Event) []Event {
+	if len(events) > Cap {
+		events = events[len(events)-Cap:]
+	}
+
+	for len(events) > 1 {
+		data, err := marshalEvents(events)
+		if err != nil || len(data) <= MaxBytes {
+			break
+		}
+		// Drop the oldest ~12.5% rather than one-at-a-time: re-marshaling
+		// per dropped entry would be quadratic on pathological payloads.
+		drop := len(events) / 8
+		if drop == 0 {
+			drop = 1
+		}
+		events = events[drop:]
+	}
+	return events
 }
 
 // List returns up to limit events for project, newest first. A missing
@@ -149,7 +251,7 @@ func (s *ConfigMapStore) List(ctx context.Context, project string, limit int) ([
 		Namespace: projectNamespace(project),
 		Name:      configMapName(project),
 	}, &cm)
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return []Event{}, nil
 	}
 	if err != nil {
@@ -169,6 +271,65 @@ func (s *ConfigMapStore) List(ctx context.Context, project string, limit int) ([
 		reversed = reversed[:limit]
 	}
 	return reversed, nil
+}
+
+// ListPage returns up to limit events newest-first, starting strictly after
+// cursor (an opaque value from a previous page; "" means from the newest).
+// nextCursor is "" when the returned page reaches the oldest stored event.
+// Cursors are seq-based: stable across appends and trims because seq is
+// assigned once and never reused. A cursor older than the retention window
+// simply yields an empty final page.
+func (s *ConfigMapStore) ListPage(ctx context.Context, project string, limit int, cursor string) ([]Event, string, error) {
+	if limit <= 0 || limit > Cap {
+		limit = Cap
+	}
+
+	var before int64
+	if cursor != "" {
+		parsed, err := strconv.ParseInt(cursor, 10, 64)
+		if err != nil || parsed <= 0 {
+			return nil, "", fmt.Errorf("%w: %q", ErrBadCursor, cursor)
+		}
+		before = parsed
+	}
+
+	var cm corev1.ConfigMap
+	err := s.Client.Get(ctx, types.NamespacedName{
+		Namespace: projectNamespace(project),
+		Name:      configMapName(project),
+	}, &cm)
+	if k8serrors.IsNotFound(err) {
+		return []Event{}, "", nil
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	events, err := unmarshalEvents(cm.Data[eventsKey])
+	if err != nil {
+		return nil, "", err
+	}
+	// Reads never mutate the ConfigMap; compute cursor positions for any
+	// legacy zero-seq entries in memory the same way the write path would.
+	backfillSeq(events)
+
+	page := make([]Event, 0, limit)
+	oldestSeq := int64(0)
+	if len(events) > 0 {
+		oldestSeq = events[0].Seq
+	}
+	for i := len(events) - 1; i >= 0 && len(page) < limit; i-- {
+		if before > 0 && events[i].Seq >= before {
+			continue
+		}
+		page = append(page, events[i])
+	}
+
+	next := ""
+	if n := len(page); n > 0 && page[n-1].Seq > oldestSeq {
+		next = strconv.FormatInt(page[n-1].Seq, 10)
+	}
+	return page, next, nil
 }
 
 func marshalEvents(events []Event) (string, error) {

--- a/internal/activity/configmap_store.go
+++ b/internal/activity/configmap_store.go
@@ -173,22 +173,22 @@ func (s *ConfigMapStore) appendOnce(ctx context.Context, e Event) error {
 	return s.Client.Update(ctx, &cm)
 }
 
-// backfillSeq assigns 1..n positions to legacy zero-seq entries, preserving
-// order and staying below any already-assigned seq.
+// backfillSeq assigns sequence numbers to legacy zero-seq entries by
+// continuing the sequence seen so far in buffer order. For an all-legacy
+// buffer that yields positions 1..n. In the mixed-history edge (an operator
+// rollback appends zero-seq entries after seq-carrying ones, e.g.
+// [5,6,0,0]), the zero-seq entries were appended later — so continuing past
+// the running max ([5,6,7,8]) both preserves true recency order and makes
+// duplicate seqs impossible, which positional assignment could mint
+// ([2,3,0] must not become [2,3,3]).
 func backfillSeq(events []Event) {
-	needsBackfill := false
+	var runningMax int64
 	for i := range events {
 		if events[i].Seq == 0 {
-			needsBackfill = true
-			break
+			events[i].Seq = runningMax + 1
 		}
-	}
-	if !needsBackfill {
-		return
-	}
-	for i := range events {
-		if events[i].Seq == 0 {
-			events[i].Seq = int64(i + 1)
+		if events[i].Seq > runningMax {
+			runningMax = events[i].Seq
 		}
 	}
 }

--- a/internal/activity/configmap_store_test.go
+++ b/internal/activity/configmap_store_test.go
@@ -26,8 +26,10 @@ func newFakeClient(t *testing.T) client.Client {
 }
 
 func baseEvent(project string, i int) activity.Event {
+	// Recent, strictly ordered stamps: retention pruning (30d) must not
+	// touch fixture events.
 	return activity.Event{
-		Timestamp:    time.Unix(int64(i), 0).UTC(),
+		Timestamp:    time.Now().UTC().Add(time.Duration(i) * time.Second),
 		Actor:        "jane@example.com",
 		Action:       "app.deploy",
 		ResourceKind: "App",

--- a/internal/activity/event.go
+++ b/internal/activity/event.go
@@ -4,6 +4,11 @@ import "time"
 
 // Event is a single project-scoped audit entry. Fields mirror SPEC §5.11.
 type Event struct {
+	// Seq is a per-project monotonically increasing sequence number assigned
+	// at append time. It makes pagination cursors stable when timestamps
+	// collide. Entries written before pagination existed carry Seq 0 until
+	// the one-time backfill in appendOnce assigns them positions.
+	Seq          int64             `json:"seq,omitempty"`
 	Timestamp    time.Time         `json:"ts"`
 	Actor        string            `json:"actor"`
 	Action       string            `json:"action"`

--- a/internal/activity/option_c_test.go
+++ b/internal/activity/option_c_test.go
@@ -1,0 +1,224 @@
+package activity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// White-box tests for the Option C mechanics (#165): the etcd-budget math,
+// seq assignment/backfill, cursor pagination, retention, and byte-trim.
+
+func newStore(t *testing.T) *ConfigMapStore {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	ns := &corev1.Namespace{}
+	ns.Name = "pj-demo"
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	return NewConfigMapStore(c)
+}
+
+func recentEvent(i int, msg string) Event {
+	return Event{
+		Timestamp:    time.Now().UTC().Add(time.Duration(i) * time.Millisecond),
+		Actor:        "jane@example.com",
+		Action:       "app.deploy",
+		ResourceKind: "App",
+		ResourceName: fmt.Sprintf("app-%d", i),
+		Project:      "demo",
+		Message:      msg,
+	}
+}
+
+// TestCapFitsEtcdBudget is the measured math behind Cap and MaxBytes: a
+// buffer of Cap typical events must fit the byte budget with headroom, and
+// MaxBytes must leave >= 256 KiB of the 1 MiB etcd object limit for
+// ConfigMap metadata. If Event grows fields and typical size drifts up,
+// this fails and the constants get re-derived instead of silently lying.
+func TestCapFitsEtcdBudget(t *testing.T) {
+	typical := make([]Event, Cap)
+	for i := range typical {
+		e := recentEvent(i, "Deployed my-service to production (image sha256:0123456789abcdef)")
+		e.Seq = int64(i + 1)
+		typical[i] = e
+	}
+	data, err := marshalEvents(typical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	perEntry := len(data) / Cap
+	t.Logf("measured typical entry: %d B; %d entries: %d KiB", perEntry, Cap, len(data)/1024)
+	if len(data) > MaxBytes {
+		t.Fatalf("Cap (%d) typical events = %d B exceeds MaxBytes (%d) — re-derive the constants", Cap, len(data), MaxBytes)
+	}
+	const etcdLimit = 1024 * 1024
+	if etcdLimit-MaxBytes < 256*1024 {
+		t.Fatalf("MaxBytes (%d) leaves less than 256 KiB metadata headroom under the 1 MiB etcd limit", MaxBytes)
+	}
+}
+
+func TestAppendAssignsMonotonicSeq(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		if err := s.Append(ctx, recentEvent(i, "m")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events, err := s.List(ctx, "demo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Newest first: seqs 5..1.
+	for i, e := range events {
+		if want := int64(5 - i); e.Seq != want {
+			t.Fatalf("events[%d].Seq = %d, want %d", i, e.Seq, want)
+		}
+	}
+}
+
+func TestBackfillAssignsLegacyZeroSeq(t *testing.T) {
+	events := []Event{{Seq: 0}, {Seq: 0}, {Seq: 0}}
+	backfillSeq(events)
+	for i, e := range events {
+		if e.Seq != int64(i+1) {
+			t.Fatalf("backfill events[%d].Seq = %d, want %d", i, e.Seq, i+1)
+		}
+	}
+	if nextSeq(events) != 4 {
+		t.Fatalf("nextSeq = %d, want 4", nextSeq(events))
+	}
+}
+
+func TestListPagePaginatesStableAcrossAppends(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	for i := 0; i < 25; i++ {
+		if err := s.Append(ctx, recentEvent(i, fmt.Sprintf("m%d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, cursor, err := s.ListPage(ctx, "demo", 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1) != 10 || cursor == "" {
+		t.Fatalf("page1: %d events, cursor %q", len(page1), cursor)
+	}
+
+	// Concurrent append between pages must not shift page 2: cursors are
+	// seq-anchored, not offset-anchored.
+	if err := s.Append(ctx, recentEvent(99, "concurrent")); err != nil {
+		t.Fatal(err)
+	}
+
+	page2, cursor2, err := s.ListPage(ctx, "demo", 10, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 10 {
+		t.Fatalf("page2: %d events", len(page2))
+	}
+	if page2[0].Seq != page1[9].Seq-1 {
+		t.Fatalf("page2 must continue exactly after page1: got seq %d after %d", page2[0].Seq, page1[9].Seq)
+	}
+	seen := map[int64]bool{}
+	for _, e := range append(append([]Event{}, page1...), page2...) {
+		if seen[e.Seq] {
+			t.Fatalf("duplicate seq %d across pages", e.Seq)
+		}
+		seen[e.Seq] = true
+	}
+
+	page3, cursor3, err := s.ListPage(ctx, "demo", 10, cursor2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3) != 5 {
+		t.Fatalf("page3: %d events, want the remaining 5", len(page3))
+	}
+	if cursor3 != "" {
+		t.Fatalf("final page must return empty cursor, got %q", cursor3)
+	}
+}
+
+func TestListPageBadCursor(t *testing.T) {
+	s := newStore(t)
+	if _, _, err := s.ListPage(context.Background(), "demo", 10, "not-a-cursor"); err == nil || !strings.Contains(err.Error(), "invalid cursor") {
+		t.Fatalf("expected ErrBadCursor, got %v", err)
+	}
+}
+
+func TestRetentionPrunesOldEntriesButNeverTheAppended(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Two appends at T0.
+	base := time.Now().UTC()
+	s.now = func() time.Time { return base }
+	old1 := recentEvent(0, "old")
+	old1.Timestamp = base
+	if err := s.Append(ctx, old1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Time passes beyond the retention horizon; a new append prunes the
+	// old entries but keeps itself, even if its own stamp were stale.
+	s.now = func() time.Time { return base.Add(Retention + time.Hour) }
+	stale := recentEvent(1, "fresh-append-stale-stamp")
+	stale.Timestamp = base // deliberately ancient stamp
+	if err := s.Append(ctx, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := s.List(ctx, "demo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected only the just-appended event to survive retention, got %d", len(events))
+	}
+	if events[0].Message != "fresh-append-stale-stamp" {
+		t.Fatalf("survivor = %q", events[0].Message)
+	}
+}
+
+func TestByteBudgetTrimsOldestNeverBlocks(t *testing.T) {
+	// Entries with ~8 KiB messages: ~96 of them blow through MaxBytes long
+	// before Cap. Appends must keep succeeding while capacity degrades.
+	s := newStore(t)
+	ctx := context.Background()
+	big := strings.Repeat("x", 8*1024)
+	const n = 120
+	for i := 0; i < n; i++ {
+		if err := s.Append(ctx, recentEvent(i, big)); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	events, err := s.List(ctx, "demo", Cap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 || len(events) >= n {
+		t.Fatalf("expected byte budget to trim some but not all: kept %d of %d", len(events), n)
+	}
+	// Newest survive, oldest were dropped.
+	if events[0].Seq != int64(n) {
+		t.Fatalf("newest seq = %d, want %d", events[0].Seq, n)
+	}
+	data, err := marshalEvents(nil)
+	_ = data
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/activity/option_c_test.go
+++ b/internal/activity/option_c_test.go
@@ -99,6 +99,36 @@ func TestBackfillAssignsLegacyZeroSeq(t *testing.T) {
 	}
 }
 
+// TestBackfillMixedHistoryRollbackEdge pins the operator-rollback edge: old
+// code appended zero-seq entries after seq-carrying ones. Backfill must keep
+// buffer order as recency order (later entries get higher seqs) and must
+// never mint a duplicate seq.
+func TestBackfillMixedHistoryRollbackEdge(t *testing.T) {
+	events := []Event{{Seq: 5}, {Seq: 6}, {Seq: 0}, {Seq: 0}}
+	backfillSeq(events)
+	want := []int64{5, 6, 7, 8}
+	for i, e := range events {
+		if e.Seq != want[i] {
+			t.Fatalf("mixed backfill events[%d].Seq = %d, want %d", i, e.Seq, want[i])
+		}
+	}
+
+	// The duplicate-minting shape: positional assignment would turn
+	// [2,3,0] into [2,3,3].
+	events = []Event{{Seq: 2}, {Seq: 3}, {Seq: 0}}
+	backfillSeq(events)
+	seen := map[int64]bool{}
+	for _, e := range events {
+		if seen[e.Seq] {
+			t.Fatalf("backfill minted duplicate seq %d in %v", e.Seq, events)
+		}
+		seen[e.Seq] = true
+	}
+	if events[2].Seq != 4 {
+		t.Fatalf("trailing legacy entry seq = %d, want 4", events[2].Seq)
+	}
+}
+
 func TestListPagePaginatesStableAcrossAppends(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()

--- a/internal/activity/store.go
+++ b/internal/activity/store.go
@@ -1,9 +1,18 @@
 package activity
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrBadCursor is returned by ListPage for a cursor that is not one this
+// store produced. Handlers map it to a 400.
+var ErrBadCursor = errors.New("activity: invalid cursor")
 
 // Store is the per-project append-only activity event store. Backed by a
-// ConfigMap ring buffer in the project namespace (see SPEC §5.11).
+// ConfigMap ring buffer in the project namespace (see SPEC §5.11). The
+// interface is deliberately narrow so a future SQLite/observer-backed
+// implementation (#165 Option A) is a drop-in swap.
 type Store interface {
 	// Append adds an event to the project's ring buffer and emits a
 	// stdout audit line. Never returns an error for "ConfigMap not
@@ -15,4 +24,10 @@ type Store interface {
 	// order (newest first). Caller passes the project name. If
 	// limit <= 0 or > Cap, Cap is used.
 	List(ctx context.Context, project string, limit int) ([]Event, error)
+
+	// ListPage is List with cursor pagination: it returns up to limit
+	// events newest-first strictly after cursor ("" = from the newest)
+	// plus the cursor for the next page ("" = no more pages). Cursors
+	// are opaque to callers and stable across concurrent appends.
+	ListPage(ctx context.Context, project string, limit int, cursor string) ([]Event, string, error)
 }

--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,21 +20,31 @@ import (
 
 const (
 	defaultActivityLimit = 100
-	maxActivityLimit     = activity.Cap
+	// maxActivityLimit caps one page/response. Deliberately far below
+	// activity.Cap (2000): a full buffer is ~500 KiB of JSON — that is
+	// what cursor pagination is for.
+	maxActivityLimit = 500
 )
 
 // ListActivity returns recent project activity, newest first.
 //
-// GET /api/projects/{project}/activity?limit=100
+// GET /api/projects/{project}/activity?limit=100&cursor=...
+//
+// Pagination is cursor-based and additive: the response body stays a bare
+// array for compatibility, and the opaque cursor for the next page is
+// returned in the X-Next-Cursor response header (absent on the last page).
+// Pass it back via ?cursor= to fetch the next page.
 //
 // @Summary List project activity
-// @Description Returns recent activity events for a project, newest first
+// @Description Returns recent activity events for a project, newest first. The X-Next-Cursor response header carries the cursor for the next page; pass it back via the cursor query parameter. No header means no further pages.
 // @Tags activity
 // @Produce json
 // @Security BearerAuth
 // @Param project path string true "Project name"
-// @Param limit query integer false "Max number of events (default: 100)"
+// @Param limit query integer false "Max number of events per page (default: 100, max: 500)"
+// @Param cursor query string false "Opaque cursor from a previous page's X-Next-Cursor header"
 // @Success 200 {array} activity.Event
+// @Header 200 {string} X-Next-Cursor "Cursor for the next page; absent on the last page"
 // @Failure 400 {object} errorResponse
 // @Failure 403 {object} errorResponse
 // @Failure 404 {object} errorResponse
@@ -60,16 +71,26 @@ func (s *Server) ListActivity(w http.ResponseWriter, r *http.Request) {
 		limit = parsed
 	}
 
-	events, err := s.activityStore.List(r.Context(), projectName, limit)
+	events, nextCursor, err := s.activityStore.ListPage(r.Context(), projectName, limit, r.URL.Query().Get("cursor"))
 	if err != nil {
+		if errors.Is(err, activity.ErrBadCursor) {
+			writeJSON(w, http.StatusBadRequest, errorResponse{"invalid cursor"})
+			return
+		}
 		writeError(w, r, err)
 		return
+	}
+	if nextCursor != "" {
+		w.Header().Set("X-Next-Cursor", nextCursor)
 	}
 	writeJSON(w, http.StatusOK, events)
 }
 
 // ListPlatformActivity returns recent activity across all projects the caller
-// can read, newest first.
+// can read, newest first. Deliberately limit-only: per-project cursors do not
+// compose across a merged stream, and the platform dashboard (obs-v2 O5) will
+// consume its own aggregate endpoint. Page depth here stays bounded by
+// maxActivityLimit.
 //
 // GET /api/activity?limit=100
 //

--- a/internal/api/activity_test.go
+++ b/internal/api/activity_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -380,5 +381,89 @@ func TestListPlatformActivityLimitValidation(t *testing.T) {
 	w := doRequest(h, http.MethodGet, "/api/activity?limit=abc", nil)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListActivityCursorPagination(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+
+	seedProject(t, k8sClient, "pag-cursor")
+	store := activity.NewConfigMapStore(k8sClient)
+	for i := 0; i < 7; i++ {
+		if err := store.Append(context.Background(), activity.Event{
+			Timestamp:    time.Now().Add(time.Duration(i) * time.Second),
+			Actor:        "a@example.com",
+			Action:       "update",
+			ResourceKind: "app",
+			ResourceName: "web",
+			Project:      "pag-cursor",
+			Message:      fmt.Sprintf("event %d", i),
+		}); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	// Page 1: 3 newest, with the next-page cursor in the header.
+	w := doRequest(h, http.MethodGet, "/api/projects/pag-cursor/activity?limit=3", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("page1: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	cursor := w.Header().Get("X-Next-Cursor")
+	if cursor == "" {
+		t.Fatal("page1: expected X-Next-Cursor header")
+	}
+	var page1 []activityEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&page1); err != nil {
+		t.Fatalf("decode page1: %v", err)
+	}
+	if len(page1) != 3 || page1[0].Msg != "event 6" {
+		t.Fatalf("page1 = %d events, first %q", len(page1), page1[0].Msg)
+	}
+
+	// Page 2 continues exactly where page 1 ended.
+	w = doRequest(h, http.MethodGet, "/api/projects/pag-cursor/activity?limit=3&cursor="+cursor, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("page2: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var page2 []activityEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&page2); err != nil {
+		t.Fatalf("decode page2: %v", err)
+	}
+	if len(page2) != 3 || page2[0].Msg != "event 3" {
+		t.Fatalf("page2 = %d events, first %q", len(page2), page2[0].Msg)
+	}
+
+	// Final page: one event, no cursor header.
+	cursor = w.Header().Get("X-Next-Cursor")
+	if cursor == "" {
+		t.Fatal("page2: expected X-Next-Cursor header")
+	}
+	w = doRequest(h, http.MethodGet, "/api/projects/pag-cursor/activity?limit=3&cursor="+cursor, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("page3: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var page3 []activityEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&page3); err != nil {
+		t.Fatalf("decode page3: %v", err)
+	}
+	if len(page3) != 1 || page3[0].Msg != "event 0" {
+		t.Fatalf("page3 = %d events, first %q", len(page3), page3[0].Msg)
+	}
+	if got := w.Header().Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("final page must omit X-Next-Cursor, got %q", got)
+	}
+}
+
+func TestListActivityInvalidCursor(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	srv := newAdminServer(t, k8sClient)
+	h := srv.Handler()
+	seedProject(t, k8sClient, "pag-badcursor")
+
+	w := doRequest(h, http.MethodGet, "/api/projects/pag-badcursor/activity?cursor=bogus", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad cursor, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -18,6 +18,13 @@ definitions:
         type: string
       resource:
         type: string
+      seq:
+        description: |-
+          Seq is a per-project monotonically increasing sequence number assigned
+          at append time. It makes pagination cursors stable when timestamps
+          collide. Entries written before pagination existed carry Seq 0 until
+          the one-time backfill in appendOnce assigns them positions.
+        type: integer
       ts:
         type: string
     type: object
@@ -3132,22 +3139,32 @@ paths:
       - projects
   /projects/{project}/activity:
     get:
-      description: Returns recent activity events for a project, newest first
+      description: Returns recent activity events for a project, newest first. The
+        X-Next-Cursor response header carries the cursor for the next page; pass it
+        back via the cursor query parameter. No header means no further pages.
       parameters:
       - description: Project name
         in: path
         name: project
         required: true
         type: string
-      - description: 'Max number of events (default: 100)'
+      - description: 'Max number of events per page (default: 100, max: 500)'
         in: query
         name: limit
         type: integer
+      - description: Opaque cursor from a previous page's X-Next-Cursor header
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          headers:
+            X-Next-Cursor:
+              description: Cursor for the next page; absent on the last page
+              type: string
           schema:
             items:
               $ref: '#/definitions/activity.Event'

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -146,7 +146,7 @@ async function refreshSession(force = false): Promise<boolean> {
 	return refreshPromise;
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+async function request<T>(path: string, init?: RequestInit, onResponse?: (res: Response) => void): Promise<T> {
 	const method = init?.method?.toUpperCase();
 	const retryable = method === 'PUT' || method === 'PATCH';
 	const maxRetries = retryable ? 3 : 0;
@@ -203,8 +203,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 		}
 
 		if (res.status === 204) {
+			onResponse?.(res);
 			return undefined as T;
 		}
+		onResponse?.(res);
 		const text = await res.text();
 		if (!text) {
 			return undefined as T;
@@ -584,6 +586,25 @@ export const api = {
 	// --- activity ---
 	listActivity: (project: string) =>
 		request<ActivityEvent[]>(`/projects/${enc(project)}/activity`),
+	// Cursor-paginated variant: the next-page cursor arrives via the
+	// X-Next-Cursor response header (null when there are no more pages).
+	listActivityPage: async (
+		project: string,
+		cursor?: string,
+		limit = 100
+	): Promise<{ events: ActivityEvent[]; nextCursor: string | null }> => {
+		let nextCursor: string | null = null;
+		const params = new URLSearchParams({ limit: String(limit) });
+		if (cursor) params.set('cursor', cursor);
+		const events = await request<ActivityEvent[]>(
+			`/projects/${enc(project)}/activity?${params}`,
+			undefined,
+			(res) => {
+				nextCursor = res.headers.get('X-Next-Cursor');
+			}
+		);
+		return { events: events ?? [], nextCursor };
+	},
 	listPlatformActivity: (limit = 100) =>
 		request<ActivityEvent[]>(`/activity?limit=${limit}`),
 

--- a/ui/src/lib/components/ActivityRail.svelte
+++ b/ui/src/lib/components/ActivityRail.svelte
@@ -8,6 +8,8 @@
 
   let events = $state<ActivityEvent[]>([]);
   let loading = $state(false);
+  let loadingMore = $state(false);
+  let nextCursor = $state<string | null>(null);
   let filter = $state<'all' | 'deploys' | 'changes' | 'members'>('all');
 
   $effect(() => {
@@ -21,11 +23,28 @@
     if (!project) return;
     loading = true;
     try {
-      events = await api.listActivity(project);
+      const page = await api.listActivityPage(project);
+      events = page.events;
+      nextCursor = page.nextCursor;
     } catch {
       events = [];
+      nextCursor = null;
     } finally {
       loading = false;
+    }
+  }
+
+  async function loadMore() {
+    if (!project || !nextCursor || loadingMore) return;
+    loadingMore = true;
+    try {
+      const page = await api.listActivityPage(project, nextCursor);
+      events = [...events, ...page.events];
+      nextCursor = page.nextCursor;
+    } catch {
+      // Keep what we have; the button stays for a retry.
+    } finally {
+      loadingMore = false;
     }
   }
 
@@ -143,6 +162,18 @@
             </div>
           {/each}
         </div>
+        {#if nextCursor}
+          <div class="p-3">
+            <button
+              type="button"
+              onclick={() => void loadMore()}
+              disabled={loadingMore}
+              class="w-full rounded-md border border-surface-600 py-1.5 text-xs text-gray-400 hover:bg-surface-700 hover:text-white disabled:opacity-50"
+            >
+              {loadingMore ? 'Loading…' : 'Load more'}
+            </button>
+          </div>
+        {/if}
       {/if}
     </div>
   </div>

--- a/ui/tests/e2e/activity-rail.spec.ts
+++ b/ui/tests/e2e/activity-rail.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import {
+	ensureAdmin,
+	loginViaAPI,
+	injectToken,
+	randomSuffix,
+	createProjectViaAPI,
+	deleteProjectViaAPI
+} from './helpers';
+
+// Baseline coverage for the activity rail: open it, see recorded activity,
+// close it. The Load-more control only renders past one page (100+ events),
+// which real-API seeding cannot reasonably produce here — its pagination
+// logic is covered at the store and handler layers
+// (internal/activity/option_c_test.go, internal/api/activity_test.go).
+test.describe('activity rail', () => {
+	let adminToken: string;
+	let project: string;
+
+	test.beforeAll(async ({ request }) => {
+		await ensureAdmin(request);
+		adminToken = await loginViaAPI(request);
+		project = `act-rail-${randomSuffix()}`;
+		await createProjectViaAPI(request, adminToken, project);
+	});
+
+	test.afterAll(async ({ request }) => {
+		await deleteProjectViaAPI(request, adminToken, project);
+	});
+
+	test('opens, shows project activity, closes', async ({ page }) => {
+		await injectToken(page, adminToken);
+		await page.goto(`/projects/${project}`);
+
+		await page.getByTitle('Activity', { exact: true }).click();
+		await expect(page.getByRole('heading', { name: 'Activity', exact: true })).toBeVisible();
+
+		// Project creation is backfilled into activity by the controller.
+		await expect(page.getByText(`Created project ${project}`, { exact: true })).toBeVisible();
+
+		await page.getByRole('button', { name: 'Close activity rail', exact: true }).click();
+		await expect(page.getByRole('heading', { name: 'Activity', exact: true })).not.toBeVisible();
+	});
+});


### PR DESCRIPTION
Obs-v2 O3: the ConfigMap activity store keeps its architecture and loses its arbitrary limits. Fixes #165 (Option C). Fixes mo-1mm.

## Measured cap raise (the math)

`Cap` goes 500 → 2000, and the number is derived, not guessed: `TestCapFitsEtcdBudget` marshals 2000 representative events and asserts the payload fits the budget. Measured typical entry: ~260 B; 2000 of them ≈ 500 KiB. The real guarantee is the new **`MaxBytes` budget (768 KiB)** — leaving ≥256 KiB of the 1 MiB etcd object limit for ConfigMap metadata and managedFields — enforced on every append by oldest-first byte-trim, so pathological entry sizes degrade capacity but can never block a write (tested with 8 KiB messages). If `Event` grows and typical size drifts, the math test fails and the constants get re-derived instead of silently lying.

## Cursor pagination

Every event gets a per-project monotonic `seq` at append (with a one-time backfill for pre-existing zero-seq entries, applied in-memory on reads so `List` never mutates). `ListPage` returns seq-anchored pages that are **stable across concurrent appends and trims** — the pagination test appends mid-pagination and asserts page 2 continues exactly where page 1 ended, no duplicates, no skips. The API stays backward-compatible: the response body remains a bare array; the next-page cursor travels in the `X-Next-Cursor` response header (absent on the last page), `?cursor=` feeds it back, invalid cursors are a 400. Page size is capped at 500 — a full buffer is ~500 KiB of JSON, which is what pagination is for.

The platform-wide endpoint stays limit-only on purpose: per-project cursors don't compose across a merged stream, and the platform dashboard (obs-v2 O5) gets its own aggregate endpoint. Rationale is in the handler comment.

## Time pruning

Entries older than 30 days drop on append — which already rewrites the whole ConfigMap, so pruning is free. Retention never drops the event being appended (tested). The stdout audit stream remains the unbounded system of record.

## UI

The rail loads pages and gains a **Load more** button (exact-name selector discipline). New `activity-rail.spec.ts` covers open, shows recorded activity, close as baseline e2e; the Load-more control only renders past one page (100+ events), which real-API seeding can't reasonably produce in e2e — its logic is pinned at the store and handler layers instead, stated in the spec's header comment.

## Explicitly future

The SQLite/observer-backed store (#165 Option A) is **not** this PR and stays deferred until obs-v2 needs it: the `Store` interface deliberately stays narrow (`Append`/`List`/`ListPage`) so that backend is a drop-in swap.

## Gates

Full ci-local, run in two halves coordinated around crew1's cluster usage: unit+envtest 79s, helm lint, vet+staticcheck, ui build — green; `make test-integration` fully green (523s, zero failures); ui-e2e 161/161 (42.8s) including the new rail spec. Swagger regenerated.
