### PR TITLE
fix(build): interruption retryable + adopt pushed image before relaunch + uncached lost-tracker re-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Build interruption is retryable, not terminal** (#447, #290): losing a
+  build tracker (e.g. an OOM-killed or restarted operator) no longer fails
+  the BuildRun terminally at the second loss. The run relaunches with
+  exponential backoff (immediately on first loss, then 1m/2m/4m…) up to 5
+  attempts before failing with the distinct `BuildRetriesExhausted` reason;
+  only that exhausted state latches the App and hard-fails a preview
+  environment. Before relaunching, the controller probes the registry for
+  the interrupted attempt's push tag and adopts the image if the push
+  already completed — no pointless rebuild (explicitly requested rebuilds
+  are exempt from adoption). The lost-tracker re-read now bypasses the
+  informer cache via an APIReader so a just-finished build is never
+  mistaken for a lost one and restarted.
 - **`install.sh` dev-path built the wrong binary**: the repo-clone flow's
   untargeted `docker build` produced the Dockerfile's final stage — the
   observer binary — tagged as the operator image, so the installed

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,12 @@ dev-reset: ## Tear down dev cluster completely, rebuild, and start fresh
 ##@ Integration Tests
 
 INT_CLUSTER ?= mortise-int
+# Every kubectl/helm/go-test step below pins this context explicitly. The
+# setup must never ride the ambient current-context: k3d cluster create
+# SWITCHES current-context, so any concurrent cluster creation on the box
+# (another crew's gate, a dev-up) would silently redirect an unpinned
+# install or test suite into the wrong cluster mid-run.
+INT_KUBE_CONTEXT ?= k3d-$(INT_CLUSTER)
 INT_IMG ?= mortise:int
 INT_OBSERVER_IMG ?= mortise-observer:int
 # Test fixtures plus the umbrella chart's dependency images (traefik,
@@ -249,7 +255,13 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	@echo "==> Creating k3d cluster $(INT_CLUSTER)..."
 	# --config wires the containerd mirror rule that makes
 	# registry.mortise-test-deps.svc:5000 pulls reachable from the node.
-	k3d cluster create --config test/integration/k3d-config.yaml --runtime-ulimit $(K3D_RUNTIME_ULIMIT) --wait
+	# The config hardcodes metadata.name, so stamp INT_CLUSTER into it the
+	# same way dev-up stamps DEV_CLUSTER — otherwise create ignores the
+	# variable and concurrent gates collide on the shared name.
+	@tmp_config=$$(mktemp); \
+	trap 'rm -f "$$tmp_config"' EXIT; \
+	sed 's/name: mortise-int/name: $(INT_CLUSTER)/' test/integration/k3d-config.yaml > "$$tmp_config"; \
+	k3d cluster create --config "$$tmp_config" --runtime-ulimit $(K3D_RUNTIME_ULIMIT) --wait
 	@echo "==> Building Docker images..."
 	$(CONTAINER_TOOL) build --target operator -t $(INT_IMG) .
 	$(CONTAINER_TOOL) build --target observer -t $(INT_OBSERVER_IMG) .
@@ -273,16 +285,16 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 		k3d image import $(INT_IMG) $(INT_OBSERVER_IMG) $(INT_DEP_IMAGES) -c $(INT_CLUSTER); \
 	fi
 	@echo "==> Installing CRDs..."
-	kubectl apply -f charts/mortise-core/crds/
+	kubectl --context $(INT_KUBE_CONTEXT) apply -f charts/mortise-core/crds/
 	@echo "==> Waiting for CRDs to be established..."
-	kubectl wait --for=condition=Established crd/platformconfigs.mortise.mortise.dev --timeout=30s
+	kubectl --context $(INT_KUBE_CONTEXT) wait --for=condition=Established crd/platformconfigs.mortise.mortise.dev --timeout=30s
 	@echo "==> Installing test-only dependencies (registry, Gitea, BuildKit)..."
-	kubectl create namespace mortise-system --dry-run=client -o yaml | kubectl apply -f -
-	kubectl apply -f test/integration/manifests/
+	kubectl --context $(INT_KUBE_CONTEXT) create namespace mortise-system --dry-run=client -o yaml | kubectl --context $(INT_KUBE_CONTEXT) apply -f -
+	kubectl --context $(INT_KUBE_CONTEXT) apply -f test/integration/manifests/
 	@echo "==> Waiting for test dependencies to become ready..."
-	kubectl -n mortise-test-deps rollout status deployment/registry  --timeout=120s
-	kubectl -n mortise-test-deps rollout status deployment/gitea     --timeout=180s
-	kubectl -n mortise-test-deps rollout status deployment/buildkitd --timeout=180s
+	kubectl --context $(INT_KUBE_CONTEXT) -n mortise-test-deps rollout status deployment/registry  --timeout=120s
+	kubectl --context $(INT_KUBE_CONTEXT) -n mortise-test-deps rollout status deployment/gitea     --timeout=180s
+	kubectl --context $(INT_KUBE_CONTEXT) -n mortise-test-deps rollout status deployment/buildkitd --timeout=180s
 	@echo "==> Fetching Helm chart dependencies..."
 	helm repo add traefik https://traefik.github.io/charts
 	helm repo add jetstack https://charts.jetstack.io
@@ -290,7 +302,7 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	helm repo update
 	helm dependency build charts/mortise
 	@echo "==> Installing Mortise via Helm..."
-	helm upgrade --install mortise charts/mortise \
+	helm --kube-context $(INT_KUBE_CONTEXT) upgrade --install mortise charts/mortise \
 		--namespace mortise-system --create-namespace \
 		--skip-crds \
 		--set mortise-core.image.repository=mortise \
@@ -307,7 +319,9 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 		--set metrics-server.args='{--kubelet-insecure-tls}' \
 		--wait --timeout $(HELM_WAIT_TIMEOUT)
 	@echo "==> Running integration tests..."
-	go test -v -parallel 25 -tags integration -count=1 -timeout 45m ./test/integration/... || \
+	# The suite builds its client from KUBECONFIG's current context; a
+	# standalone kubeconfig from k3d pins it to this run's cluster.
+	KUBECONFIG=$$(k3d kubeconfig write $(INT_CLUSTER)) go test -v -parallel 25 -tags integration -count=1 -timeout 45m ./test/integration/... || \
 		{ echo "==> Tests failed; leaving cluster for diagnostics (run: k3d cluster delete $(INT_CLUSTER))"; exit 1; }
 	@echo "==> Tearing down cluster..."
 	k3d cluster delete $(INT_CLUSTER)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -452,6 +452,7 @@ func main() {
 	controller.NewAppPhaseCollector(mgr.GetClient())
 	if err := (&controller.BuildRunReconciler{
 		Client:          mgr.GetClient(),
+		APIReader:       mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
 		BuildClient:     stk.build,
 		GitClient:       stk.git,

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1452,8 +1452,12 @@ func isTerminalBuildFailureCondition(cond *metav1.Condition) bool {
 	if cond == nil || cond.Type != "BuildSucceeded" || cond.Status != metav1.ConditionFalse {
 		return false
 	}
+	// BuildInterrupted is deliberately absent: interruption is retryable (the
+	// BuildRun controller relaunches the build) and must not latch the app
+	// into refusing future builds. Only the exhausted-retry-budget escape
+	// (BuildRetriesExhausted) is terminal.
 	switch cond.Reason {
-	case "BuildFailed", "BuildInterrupted":
+	case "BuildFailed", "BuildRetriesExhausted":
 		return true
 	default:
 		return false

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4582,10 +4582,40 @@ func (f *fakeGitClient) Fetch(_ context.Context, _, _ string) error {
 	return f.err
 }
 
+// #447: interruption is retryable and must not latch the app into refusing
+// future builds; only genuine failures and the exhausted-retry escape do.
+func TestIsTerminalBuildFailureCondition(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{"BuildFailed", true},
+		{"BuildRetriesExhausted", true},
+		{"BuildInterrupted", false},
+		{"GitAuthFailed", false},
+	}
+	for _, tc := range cases {
+		got := isTerminalBuildFailureCondition(&metav1.Condition{
+			Type:   "BuildSucceeded",
+			Status: metav1.ConditionFalse,
+			Reason: tc.reason,
+		})
+		if got != tc.want {
+			t.Errorf("isTerminalBuildFailureCondition(reason=%s) = %v, want %v", tc.reason, got, tc.want)
+		}
+	}
+	if isTerminalBuildFailureCondition(nil) {
+		t.Error("nil condition must not be terminal")
+	}
+}
+
 // fakeRegistryBackend implements registry.RegistryBackend for tests.
 type fakeRegistryBackend struct {
 	imageRef       registry.ImageRef
 	pullSecretName string
+	resolveDigest  string
+	resolveFound   bool
+	resolveErr     error
 }
 
 func (f *fakeRegistryBackend) PushTarget(app, tag string) (registry.ImageRef, error) {
@@ -4608,6 +4638,10 @@ func (f *fakeRegistryBackend) PullSecretRef() string { return f.pullSecretName }
 
 func (f *fakeRegistryBackend) Tags(_ context.Context, _ string) ([]string, error) {
 	return nil, nil
+}
+
+func (f *fakeRegistryBackend) ResolveTag(_ context.Context, _, _ string) (string, bool, error) {
+	return f.resolveDigest, f.resolveFound, f.resolveErr
 }
 
 func (f *fakeRegistryBackend) DeleteTag(_ context.Context, _, _ string) error {

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/build"
@@ -41,16 +43,29 @@ import (
 )
 
 const (
-	buildRunPollInterval        = 15 * time.Second
-	buildRunTrackerLossGrace    = 5 * time.Second
-	maxBuildRunRecoveryAttempts = 2
-	buildRunHistoryLimit        = 10
+	buildRunPollInterval     = 15 * time.Second
+	buildRunTrackerLossGrace = 5 * time.Second
+	buildRunHistoryLimit     = 10
+
+	// Interruption (tracker loss, e.g. an OOM-killed operator) is retryable:
+	// the first loss relaunches immediately, later losses back off
+	// exponentially from this base so a crash-looping operator doesn't spend
+	// the whole retry budget in seconds. After the attempt budget is spent the
+	// run fails terminally with BuildRetriesExhausted.
+	maxBuildRunInterruptionAttempts = 5
+	buildRunInterruptionBackoffBase = time.Minute
+
+	buildRunInterruptedCondition = "Interrupted"
 )
 
 // BuildRunReconciler reconciles durable BuildRun objects.
 type BuildRunReconciler struct {
 	client.Client
-	Scheme          *runtime.Scheme
+	Scheme *runtime.Scheme
+	// APIReader reads straight from the API server, bypassing the informer
+	// cache. The lost-tracker path uses it because a cached read can present
+	// a finished build as still Running right after the terminal persist.
+	APIReader       client.Reader
 	Clock           clock.Clock
 	BuildClient     build.BuildClient
 	GitClient       git.GitClient
@@ -110,8 +125,7 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// Persist the terminal outcome BEFORE dropping the tracker. If the
 			// tracker is deleted first and any write below fails, the next
 			// reconcile sees phase Running with no tracker and treats a
-			// finished build as lost — triggering a duplicate rebuild or a
-			// terminal BuildInterrupted failure.
+			// finished build as lost — triggering a duplicate rebuild.
 			logRef, err := r.persistBuildRunLog(ctx, &br, tracker)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -177,10 +191,13 @@ func (r *BuildRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {
 	// A concurrent reconcile may have persisted the terminal outcome and
-	// dropped the tracker after our (possibly cached) read. Re-read before
-	// treating a finished build as lost.
+	// dropped the tracker after our (possibly cached) read. Re-read through
+	// the uncached APIReader before treating a finished build as lost:
+	// informer lag can present Running-with-no-tracker long after StartedAt's
+	// grace window has elapsed, and a cached re-read would restart a build
+	// that already finished.
 	var latest mortisev1alpha1.BuildRun
-	if err := r.Get(ctx, key, &latest); err != nil {
+	if err := r.uncachedReader().Get(ctx, key, &latest); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
@@ -200,30 +217,162 @@ func (r *BuildRunReconciler) handleLostBuildRunTracker(ctx context.Context, key 
 		return ctrl.Result{RequeueAfter: buildRunTrackerLossGrace - elapsed}, nil
 	}
 
+	// The interrupted attempt may have finished pushing before the tracker
+	// was lost; adopt the pushed image instead of rebuilding (#290).
+	if adopted, err := r.adoptPushedBuildResult(ctx, br, key); adopted || err != nil {
+		return ctrl.Result{}, err
+	}
+
 	attempt := br.Status.Attempt
 	if attempt < 1 {
 		attempt = 1
 	}
-	if attempt < maxBuildRunRecoveryAttempts {
-		marker := fmt.Sprintf("[recovery] build tracker lost; restarting attempt %d", attempt+1)
-		if err := r.appendBuildRunLogMarker(ctx, br, marker); err != nil {
+	if attempt >= maxBuildRunInterruptionAttempts {
+		message := fmt.Sprintf("build interrupted %d times without completing", attempt)
+		if err := r.appendBuildRunLogMarker(ctx, br, "[interrupted] "+message); err != nil {
 			return ctrl.Result{}, err
 		}
-		return r.startBuildRunAttempt(ctx, br, key, attempt+1, marker)
+		if err := r.failBuildRun(ctx, br, attempt, "BuildRetriesExhausted", message); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.projectTerminalBuildRunStatus(ctx, br); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.Builds.delete(key)
+		return ctrl.Result{}, nil
 	}
 
-	message := fmt.Sprintf("build tracker lost after recovery attempt %d", attempt)
-	if err := r.appendBuildRunLogMarker(ctx, br, "[interrupted] "+message); err != nil {
+	if delay := buildRunInterruptionBackoff(attempt); delay > 0 {
+		remaining, err := r.awaitInterruptionBackoff(ctx, br, delay)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if remaining > 0 {
+			return ctrl.Result{RequeueAfter: remaining}, nil
+		}
+	}
+
+	marker := fmt.Sprintf("[recovery] build tracker lost; restarting attempt %d", attempt+1)
+	if err := r.appendBuildRunLogMarker(ctx, br, marker); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.failBuildRun(ctx, br, attempt, "BuildInterrupted", message); err != nil {
-		return ctrl.Result{}, err
+	return r.startBuildRunAttempt(ctx, br, key, attempt+1, marker)
+}
+
+// adoptPushedBuildResult probes the registry for the interrupted build's push
+// target and, when the image is already there, persists the success instead of
+// rebuilding. Requested rebuilds (RequestID/NoCache) are exempt: their push
+// tag can pre-exist from the previous build, so adoption would silently skip
+// the rebuild the user asked for.
+func (r *BuildRunReconciler) adoptPushedBuildResult(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName) (bool, error) {
+	if r.RegistryBackend == nil || br.Spec.NoCache || br.Spec.RequestID != "" {
+		return false, nil
+	}
+	appName := firstNonEmpty(br.Spec.AppName, br.Spec.TargetRef.Name)
+	pushRef := parseImageRef(br.Spec.PushTarget)
+	if appName == "" || pushRef.Tag == "" {
+		return false, nil
+	}
+
+	digest, found, err := r.RegistryBackend.ResolveTag(ctx, appName, pushRef.Tag)
+	if err != nil {
+		// The probe is an optimization; registry trouble must not block recovery.
+		logf.FromContext(ctx).Error(err, "registry probe for interrupted build failed; falling back to rebuild",
+			"buildrun", key, "tag", pushRef.Tag)
+		return false, nil
+	}
+	if !found {
+		return false, nil
+	}
+
+	pullRef := parseImageRef(firstNonEmpty(br.Spec.PullTarget, br.Spec.PushTarget))
+	image := pullRef.Full
+	if digest != "" {
+		image = pullRef.Registry + "/" + pullRef.Path + "@" + digest
+	}
+
+	if err := r.appendBuildRunLogMarker(ctx, br, fmt.Sprintf("[recovery] image %s already pushed by interrupted attempt; adopting", image)); err != nil {
+		return false, err
+	}
+
+	now := metav1.NewTime(r.clock().Now())
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current mortisev1alpha1.BuildRun
+		if err := r.Get(ctx, key, &current); err != nil {
+			return err
+		}
+		current.Status.Phase = mortisev1alpha1.BuildRunPhaseSucceeded
+		current.Status.Image = image
+		current.Status.Digest = digest
+		current.Status.FinishedAt = &now
+		current.Status.CompletedAt = &now
+		current.Status.LogRef = &corev1.LocalObjectReference{Name: buildRunLogConfigMapName(br.Name)}
+		current.Status.FailureReason = ""
+		current.Status.FailureMessage = ""
+		meta.RemoveStatusCondition(&current.Status.Conditions, buildRunInterruptedCondition)
+		setBuildRunCondition(&current.Status.Conditions, mortisev1alpha1.BuildRunPhaseSucceeded, current.Generation, "build completed (adopted image pushed by interrupted attempt)", now)
+		if err := r.Status().Update(ctx, &current); err != nil {
+			return err
+		}
+		*br = current
+		return nil
+	}); err != nil {
+		return false, err
 	}
 	if err := r.projectTerminalBuildRunStatus(ctx, br); err != nil {
-		return ctrl.Result{}, err
+		return true, err
 	}
 	r.Builds.delete(key)
-	return ctrl.Result{}, nil
+	if err := r.gcBuildRunHistory(ctx, br); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// buildRunInterruptionBackoff returns how long to wait before relaunching
+// after the given attempt was interrupted. The first loss restarts
+// immediately; later ones back off exponentially.
+func buildRunInterruptionBackoff(attempt int32) time.Duration {
+	if attempt < 2 {
+		return 0
+	}
+	return buildRunInterruptionBackoffBase << (attempt - 2)
+}
+
+// awaitInterruptionBackoff marks the run interrupted (if not already) and
+// returns the remaining backoff before the next relaunch, using the
+// Interrupted condition's transition time as the durable reference point.
+// Zero means the backoff has elapsed and the caller may restart now.
+func (r *BuildRunReconciler) awaitInterruptionBackoff(ctx context.Context, br *mortisev1alpha1.BuildRun, delay time.Duration) (time.Duration, error) {
+	now := r.clock().Now()
+	cond := meta.FindStatusCondition(br.Status.Conditions, buildRunInterruptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		meta.SetStatusCondition(&br.Status.Conditions, metav1.Condition{
+			Type:               buildRunInterruptedCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "BuildInterrupted",
+			Message:            fmt.Sprintf("build tracker lost on attempt %d; retrying after backoff", br.Status.Attempt),
+			ObservedGeneration: br.Generation,
+			LastTransitionTime: metav1.NewTime(now),
+		})
+		if err := r.Status().Update(ctx, br); err != nil {
+			return 0, err
+		}
+		return delay, nil
+	}
+	if waited := now.Sub(cond.LastTransitionTime.Time); waited < delay {
+		return delay - waited, nil
+	}
+	return 0, nil
+}
+
+// uncachedReader returns the APIReader when configured, falling back to the
+// manager client for tests that don't wire one.
+func (r *BuildRunReconciler) uncachedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 func (r *BuildRunReconciler) startBuildRunAttempt(ctx context.Context, br *mortisev1alpha1.BuildRun, key types.NamespacedName, attempt int32, marker string) (ctrl.Result, error) {
@@ -250,6 +399,7 @@ func (r *BuildRunReconciler) startBuildRunAttempt(ctx context.Context, br *morti
 	if attempt > 1 {
 		message = fmt.Sprintf("build recovered after tracker loss (attempt %d)", attempt)
 	}
+	meta.RemoveStatusCondition(&br.Status.Conditions, buildRunInterruptedCondition)
 	setBuildRunCondition(&br.Status.Conditions, mortisev1alpha1.BuildRunPhaseRunning, br.Generation, message, now)
 	if err := r.Status().Update(ctx, br); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/buildrun_controller_recovery_test.go
+++ b/internal/controller/buildrun_controller_recovery_test.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -140,7 +141,127 @@ func TestBuildRunRestartsOnceAfterTrackerLoss(t *testing.T) {
 	}
 }
 
-func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
+// Interruption is retryable (#447): a second tracker loss must not fail the
+// run terminally. It backs off (durably, via the Interrupted condition), then
+// relaunches the build as the next attempt.
+func TestBuildRunSecondTrackerLossBacksOffThenRetries(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	release := make(chan struct{})
+	defer close(release)
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-2", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment:    "production",
+			Repo:           "https://example.com/repo.git",
+			Branch:         "main",
+			Revision:       "abc123",
+			DockerfilePath: "Dockerfile",
+			PushTarget:     "registry.example.com/mortise/demo:abc123",
+			PullTarget:     "registry.example.com/mortise/demo:abc123",
+			TokenSecretRef: &mortisev1alpha1.SecretRef{Name: "git-token", Namespace: "mortise-system", Key: "token"},
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   2,
+			StartedAt: &started,
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-token", Namespace: "mortise-system"},
+		Data:       map[string][]byte{"token": []byte("tok")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run, secret).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Second))
+	buildClient := &countingGatedBuildClient{release: release}
+	r := &BuildRunReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		Clock:           clock,
+		BuildClient:     buildClient,
+		GitClient:       &fakeGitClient{},
+		RegistryBackend: &fakeRegistryBackend{},
+		Builds:          &BuildTrackerStore{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile interrupted buildrun: %v", err)
+	}
+	if res.RequeueAfter != buildRunInterruptionBackoff(2) {
+		t.Fatalf("expected full backoff requeue %v, got %v", buildRunInterruptionBackoff(2), res.RequeueAfter)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning {
+		t.Fatalf("expected buildrun to stay retryable (Running), got %q", updated.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, buildRunInterruptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Interrupted condition set during backoff, got %+v", cond)
+	}
+	if buildClient.count() != 0 {
+		t.Fatalf("expected no relaunch during backoff, got %d submits", buildClient.count())
+	}
+
+	// Mid-backoff reconciles keep waiting out the same window.
+	clock.Step(30 * time.Second)
+	res, err = r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("mid-backoff reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 || res.RequeueAfter > buildRunInterruptionBackoff(2)-30*time.Second {
+		t.Fatalf("expected remaining-backoff requeue, got %v", res.RequeueAfter)
+	}
+	if buildClient.count() != 0 {
+		t.Fatalf("expected no relaunch mid-backoff, got %d submits", buildClient.count())
+	}
+
+	// Once the backoff elapses the build relaunches as the next attempt.
+	clock.Step(buildRunInterruptionBackoff(2))
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("post-backoff reconcile: %v", err)
+	}
+	if err := waitForBuildSubmits(buildClient, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning {
+		t.Fatalf("expected running after relaunch, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Attempt != 3 {
+		t.Fatalf("expected attempt 3 after relaunch, got %d", updated.Status.Attempt)
+	}
+	if cond := meta.FindStatusCondition(updated.Status.Conditions, buildRunInterruptedCondition); cond != nil {
+		t.Fatalf("expected Interrupted condition cleared on relaunch, got %+v", cond)
+	}
+}
+
+// The retry budget is capped: once the attempt budget is spent, the run fails
+// terminally with a reason distinct from BuildInterrupted so a crash-looping
+// operator doesn't rebuild forever.
+func TestBuildRunInterruptionBudgetExhaustedFailsTerminally(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add mortise scheme: %v", err)
@@ -151,7 +272,7 @@ func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
 
 	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
 	run := &mortisev1alpha1.BuildRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-2", Namespace: "pj-default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-5", Namespace: "pj-default"},
 		Spec: mortisev1alpha1.BuildRunSpec{
 			AppName: "demo",
 			TargetRef: mortisev1alpha1.BuildRunTargetRef{
@@ -165,7 +286,7 @@ func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
 		},
 		Status: mortisev1alpha1.BuildRunStatus{
 			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
-			Attempt:   2,
+			Attempt:   maxBuildRunInterruptionAttempts,
 			StartedAt: &started,
 		},
 	}
@@ -181,7 +302,7 @@ func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile interrupted buildrun: %v", err)
+		t.Fatalf("reconcile exhausted buildrun: %v", err)
 	}
 
 	var updated mortisev1alpha1.BuildRun
@@ -191,11 +312,165 @@ func TestBuildRunFailsAfterSecondTrackerLoss(t *testing.T) {
 	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseFailed {
 		t.Fatalf("expected failed buildrun, got %q", updated.Status.Phase)
 	}
-	if updated.Status.FailureReason != "BuildInterrupted" {
-		t.Fatalf("expected BuildInterrupted failure reason, got %q", updated.Status.FailureReason)
+	if updated.Status.FailureReason != "BuildRetriesExhausted" {
+		t.Fatalf("expected BuildRetriesExhausted failure reason, got %q", updated.Status.FailureReason)
 	}
-	if !strings.Contains(updated.Status.FailureMessage, "tracker lost") {
+	if !strings.Contains(updated.Status.FailureMessage, "interrupted") {
 		t.Fatalf("expected interruption message, got %q", updated.Status.FailureMessage)
+	}
+}
+
+// #290: when the interrupted build already pushed its image, recovery adopts
+// the pushed result instead of re-cloning and rebuilding from scratch.
+func TestBuildRunInterruptedAdoptsPushedImage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-6", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment: "production",
+			Repo:        "https://example.com/repo.git",
+			Revision:    "abc123",
+			PushTarget:  "registry.example.com/mortise/demo:abc123",
+			PullTarget:  "pull.example.com/mortise/demo:abc123",
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   1,
+			StartedAt: &started,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Second))
+	// No BuildClient configured: an erroneous rebuild attempt would flip the
+	// run to Failed/BuildInfraUnavailable, which the assertions below catch.
+	r := &BuildRunReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		Clock:           clock,
+		RegistryBackend: &fakeRegistryBackend{resolveFound: true, resolveDigest: "sha256:cafe"},
+		Builds:          &BuildTrackerStore{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile interrupted buildrun: %v", err)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseSucceeded {
+		t.Fatalf("expected adopted buildrun to succeed, got %q (reason %q)", updated.Status.Phase, updated.Status.FailureReason)
+	}
+	if updated.Status.Image != "pull.example.com/mortise/demo@sha256:cafe" {
+		t.Fatalf("expected adopted digest-pinned pull image, got %q", updated.Status.Image)
+	}
+	if updated.Status.Digest != "sha256:cafe" {
+		t.Fatalf("expected adopted digest, got %q", updated.Status.Digest)
+	}
+
+	var logCM corev1.ConfigMap
+	if err := c.Get(context.Background(), types.NamespacedName{Name: buildRunLogConfigMapName(run.Name), Namespace: run.Namespace}, &logCM); err != nil {
+		t.Fatalf("get buildrun log configmap: %v", err)
+	}
+	if !strings.Contains(logCM.Data["lines"], "adopting") {
+		t.Fatalf("expected adoption marker in persisted logs, got %q", logCM.Data["lines"])
+	}
+}
+
+// A requested rebuild's push tag can pre-exist from the previous build, so
+// adoption would silently skip the rebuild the user asked for. Recovery must
+// rebuild instead.
+func TestBuildRunRequestedRebuildDoesNotAdoptPushedImage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	release := make(chan struct{})
+	defer close(release)
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-7", Namespace: "pj-default"},
+		Spec: mortisev1alpha1.BuildRunSpec{
+			AppName: "demo",
+			TargetRef: mortisev1alpha1.BuildRunTargetRef{
+				Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+				Name:      "demo",
+				Namespace: "pj-default",
+			},
+			Environment:    "production",
+			Repo:           "https://example.com/repo.git",
+			Branch:         "main",
+			Revision:       "abc123",
+			RequestID:      "2026-08-09T00:00:00Z",
+			NoCache:        true,
+			DockerfilePath: "Dockerfile",
+			PushTarget:     "registry.example.com/mortise/demo:abc123",
+			PullTarget:     "registry.example.com/mortise/demo:abc123",
+			TokenSecretRef: &mortisev1alpha1.SecretRef{Name: "git-token", Namespace: "mortise-system", Key: "token"},
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   1,
+			StartedAt: &started,
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-token", Namespace: "mortise-system"},
+		Data:       map[string][]byte{"token": []byte("tok")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run).WithObjects(run, secret).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Second))
+	buildClient := &countingGatedBuildClient{release: release}
+	r := &BuildRunReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		Clock:           clock,
+		BuildClient:     buildClient,
+		GitClient:       &fakeGitClient{},
+		RegistryBackend: &fakeRegistryBackend{resolveFound: true, resolveDigest: "sha256:stale"},
+		Builds:          &BuildTrackerStore{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile interrupted rebuild: %v", err)
+	}
+	if err := waitForBuildSubmits(buildClient, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := c.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning {
+		t.Fatalf("expected rebuild to relaunch instead of adopting, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Attempt != 2 {
+		t.Fatalf("expected attempt 2 after relaunch, got %d", updated.Status.Attempt)
 	}
 }
 
@@ -372,6 +647,66 @@ func TestHandleLostTrackerDoesNotRestartTerminalBuildRun(t *testing.T) {
 	}
 	if updated.Status.Attempt != 1 {
 		t.Fatalf("expected no restart attempt, got attempt %d", updated.Status.Attempt)
+	}
+}
+
+// mo-uca: the informer cache can present Running-with-no-tracker right after
+// a concurrent reconcile persisted the terminal outcome and StartedAt's grace
+// is long elapsed. The lost-tracker re-read must go through the uncached
+// APIReader so the finished build is left alone instead of restarted.
+func TestHandleLostTrackerReadsThroughAPIReader(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+
+	started := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	spec := mortisev1alpha1.BuildRunSpec{
+		AppName: "demo",
+		TargetRef: mortisev1alpha1.BuildRunTargetRef{
+			Kind:      mortisev1alpha1.BuildRunTargetAppEnvironment,
+			Name:      "demo",
+			Namespace: "pj-default",
+		},
+		Environment: "production",
+		Revision:    "abc123",
+	}
+	stale := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "buildrun-8", Namespace: "pj-default"},
+		Spec:       spec,
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:     mortisev1alpha1.BuildRunPhaseRunning,
+			Attempt:   1,
+			StartedAt: &started,
+		},
+	}
+	fresh := stale.DeepCopy()
+	fresh.Status.Phase = mortisev1alpha1.BuildRunPhaseSucceeded
+	fresh.Status.Image = "registry.example.com/mortise/demo:abc123"
+
+	cached := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stale).WithObjects(stale).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(fresh).Build()
+	clock := clocktesting.NewFakeClock(started.Add(buildRunTrackerLossGrace + time.Minute))
+	// No BuildClient configured: if the stale cached read were used, the
+	// restart path would flip the run to Failed/BuildInfraUnavailable.
+	r := &BuildRunReconciler{Client: cached, APIReader: apiReader, Scheme: scheme, Clock: clock, Builds: &BuildTrackerStore{}}
+
+	key := types.NamespacedName{Name: stale.Name, Namespace: stale.Namespace}
+	res, err := r.handleLostBuildRunTracker(context.Background(), key)
+	if err != nil {
+		t.Fatalf("handleLostBuildRunTracker: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for a finished build, got %v", res.RequeueAfter)
+	}
+
+	var updated mortisev1alpha1.BuildRun
+	if err := cached.Get(context.Background(), key, &updated); err != nil {
+		t.Fatalf("get buildrun: %v", err)
+	}
+	if updated.Status.Phase != mortisev1alpha1.BuildRunPhaseRunning || updated.Status.Attempt != 1 {
+		t.Fatalf("expected finished build left alone (no restart, no failure), got phase %q attempt %d reason %q",
+			updated.Status.Phase, updated.Status.Attempt, updated.Status.FailureReason)
 	}
 }
 

--- a/internal/controller/previewenvironment_controller.go
+++ b/internal/controller/previewenvironment_controller.go
@@ -225,6 +225,12 @@ func (r *PreviewEnvironmentReconciler) previewBuildFailure(ctx context.Context, 
 			return "", "", false, err
 		}
 
+		// Interruption is retryable — the BuildRun controller relaunches the
+		// build — so it must not hard-fail the preview.
+		if run.Status.FailureReason == "BuildInterrupted" {
+			continue
+		}
+
 		return firstNonEmpty(run.Status.FailureReason, reason),
 			firstNonEmpty(run.Status.FailureMessage, msg),
 			true,

--- a/internal/controller/previewenvironment_controller_test.go
+++ b/internal/controller/previewenvironment_controller_test.go
@@ -238,6 +238,104 @@ func TestPreviewEnvironmentReconcileMarksFailedWhenPreviewAppBuildFails(t *testi
 	}
 }
 
+// #447: interruption is retryable — the BuildRun controller relaunches the
+// build — so a BuildInterrupted run must not hard-fail the preview.
+func TestPreviewEnvironmentReconcileNotFailedOnInterruptedBuild(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add mortise scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Preview:      &mortisev1alpha1.PreviewConfig{Enabled: true},
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "staging"}},
+		},
+	}
+	pe := &mortisev1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-pr-7",
+			Namespace: constants.ControlNamespace(project.Name),
+		},
+		Spec: mortisev1alpha1.PreviewEnvironmentSpec{
+			ProjectRef: project.Name,
+			SourceEnv:  "staging",
+			PullRequest: mortisev1alpha1.PullRequestRef{
+				Number: 7,
+				Branch: "feature/interrupted",
+				SHA:    "deadbeef",
+			},
+		},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-app",
+			Namespace: pe.Namespace,
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:   mortisev1alpha1.SourceTypeGit,
+				Repo:   "https://github.com/example/repo",
+				Branch: "main",
+			},
+			Environments: []mortisev1alpha1.Environment{{Name: "staging"}},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "pr-7",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "buildrun-1",
+					Phase: mortisev1alpha1.BuildRunPhaseFailed,
+				},
+			}},
+		},
+	}
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buildrun-1",
+			Namespace: pe.Namespace,
+		},
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:          mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason:  "BuildInterrupted",
+			FailureMessage: "build tracker lost after recovery attempt 2",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pe).
+		WithObjects(project, pe, app, run).
+		Build()
+	r := &PreviewEnvironmentReconciler{
+		Client: c,
+		Scheme: scheme,
+		Clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var updated mortisev1alpha1.PreviewEnvironment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pe.Name, Namespace: pe.Namespace}, &updated); err != nil {
+		t.Fatalf("get preview environment: %v", err)
+	}
+	if updated.Status.Phase == mortisev1alpha1.PreviewPhaseFailed {
+		t.Fatalf("expected preview not to fail on interrupted build, got phase %q", updated.Status.Phase)
+	}
+	if updated.Status.Phase != mortisev1alpha1.PreviewPhaseReady {
+		t.Fatalf("expected preview phase %q, got %q", mortisev1alpha1.PreviewPhaseReady, updated.Status.Phase)
+	}
+}
+
 // This test previously asserted that a PE actively clears the preview branch
 // on non-matching repo apps. That behavior was deliberately removed for
 // GH #435: two same-numbered PRs in different repos share the pr-{N} env

--- a/internal/registry/backend.go
+++ b/internal/registry/backend.go
@@ -14,5 +14,9 @@ type RegistryBackend interface {
 	PullTarget(app, tag string) (ImageRef, error)
 	PullSecretRef() string
 	Tags(ctx context.Context, app string) ([]string, error)
+	// ResolveTag reports whether app:tag exists in the registry and, if so,
+	// its manifest digest. digest may be empty when the registry does not
+	// return a digest header.
+	ResolveTag(ctx context.Context, app, tag string) (digest string, found bool, err error)
 	DeleteTag(ctx context.Context, app, tag string) error
 }

--- a/internal/registry/oci.go
+++ b/internal/registry/oci.go
@@ -179,6 +179,33 @@ func (b *OCIBackend) Tags(ctx context.Context, app string) ([]string, error) {
 	return payload.Tags, nil
 }
 
+// ResolveTag reports whether app:tag exists in the registry and, if so, its
+// manifest digest. Calls HEAD /v2/<namespace>/<app>/manifests/<tag> per OCI
+// Distribution Spec §9.2.
+func (b *OCIBackend) ResolveTag(ctx context.Context, app, tag string) (string, bool, error) {
+	path := b.imagePath(app)
+	headURL := b.cfg.URL + "/v2/" + path + "/manifests/" + tag
+
+	resp, err := b.do(ctx, http.MethodHead, headURL, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("resolving manifest for %s:%s: %w", app, tag, err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("HEAD manifests returned %d for %s:%s", resp.StatusCode, app, tag)
+	}
+
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		digest = resp.Header.Get("Content-Digest")
+	}
+	return digest, true, nil
+}
+
 // DeleteTag deletes the manifest identified by tag from the registry.
 // OCI Distribution Spec §10.4 requires deleting by digest, so DeleteTag first
 // resolves the digest via a HEAD on the manifests endpoint, then issues

--- a/internal/registry/oci_test.go
+++ b/internal/registry/oci_test.go
@@ -166,6 +166,80 @@ func TestTagsEmptyList(t *testing.T) {
 	}
 }
 
+// ---- ResolveTag ----
+
+func TestResolveTagFound(t *testing.T) {
+	const digest = "sha256:abc123def456"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead || r.URL.Path != "/v2/mortise/my-app/manifests/v1" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", digest)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	b := newTestBackend(t, srv, Config{})
+	got, found, err := b.ResolveTag(context.Background(), "my-app", "v1")
+	if err != nil {
+		t.Fatalf("ResolveTag: %v", err)
+	}
+	if !found {
+		t.Fatal("expected tag to be found")
+	}
+	if got != digest {
+		t.Errorf("expected digest %q, got %q", digest, got)
+	}
+}
+
+func TestResolveTagNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	b := newTestBackend(t, srv, Config{})
+	_, found, err := b.ResolveTag(context.Background(), "app", "missing")
+	if err != nil {
+		t.Fatalf("expected nil error for 404, got: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for 404")
+	}
+}
+
+func TestResolveTagServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	b := newTestBackend(t, srv, Config{})
+	if _, _, err := b.ResolveTag(context.Background(), "app", "v1"); err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestResolveTagNoDigestHeader(t *testing.T) {
+	// Tag exists but the registry omits the digest header — still found,
+	// with an empty digest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	b := newTestBackend(t, srv, Config{})
+	digest, found, err := b.ResolveTag(context.Background(), "app", "v1")
+	if err != nil {
+		t.Fatalf("ResolveTag: %v", err)
+	}
+	if !found || digest != "" {
+		t.Errorf("expected found with empty digest, got found=%v digest=%q", found, digest)
+	}
+}
+
 // ---- DeleteTag ----
 
 func TestDeleteTagHappyPath(t *testing.T) {


### PR DESCRIPTION
Fixes #447. Fixes #290 (folded in — see #447 comment for the merged ACs). Fixes mo-uca.

## What changes

Losing a build tracker (an OOM-killed or restarted operator) previously failed the BuildRun terminally at the second loss with `BuildInterrupted` — which latched the App against all future builds and hard-failed preview environments. Interruption is a platform hiccup, not a property of the code being built; it is now retryable.

- **Retryable interruption with capped backoff.** First loss relaunches immediately; later losses back off exponentially (1m base, doubling) tracked via an `Interrupted` condition whose transition time anchors the backoff durably across reconciles. After 5 attempts the run fails terminally with the distinct `BuildRetriesExhausted` reason — the only interruption-derived state the App latch (`isTerminalBuildFailureCondition`) and the PE failure path treat as terminal. The PE path retains a backward-compat skip for legacy `BuildInterrupted` failure reasons on pre-upgrade runs.
- **Probe before relaunch (#290).** Before re-running a lost build, the controller probes the registry (new `RegistryBackend.ResolveTag`, HEAD manifests per OCI Distribution Spec §9.2) and adopts the pushed image when the interrupted attempt already completed its push — persisting Succeeded with the digest-pinned image instead of re-cloning and rebuilding. Explicitly requested rebuilds (`RequestID`/`NoCache`) are exempt: their tag can pre-exist, and adoption would silently skip the rebuild the user asked for. Registry errors degrade to a rebuild; the probe never blocks recovery.
- **Uncached lost-tracker re-read (mo-uca).** The re-read at the top of `handleLostBuildRunTracker` goes through `mgr.GetAPIReader()` so informer lag cannot present a just-finished build as Running-with-no-tracker and trigger a spurious restart.

## Provenance

Based on nitro's preserved WIP branch (`polecat/nitro/mo-9br+msmr4dml`), evaluated complete on all three spec items, rebased onto current main. Dropped its stale `mortise-core-0.1.0.tgz` repack (no CRD changes in this lane; the in-repo placeholder is `0.0.0-dev` now).

## Rider: gate isolation (mo-qxt interim)

`e0bbc38` fixes two holes that let concurrent crew gates interfere, both hit live during this PR's gate cycle: `test-integration`'s create ignored `INT_CLUSTER` (the k3d config hardcodes `metadata.name`), and the setup steps + go-test suite rode the ambient kubeconfig current-context, which `k3d cluster create` switches. Every step is now pinned (`--context`/`--kube-context`/standalone `KUBECONFIG` via `k3d kubeconfig write`), mirroring the dev targets' existing discipline. No behavior change for the default names CI uses. Cross-crew occurrences (one in each direction) documented on mo-qxt.

## Tests

- `buildrun_controller_recovery_test.go`: second-loss backoff window math (fake clock, mid-backoff requeue, condition lifecycle, no relaunch until elapsed), budget-exhausted→`BuildRetriesExhausted`, adopt-pushed-image (digest-pinned), requested-rebuild adoption exemption, two-client APIReader test (cached says Running, uncached says Succeeded → no restart).
- `previewenvironment_controller_test.go`: PE not failed on interruption.
- `app_controller_test.go`: `TestIsTerminalBuildFailureCondition` latch table.
- `oci_test.go`: ResolveTag found / not-found / server-error / no-digest-header.

## Gate

unit+envtest, helm lint, vet+staticcheck, ui build: green. Integration: 53/56 on an isolated cluster; the 3 reds are the tracked mo-j6k ready-ceiling shape (zero error-forbidden, 11 benign fast-requeues), and all three pass in isolation with 260s+ of ceiling margin — occurrences and margin numbers recorded on mo-j6k. E2E: 165 passed + 1 flaky-passed (dashboard spec, passed on retry). Earlier gate cycles also surfaced and recorded occurrences on mo-24b (preview condition flapping, sharpened diagnosis) and mo-4rz (port-forward transient).