### PR TITLE
fix(auth): bcrypt timing oracle, login rate limit, uniform webhook 401, providerRef single-provider matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,18 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every resource in the generated `config/rbac/role.yaml` is granted by
   the packaged chart's rendered roles, so chart-vs-code RBAC drift fails
   CI instead of failing at runtime.
-
-
+- **Auth-surface hardening** (#444, auth items): login is rate-limited
+  per username+IP (token bucket 5/min burst 10, 15-minute lockout after
+  10 consecutive failures, `429` + `Retry-After`, env-overridable via
+  `MORTISE_LOGIN_*`); the user-not-found path now pays the same bcrypt
+  cost as a wrong password, closing a username-enumeration timing
+  oracle; unauthenticated webhook deliveries get a uniform `401` whether
+  the provider is unknown, secretless, or the signature is bad (the
+  distinction moved to server logs); and an App with empty
+  `spec.source.providerRef` matches webhooks only while exactly one
+  GitProvider is registered instead of accepting events from any
+  provider — a **behavior change** for multi-provider installs, see
+  "Breaking changes → Authentication" in docs/migration-v1.md.
 - **Build interruption is retryable, not terminal** (#447, #290): losing a
   build tracker (e.g. an OOM-killed or restarted operator) no longer fails
   the BuildRun terminally at the second loss. The run relaunches with

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -57,6 +57,41 @@ cannot be re-created via the API.
 field (initialized to `"0"`). Changing a password increments this value
 and invalidates all tokens issued before the change.
 
+**Login rate limiting**: `/api/auth/login` is throttled per
+username-and-IP (token bucket, 5/min sustained with a burst of 10, and a
+15-minute lockout after 10 consecutive failures — a successful login
+resets the counters). Throttled requests get `429` with a `Retry-After`
+header. Automation that retries logins in a tight loop must respect
+`Retry-After` or switch to a long-lived token. Override the defaults
+with `MORTISE_LOGIN_RATE_PER_MIN`, `MORTISE_LOGIN_BURST`,
+`MORTISE_LOGIN_LOCKOUT_FAILURES`, and `MORTISE_LOGIN_LOCKOUT_MINUTES`
+on the operator Deployment.
+
+**Webhook rejections are uniform**: unauthenticated webhook deliveries
+that previously received `404 provider not found` or `403 webhook secret
+not configured` now receive the same `401 unauthorized` as a bad
+signature. The distinction still appears in the operator logs; only the
+HTTP response is uniform. Anything alerting on webhook 404/403s should
+watch for 401s instead.
+
+**Empty `providerRef` no longer matches every provider**: a git-source
+App whose `spec.source.providerRef` is empty previously accepted webhook
+events from *any* registered GitProvider. It now matches only while
+exactly **one** GitProvider is registered (the delivery necessarily came
+from it). With two or more providers registered, empty-ref apps are
+skipped — the operator logs which apps were skipped and why. If you run
+multiple GitProviders, set `spec.source.providerRef` explicitly on every
+git-source App **before** registering the second provider:
+
+```bash
+kubectl get apps -A -o json | jq -r '
+  .items[] | select(.spec.source.type == "git" and
+                    (.spec.source.providerRef // "") == "") |
+  "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+lists the apps that need it.
+
 ### SSE (server-sent events) authentication
 
 Log streams and live event feeds no longer accept a JWT in the `?token=`

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -230,11 +231,20 @@ func (s *Server) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	key := loginRateKey(req.Email, r)
+	if ok, retryAfter := s.loginLimiter.allow(key); !ok {
+		w.Header().Set("Retry-After", strconv.Itoa(int(retryAfter.Seconds())+1))
+		writeJSON(w, http.StatusTooManyRequests, errorResponse{"too many login attempts; try again later"})
+		return
+	}
+
 	principal, err := s.auth.Authenticate(r.Context(), auth.Credentials{Email: req.Email, Password: req.Password})
 	if err != nil {
+		s.loginLimiter.recordFailure(key)
 		writeJSON(w, http.StatusUnauthorized, errorResponse{"invalid credentials"})
 		return
 	}
+	s.loginLimiter.recordSuccess(key)
 
 	token, err := s.jwt.GenerateToken(r.Context(), principal)
 	if err != nil {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -589,5 +591,47 @@ func TestProtectedRouteAcceptsValidToken(t *testing.T) {
 	w := doRequestWithToken(h, http.MethodGet, "/api/projects", nil, token)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 with valid token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestLoginRateLimitReturns429WithRetryAfter pins the handler-level contract:
+// after the burst is spent, /api/auth/login returns 429 with a positive
+// Retry-After header (the limiter internals are covered in loginlimit_test.go;
+// this covers the wiring through the mux).
+func TestLoginRateLimitReturns429WithRetryAfter(t *testing.T) {
+	k8sClient := setupEnvtest(t)
+	ctx := context.Background()
+	_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+	authProvider := auth.NewNativeAuthProvider(k8sClient)
+	jwtHelper := auth.NewJWTHelper(k8sClient)
+	if err := authProvider.CreateUser(ctx, "admin@example.com", "initialpass", auth.RoleAdmin); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	srv := api.NewServer(k8sClient, fake.NewClientset(), nil, nil, authProvider, jwtHelper, nil, authz.NewNativePolicyEngine(k8sClient))
+	h := srv.Handler()
+
+	body := map[string]string{"email": "admin@example.com", "password": "wrong-password"}
+
+	// Burst is 10; the 11th attempt from the same key must be throttled.
+	var got429 *httptest.ResponseRecorder
+	for i := 0; i < 12; i++ {
+		w := doRequestWithToken(h, http.MethodPost, "/api/auth/login", body, "")
+		if w.Code == http.StatusTooManyRequests {
+			got429 = w
+			break
+		}
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: expected 401 before throttling, got %d", i+1, w.Code)
+		}
+	}
+	if got429 == nil {
+		t.Fatal("expected a 429 within the burst+1 window")
+	}
+	ra := got429.Header().Get("Retry-After")
+	if ra == "" {
+		t.Fatal("429 response missing Retry-After header")
+	}
+	if secs, err := strconv.Atoi(ra); err != nil || secs <= 0 {
+		t.Fatalf("expected positive integer Retry-After, got %q", ra)
 	}
 }

--- a/internal/api/loginlimit.go
+++ b/internal/api/loginlimit.go
@@ -123,6 +123,17 @@ func (l *loginLimiter) recordFailure(key string) {
 	now := l.now()
 	e := l.entries[key]
 	if e == nil {
+		// Same cap discipline as allow(): a new key under a full table gets
+		// neither throttling nor failure-tracking. Without this, failed logins
+		// for distinct usernames grow the map without bound (allow() fails open
+		// without inserting, so recordFailure is the only insert path) — the
+		// unbounded-process-memory class #447 paid for.
+		if len(l.entries) >= loginLimiterMaxEntries {
+			l.pruneLocked(now)
+		}
+		if len(l.entries) >= loginLimiterMaxEntries {
+			return
+		}
 		e = &loginEntry{tokens: l.burst, lastRefill: now}
 		l.entries[key] = e
 	}

--- a/internal/api/loginlimit.go
+++ b/internal/api/loginlimit.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Login throttling defaults; override via env (MORTISE_LOGIN_*). In-memory is
+// deliberate: the operator is single-replica by design, and a shared store
+// would be a heavier dependency than the threat warrants.
+const (
+	defaultLoginRatePerMin     = 5
+	defaultLoginBurst          = 10
+	defaultLoginLockoutAfter   = 10
+	defaultLoginLockoutMinutes = 15
+
+	// loginLimiterMaxEntries bounds memory under a key-spray attack. When the
+	// map is full, idle entries are pruned; if none are prunable the limiter
+	// fails open for new keys (a full table must not lock out real users).
+	loginLimiterMaxEntries = 10000
+	loginLimiterIdleEvict  = 30 * time.Minute
+)
+
+type loginEntry struct {
+	tokens      float64
+	lastRefill  time.Time
+	failures    int
+	lockedUntil time.Time
+	lastSeen    time.Time
+}
+
+// loginLimiter is a per-key token bucket with a sliding lockout on repeated
+// failures. Keys combine the lowercased username with the direct peer IP
+// (RemoteAddr, never X-Forwarded-For: XFF is attacker-controlled, and behind
+// a single ingress the per-username component does the real work anyway).
+type loginLimiter struct {
+	mu  sync.Mutex
+	now func() time.Time
+
+	ratePerMin   float64
+	burst        float64
+	lockoutAfter int
+	lockoutDur   time.Duration
+
+	entries map[string]*loginEntry
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func newLoginLimiter(now func() time.Time) *loginLimiter {
+	return &loginLimiter{
+		now:          now,
+		ratePerMin:   float64(envInt("MORTISE_LOGIN_RATE_PER_MIN", defaultLoginRatePerMin)),
+		burst:        float64(envInt("MORTISE_LOGIN_BURST", defaultLoginBurst)),
+		lockoutAfter: envInt("MORTISE_LOGIN_LOCKOUT_FAILURES", defaultLoginLockoutAfter),
+		lockoutDur:   time.Duration(envInt("MORTISE_LOGIN_LOCKOUT_MINUTES", defaultLoginLockoutMinutes)) * time.Minute,
+		entries:      make(map[string]*loginEntry),
+	}
+}
+
+func loginRateKey(email string, r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	return strings.ToLower(strings.TrimSpace(email)) + "|" + host
+}
+
+// allow reports whether a login attempt for key may proceed. When it may not,
+// retryAfter is how long the caller should advertise via Retry-After.
+func (l *loginLimiter) allow(key string) (bool, time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	e := l.entries[key]
+	if e == nil {
+		if len(l.entries) >= loginLimiterMaxEntries {
+			l.pruneLocked(now)
+		}
+		if len(l.entries) >= loginLimiterMaxEntries {
+			return true, 0
+		}
+		e = &loginEntry{tokens: l.burst, lastRefill: now}
+		l.entries[key] = e
+	}
+	e.lastSeen = now
+
+	if now.Before(e.lockedUntil) {
+		return false, e.lockedUntil.Sub(now)
+	}
+
+	elapsed := now.Sub(e.lastRefill).Minutes()
+	e.tokens = min(l.burst, e.tokens+elapsed*l.ratePerMin)
+	e.lastRefill = now
+
+	if e.tokens >= 1 {
+		e.tokens--
+		return true, 0
+	}
+	need := (1 - e.tokens) / l.ratePerMin
+	return false, time.Duration(need * float64(time.Minute))
+}
+
+// recordFailure counts a failed authentication. Reaching the threshold locks
+// the key out; further failures while locked out slide the window forward.
+func (l *loginLimiter) recordFailure(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	e := l.entries[key]
+	if e == nil {
+		e = &loginEntry{tokens: l.burst, lastRefill: now}
+		l.entries[key] = e
+	}
+	e.lastSeen = now
+	e.failures++
+	if e.failures >= l.lockoutAfter {
+		e.lockedUntil = now.Add(l.lockoutDur)
+	}
+}
+
+// recordSuccess clears all throttling state for the key — a successful login
+// proves the caller is not guessing.
+func (l *loginLimiter) recordSuccess(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.entries, key)
+}
+
+// pruneLocked drops entries idle past the eviction window. Callers hold l.mu.
+func (l *loginLimiter) pruneLocked(now time.Time) {
+	for k, e := range l.entries {
+		if now.Sub(e.lastSeen) > loginLimiterIdleEvict && now.After(e.lockedUntil) {
+			delete(l.entries, k)
+		}
+	}
+}

--- a/internal/api/loginlimit_test.go
+++ b/internal/api/loginlimit_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -123,6 +124,22 @@ func TestLoginLimiterFailsOpenWhenFull(t *testing.T) {
 	// service by the table being full.
 	if ok, _ := l.allow("fresh|key"); !ok {
 		t.Fatal("limiter must fail open for new keys when the table is full")
+	}
+}
+
+func TestLoginLimiterRecordFailureRespectsCap(t *testing.T) {
+	l, _ := newTestLimiter(time.Unix(1_700_000_000, 0))
+	// Fill with fresh (unprunable) entries so the cap is genuinely hit.
+	for i := 0; i < loginLimiterMaxEntries; i++ {
+		l.entries[string(rune(i))+"-filler"] = &loginEntry{lastSeen: l.now()}
+	}
+	// recordFailure is the only insert path when allow() fails open, so a
+	// spray of distinct failed-login keys must not grow the map past the cap.
+	for i := 0; i < 100; i++ {
+		l.recordFailure("spray-" + strconv.Itoa(i))
+	}
+	if len(l.entries) > loginLimiterMaxEntries {
+		t.Fatalf("recordFailure grew the map past the cap: %d > %d", len(l.entries), loginLimiterMaxEntries)
 	}
 }
 

--- a/internal/api/loginlimit_test.go
+++ b/internal/api/loginlimit_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestLimiter(start time.Time) (*loginLimiter, *time.Time) {
+	now := start
+	l := newLoginLimiter(func() time.Time { return now })
+	return l, &now
+}
+
+func TestLoginLimiterBurstThenThrottle(t *testing.T) {
+	l, _ := newTestLimiter(time.Unix(1_700_000_000, 0))
+
+	for i := 0; i < defaultLoginBurst; i++ {
+		if ok, _ := l.allow("u|ip"); !ok {
+			t.Fatalf("attempt %d within burst should be allowed", i+1)
+		}
+	}
+	ok, retryAfter := l.allow("u|ip")
+	if ok {
+		t.Fatal("attempt beyond burst should be throttled")
+	}
+	if retryAfter <= 0 || retryAfter > time.Minute {
+		t.Fatalf("expected sub-minute positive Retry-After, got %v", retryAfter)
+	}
+}
+
+func TestLoginLimiterTokensDecayBack(t *testing.T) {
+	l, now := newTestLimiter(time.Unix(1_700_000_000, 0))
+
+	for i := 0; i < defaultLoginBurst; i++ {
+		l.allow("u|ip")
+	}
+	if ok, _ := l.allow("u|ip"); ok {
+		t.Fatal("bucket should be empty")
+	}
+
+	// One minute refills ratePerMin tokens.
+	*now = now.Add(time.Minute)
+	for i := 0; i < defaultLoginRatePerMin; i++ {
+		if ok, _ := l.allow("u|ip"); !ok {
+			t.Fatalf("refilled attempt %d should be allowed", i+1)
+		}
+	}
+	if ok, _ := l.allow("u|ip"); ok {
+		t.Fatal("refill should be capped at ratePerMin after one minute")
+	}
+}
+
+func TestLoginLimiterLockoutSlidesAndExpires(t *testing.T) {
+	l, now := newTestLimiter(time.Unix(1_700_000_000, 0))
+
+	for i := 0; i < defaultLoginLockoutAfter; i++ {
+		l.recordFailure("u|ip")
+	}
+	ok, retryAfter := l.allow("u|ip")
+	if ok {
+		t.Fatal("expected lockout after threshold failures")
+	}
+	if retryAfter != time.Duration(defaultLoginLockoutMinutes)*time.Minute {
+		t.Fatalf("expected full lockout window, got %v", retryAfter)
+	}
+
+	// A failure mid-lockout slides the window forward.
+	*now = now.Add(10 * time.Minute)
+	l.recordFailure("u|ip")
+	if _, retryAfter = l.allow("u|ip"); retryAfter != time.Duration(defaultLoginLockoutMinutes)*time.Minute {
+		t.Fatalf("expected slid lockout window, got %v", retryAfter)
+	}
+
+	// After the window passes with no failures, attempts flow again.
+	*now = now.Add(time.Duration(defaultLoginLockoutMinutes)*time.Minute + time.Second)
+	if ok, _ := l.allow("u|ip"); !ok {
+		t.Fatal("expected lockout to expire")
+	}
+}
+
+func TestLoginLimiterSuccessResets(t *testing.T) {
+	l, _ := newTestLimiter(time.Unix(1_700_000_000, 0))
+
+	for i := 0; i < defaultLoginLockoutAfter-1; i++ {
+		l.recordFailure("u|ip")
+	}
+	l.recordSuccess("u|ip")
+
+	// The failure streak is gone: threshold-1 more failures do not lock out,
+	// and the bucket is back at full burst.
+	for i := 0; i < defaultLoginLockoutAfter-1; i++ {
+		l.recordFailure("u|ip")
+	}
+	if ok, _ := l.allow("u|ip"); !ok {
+		t.Fatal("success should have reset the failure streak")
+	}
+}
+
+func TestLoginLimiterKeysAreIndependent(t *testing.T) {
+	l, _ := newTestLimiter(time.Unix(1_700_000_000, 0))
+
+	for i := 0; i < defaultLoginBurst; i++ {
+		l.allow("alice|1.2.3.4")
+	}
+	if ok, _ := l.allow("alice|1.2.3.4"); ok {
+		t.Fatal("alice's bucket should be empty")
+	}
+	if ok, _ := l.allow("bob|1.2.3.4"); !ok {
+		t.Fatal("bob must not be throttled by alice's attempts")
+	}
+	if ok, _ := l.allow("alice|5.6.7.8"); !ok {
+		t.Fatal("alice from another IP must have her own bucket")
+	}
+}
+
+func TestLoginLimiterFailsOpenWhenFull(t *testing.T) {
+	l, _ := newTestLimiter(time.Unix(1_700_000_000, 0))
+	for i := 0; i < loginLimiterMaxEntries; i++ {
+		l.entries[string(rune(i))+"-filler"] = &loginEntry{lastSeen: l.now()}
+	}
+	// All entries are fresh (nothing prunable): a NEW key must not be denied
+	// service by the table being full.
+	if ok, _ := l.allow("fresh|key"); !ok {
+		t.Fatal("limiter must fail open for new keys when the table is full")
+	}
+}
+
+func TestLoginRateKeyShape(t *testing.T) {
+	r := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r.RemoteAddr = "10.1.2.3:5555"
+	if got := loginRateKey("  Alice@Example.COM ", r); got != "alice@example.com|10.1.2.3" {
+		t.Fatalf("unexpected key %q", got)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,6 +50,7 @@ type Server struct {
 	activityStore activity.Store
 	Clock         kclock.Clock
 	sseTokens     *sseTokenStore
+	loginLimiter  *loginLimiter
 	GitAPIFactory func(*mortisev1alpha1.GitProvider, string, string) (git.GitAPI, error)
 
 	// operatorNamespace/serviceAccountName identify the operator's own SA so
@@ -113,6 +115,9 @@ func NewServer(c client.Client, cs kubernetes.Interface, dc dynamic.Interface, r
 		GitAPIFactory: git.NewGitAPIFromProvider,
 	}
 	srv.sseTokens = newSSETokenStore(srv.clock())
+	// Closure (not srv.clock() directly) so a Clock injected after NewServer
+	// — the test pattern — still drives the limiter.
+	srv.loginLimiter = newLoginLimiter(func() time.Time { return srv.clock().Now() })
 	return srv
 }
 

--- a/internal/auth/native.go
+++ b/internal/auth/native.go
@@ -40,6 +40,22 @@ func NewNativeAuthProvider(c client.Client) *NativeAuthProvider {
 	}
 }
 
+// dummyPasswordHash is compared against when the user does not exist, so the
+// not-found path pays the same bcrypt cost as the found path. Without it the
+// fast not-found return is a username-enumeration timing oracle.
+var dummyPasswordHash = func() []byte {
+	h, err := bcrypt.GenerateFromPassword([]byte("mortise-timing-equalizer"), bcrypt.DefaultCost)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}()
+
+// compareHashAndPassword is a seam for tests to count bcrypt invocations —
+// the timing-oracle guarantee is "exactly one compare on every path", which
+// a counting hook asserts without flaky wall-clock measurement.
+var compareHashAndPassword = bcrypt.CompareHashAndPassword
+
 func userSecretName(email string) string {
 	return "user-" + hex.EncodeToString([]byte(email))
 }
@@ -55,6 +71,7 @@ func (n *NativeAuthProvider) Authenticate(ctx context.Context, creds Credentials
 		Namespace: namespace,
 	}, &secret)
 	if errors.IsNotFound(err) {
+		_ = compareHashAndPassword(dummyPasswordHash, []byte(creds.Password))
 		return Principal{}, fmt.Errorf("invalid credentials")
 	}
 	if err != nil {
@@ -62,7 +79,7 @@ func (n *NativeAuthProvider) Authenticate(ctx context.Context, creds Credentials
 	}
 
 	hash := secret.Data["password_hash"]
-	if err := bcrypt.CompareHashAndPassword(hash, []byte(creds.Password)); err != nil {
+	if err := compareHashAndPassword(hash, []byte(creds.Password)); err != nil {
 		return Principal{}, fmt.Errorf("invalid credentials")
 	}
 
@@ -284,13 +301,14 @@ func (n *NativeAuthProvider) VerifyPassword(ctx context.Context, email, password
 		Namespace: namespace,
 	}, &secret)
 	if errors.IsNotFound(err) {
+		_ = compareHashAndPassword(dummyPasswordHash, []byte(password))
 		return fmt.Errorf("invalid credentials")
 	}
 	if err != nil {
 		return fmt.Errorf("reading user secret: %w", err)
 	}
 
-	if err := bcrypt.CompareHashAndPassword(secret.Data["password_hash"], []byte(password)); err != nil {
+	if err := compareHashAndPassword(secret.Data["password_hash"], []byte(password)); err != nil {
 		return fmt.Errorf("invalid credentials")
 	}
 	return nil

--- a/internal/auth/native_test.go
+++ b/internal/auth/native_test.go
@@ -474,3 +474,69 @@ func TestJWTRejectsTokenWithWrongAudience(t *testing.T) {
 		t.Fatal("token with wrong audience should be rejected")
 	}
 }
+
+// countBcryptCompares swaps the compare seam for one test and reports how
+// many times it ran. The timing-oracle guarantee is structural — every
+// Authenticate/VerifyPassword path performs exactly one bcrypt comparison —
+// which a counter asserts deterministically where wall-clock timing cannot.
+func countBcryptCompares(t *testing.T) *int {
+	t.Helper()
+	orig := compareHashAndPassword
+	count := 0
+	compareHashAndPassword = func(hash, password []byte) error {
+		count++
+		return orig(hash, password)
+	}
+	t.Cleanup(func() { compareHashAndPassword = orig })
+	return &count
+}
+
+func TestAuthenticateTimingOracle(t *testing.T) {
+	provider, ctx := setup(t)
+	if err := provider.CreateUser(ctx, "alice@example.com", "s3cret12", RoleAdmin); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		email string
+	}{
+		{"existing user, wrong password", "alice@example.com"},
+		{"unknown user", "nobody@example.com"},
+	}
+	var wantErr string
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			count := countBcryptCompares(t)
+			_, err := provider.Authenticate(ctx, Credentials{Email: tc.email, Password: "wrongpwd"})
+			if err == nil {
+				t.Fatal("expected authentication failure")
+			}
+			if *count != 1 {
+				t.Fatalf("expected exactly 1 bcrypt compare, got %d", *count)
+			}
+			if i == 0 {
+				wantErr = err.Error()
+			} else if err.Error() != wantErr {
+				t.Fatalf("error strings differ between paths: %q vs %q", err.Error(), wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyPasswordTimingOracle(t *testing.T) {
+	provider, ctx := setup(t)
+	if err := provider.CreateUser(ctx, "carol@example.com", "s3cret12", RoleMember); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	for _, email := range []string{"carol@example.com", "nobody@example.com"} {
+		count := countBcryptCompares(t)
+		if err := provider.VerifyPassword(ctx, email, "wrongpwd"); err == nil {
+			t.Fatalf("expected failure for %s", email)
+		}
+		if *count != 1 {
+			t.Fatalf("expected exactly 1 bcrypt compare for %s, got %d", email, *count)
+		}
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -87,8 +87,18 @@ func (h *Handler) handleWebhook(w http.ResponseWriter, req *http.Request) {
 	// logged server-side only.
 	gp, err := h.k8s.getGitProvider(req.Context(), providerName)
 	if err != nil {
+		// Not-found is an auth decision and must be indistinguishable from the
+		// other pre-verification failures (401). A transient API error is an
+		// infrastructure fault, not an auth outcome, and returns 500 like the
+		// secret-fetch path below — it reveals nothing about provider existence
+		// since it fires regardless of whether the named provider exists.
+		if apierrors.IsNotFound(err) {
+			log.Info("webhook rejected: provider not found", "provider", providerName)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 		log.Error(err, "get GitProvider", "provider", providerName)
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,6 +35,7 @@ type Handler struct {
 // import controller-runtime directly in tests.
 type k8sReader interface {
 	getGitProvider(ctx context.Context, name string) (*mortisev1alpha1.GitProvider, error)
+	countGitProviders(ctx context.Context) (int, error)
 	getSecret(ctx context.Context, namespace, name, key string) (string, error)
 	getProject(ctx context.Context, name string) (*mortisev1alpha1.Project, error)
 	listGitApps(ctx context.Context) ([]mortisev1alpha1.App, error)
@@ -78,10 +80,15 @@ func (h *Handler) handleWebhook(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Every pre-verification failure below returns the identical 401 body.
+	// Distinguishable responses (provider-not-found 404, secret-not-configured
+	// 403, bad-signature 401) let an unauthenticated caller enumerate which
+	// provider names exist and how far their probe got; the distinction is
+	// logged server-side only.
 	gp, err := h.k8s.getGitProvider(req.Context(), providerName)
 	if err != nil {
 		log.Error(err, "get GitProvider", "provider", providerName)
-		http.Error(w, "provider not found", http.StatusNotFound)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -97,7 +104,8 @@ func (h *Handler) handleWebhook(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 	} else {
-		http.Error(w, "webhook secret not configured", http.StatusForbidden)
+		log.Info("webhook rejected: provider has no webhook secret configured", "provider", providerName)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -138,6 +146,41 @@ func (h *Handler) handleWebhook(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// providerMatches implements the empty-providerRef policy: a non-empty ref
+// must equal the delivering provider; an empty ref matches only when exactly
+// one GitProvider is registered, because the delivery then necessarily came
+// from it. Empty-ref matching against ANY of several providers would let a
+// push arriving via one provider trigger builds of Apps that belong to a
+// different forge entirely.
+func providerMatches(ref, delivering string, soleProvider bool) bool {
+	if ref != "" {
+		return ref == delivering
+	}
+	return soleProvider
+}
+
+// logSkippedAmbiguousProvider surfaces only the ambiguity skip — an ordinary
+// non-empty-ref mismatch is routine filtering and stays silent, as before.
+func logSkippedAmbiguousProvider(log logr.Logger, ref, app, namespace, delivering string) {
+	if ref != "" {
+		return
+	}
+	log.Info("skipping app: spec.source.providerRef is empty and multiple GitProviders are registered — set providerRef to receive webhooks",
+		"app", app, "namespace", namespace, "deliveringProvider", delivering)
+}
+
+// soleProvider reports whether exactly one GitProvider is registered. On a
+// count error it returns false — empty-providerRef matching then fails
+// closed (skip) rather than guessing.
+func (h *Handler) soleProvider(ctx context.Context) bool {
+	n, err := h.k8s.countGitProviders(ctx)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "count GitProviders for empty-providerRef matching")
+		return false
+	}
+	return n == 1
+}
+
 // dispatchToApps lists all git-source Apps and patches mortise.dev/revision on
 // those whose repo URL and branch match the push event. Errors are logged but
 // do not fail the HTTP response — the forge has already delivered the event.
@@ -149,6 +192,7 @@ func (h *Handler) dispatchToApps(ctx context.Context, br BuildRequest) {
 		log.Error(err, "list git apps for dispatch")
 		return
 	}
+	soleProvider := h.soleProvider(ctx)
 
 	pushedBranch := branchFromRef(br.Ref)
 
@@ -163,7 +207,8 @@ func (h *Handler) dispatchToApps(ctx context.Context, br BuildRequest) {
 		if src.Type != mortisev1alpha1.SourceTypeGit {
 			continue
 		}
-		if src.ProviderRef != "" && src.ProviderRef != br.Provider {
+		if !providerMatches(src.ProviderRef, br.Provider, soleProvider) {
+			logSkippedAmbiguousProvider(log, src.ProviderRef, app.Name, app.Namespace, br.Provider)
 			continue
 		}
 		if !repoMatches(src.Repo, br.Repo) {
@@ -203,6 +248,7 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 		log.Error(err, "list git apps for PR dispatch")
 		return
 	}
+	soleProvider := h.soleProvider(ctx)
 
 	// Collect the set of projects that have at least one app matching the
 	// PR's repo and provider. We only need one PE per project.
@@ -216,7 +262,8 @@ func (h *Handler) dispatchPREvent(ctx context.Context, pr PREvent) {
 		if src.Type != mortisev1alpha1.SourceTypeGit {
 			continue
 		}
-		if src.ProviderRef != "" && src.ProviderRef != pr.Provider {
+		if !providerMatches(src.ProviderRef, pr.Provider, soleProvider) {
+			logSkippedAmbiguousProvider(log, src.ProviderRef, app.Name, app.Namespace, pr.Provider)
 			continue
 		}
 		if !repoMatches(src.Repo, pr.Repo) {

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -29,6 +29,9 @@ type fakeK8sReader struct {
 	projects map[string]*mortisev1alpha1.Project // name -> project
 	err      error
 
+	// providerCount overrides the derived GitProvider count when > 0.
+	providerCount int
+
 	// patched records calls to patchAppRevision: app namespace/name -> sha
 	patched map[string]string
 
@@ -37,6 +40,19 @@ type fakeK8sReader struct {
 	createdPreviews []mortisev1alpha1.PreviewEnvironment
 	updatedPreviews []mortisev1alpha1.PreviewEnvironment
 	deletedKeys     []string // "ns/name" keys
+}
+
+// providerCount overrides countGitProviders when set; otherwise the count
+// mirrors whether `provider` is populated (the single-provider default that
+// keeps empty-providerRef fixtures matching, as they did pre-policy).
+func (f *fakeK8sReader) countGitProviders(_ context.Context) (int, error) {
+	if f.providerCount > 0 {
+		return f.providerCount, nil
+	}
+	if f.provider != nil {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (f *fakeK8sReader) getGitProvider(_ context.Context, name string) (*mortisev1alpha1.GitProvider, error) {
@@ -336,17 +352,45 @@ func TestGitLabWebhook_ValidToken(t *testing.T) {
 	}
 }
 
-func TestWebhook_ProviderNotFound(t *testing.T) {
-	kr := &fakeK8sReader{err: fmt.Errorf("not found")}
-	h := New(kr)
+// TestWebhook_PreVerificationFailuresAreUniform pins the anti-enumeration
+// contract: an unauthenticated caller gets the identical 401 body whether the
+// provider does not exist, exists without a webhook secret, or fails
+// signature verification — no probing which provider names are registered.
+func TestWebhook_PreVerificationFailuresAreUniform(t *testing.T) {
+	cases := []struct {
+		name string
+		kr   *fakeK8sReader
+	}{
+		{name: "provider not found", kr: &fakeK8sReader{err: fmt.Errorf("not found")}},
+		{name: "webhook secret not configured", kr: &fakeK8sReader{
+			provider: &mortisev1alpha1.GitProvider{
+				Spec: mortisev1alpha1.GitProviderSpec{Type: mortisev1alpha1.GitProviderTypeGitea},
+			},
+		}},
+		{name: "invalid signature", kr: &fakeK8sReader{
+			provider: makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "hook", "secret"),
+			secrets:  map[string]string{"mortise-system/hook/secret": "topsecret"},
+		}},
+	}
 
-	req := httptest.NewRequest(http.MethodPost, "/unknown-provider", http.NoBody)
+	var wantBody string
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := New(tc.kr)
+			req := httptest.NewRequest(http.MethodPost, "/some-provider", strings.NewReader("{}"))
 
-	rr := httptest.NewRecorder()
-	h.Routes().ServeHTTP(rr, req)
+			rr := httptest.NewRecorder()
+			h.Routes().ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", rr.Code)
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("expected uniform 401, got %d", rr.Code)
+			}
+			if i == 0 {
+				wantBody = rr.Body.String()
+			} else if rr.Body.String() != wantBody {
+				t.Fatalf("response bodies differ between pre-verification failures: %q vs %q", rr.Body.String(), wantBody)
+			}
+		})
 	}
 }
 
@@ -1749,5 +1793,70 @@ func TestRepoMatches(t *testing.T) {
 		if got != tc.match {
 			t.Errorf("repoMatches(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.match)
 		}
+	}
+}
+
+// TestWebhook_EmptyProviderRefPolicy pins the empty-providerRef matching
+// decision: an empty ref matches only when exactly one GitProvider is
+// registered (the delivery necessarily came from it); with several
+// registered, empty-ref apps are skipped instead of matching webhooks from
+// ANY provider. A non-empty ref must equal the delivering provider.
+func TestWebhook_EmptyProviderRefPolicy(t *testing.T) {
+	const secret = "secret"
+
+	emptyRef := makeGitApp("app-empty", "pj-a", "https://github.com/org/repo", "main")
+	matchingRef := makeGitApp("app-match", "pj-a", "https://github.com/org/repo", "main")
+	matchingRef.Spec.Source.ProviderRef = "github-main"
+	otherRef := makeGitApp("app-other", "pj-a", "https://github.com/org/repo", "main")
+	otherRef.Spec.Source.ProviderRef = "gitlab-main"
+
+	tests := []struct {
+		name          string
+		providerCount int
+		wantPatched   []string // ns/name expected patched
+	}{
+		{
+			name:          "single provider: empty ref matches, foreign ref does not",
+			providerCount: 1,
+			wantPatched:   []string{"pj-a/app-empty", "pj-a/app-match"},
+		},
+		{
+			name:          "multiple providers: empty ref is ambiguous and skipped",
+			providerCount: 2,
+			wantPatched:   []string{"pj-a/app-match"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := pushPayloadJSON("refs/heads/main", "shaaaaa", "org/repo")
+			gp := makeGitProvider(mortisev1alpha1.GitProviderTypeGitHub, "mortise-system", "wh-secret", "value")
+			kr := &fakeK8sReader{
+				provider:      gp,
+				providerCount: tc.providerCount,
+				secrets:       map[string]string{"mortise-system/wh-secret/value": secret},
+				apps:          []mortisev1alpha1.App{emptyRef, matchingRef, otherRef},
+			}
+			h := newTestHandler(kr)
+
+			req := httptest.NewRequest(http.MethodPost, "/github-main", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Hub-Signature-256", githubSignature(body, secret))
+
+			rr := httptest.NewRecorder()
+			h.Routes().ServeHTTP(rr, req)
+			if rr.Code != http.StatusAccepted {
+				t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+			}
+
+			if len(kr.patched) != len(tc.wantPatched) {
+				t.Fatalf("expected %d patched apps, got %v", len(tc.wantPatched), kr.patched)
+			}
+			for _, key := range tc.wantPatched {
+				if kr.patched[key] != "shaaaaa" {
+					t.Errorf("expected %s patched, got %v", key, kr.patched)
+				}
+			}
+		})
 	}
 }

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -60,7 +60,7 @@ func (f *fakeK8sReader) getGitProvider(_ context.Context, name string) (*mortise
 		return nil, f.err
 	}
 	if f.provider == nil {
-		return nil, fmt.Errorf("not found")
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "mortise.mortise.dev", Resource: "gitproviders"}, name)
 	}
 	return f.provider, nil
 }
@@ -361,7 +361,9 @@ func TestWebhook_PreVerificationFailuresAreUniform(t *testing.T) {
 		name string
 		kr   *fakeK8sReader
 	}{
-		{name: "provider not found", kr: &fakeK8sReader{err: fmt.Errorf("not found")}},
+		{name: "provider not found", kr: &fakeK8sReader{
+			err: apierrors.NewNotFound(schema.GroupResource{Group: "mortise.mortise.dev", Resource: "gitproviders"}, "some-provider"),
+		}},
 		{name: "webhook secret not configured", kr: &fakeK8sReader{
 			provider: &mortisev1alpha1.GitProvider{
 				Spec: mortisev1alpha1.GitProviderSpec{Type: mortisev1alpha1.GitProviderTypeGitea},

--- a/internal/webhook/k8s.go
+++ b/internal/webhook/k8s.go
@@ -31,6 +31,16 @@ func (r *K8sReader) getGitProvider(ctx context.Context, name string) (*mortisev1
 	return &gp, nil
 }
 
+// countGitProviders returns how many GitProviders are registered — the
+// input to the empty-providerRef matching policy.
+func (r *K8sReader) countGitProviders(ctx context.Context) (int, error) {
+	var list mortisev1alpha1.GitProviderList
+	if err := r.client.List(ctx, &list); err != nil {
+		return 0, fmt.Errorf("list GitProviders: %w", err)
+	}
+	return len(list.Items), nil
+}
+
 // getProject fetches the cluster-scoped Project CR by name.
 func (r *K8sReader) getProject(ctx context.Context, name string) (*mortisev1alpha1.Project, error) {
 	var project mortisev1alpha1.Project


### PR DESCRIPTION
Part of #444 (auth items).

## What changes

Four auth-surface items from the #444 audit, plus one the audit missed:

- **Username-enumeration timing oracle closed — in two places.** `Authenticate` returned early on user-not-found while found users paid a bcrypt comparison. `VerifyPassword` (not named in the audit) had the identical fast path. Both now perform exactly one bcrypt compare on every path (package-level precomputed dummy hash on not-found) and return byte-identical errors. Tested structurally: a counting seam on the compare function asserts exactly-one-invocation per path, with error-string identity pinned across paths — no flaky wall-clock assertions.
- **Login rate limiting.** Per username+IP token bucket (5/min sustained, burst 10) with a sliding 15-minute lockout after 10 consecutive failures; throttled requests get `429` + `Retry-After`; defaults overridable via `MORTISE_LOGIN_RATE_PER_MIN` / `MORTISE_LOGIN_BURST` / `MORTISE_LOGIN_LOCKOUT_FAILURES` / `MORTISE_LOGIN_LOCKOUT_MINUTES`. Design points worth review attention: keys use `RemoteAddr` and never `X-Forwarded-For` (attacker-controlled); a successful login deletes the key, so serial legitimate logins (CI, e2e — every spec file logs in) never accumulate toward throttling; the table is bounded at 10k entries and **fails open for new keys when full** — a deliberate choice, since a key-spray filling the table must degrade to no-throttling rather than become a denial-of-service on real users. In-memory by design: single-replica operator.
- **Uniform webhook 401.** Provider-not-found (404), secret-not-configured (403), and bad-signature (401) were three distinguishable unauthenticated responses — a provider-name enumeration oracle. All pre-verification failures now return the identical `401 unauthorized` body; a test asserts byte-identical bodies across all three modes. The distinction lives in server logs only. Genuine server faults (secret fetch error) remain 500.
- **`providerRef` empty-matches-any — decision (a), stated explicitly.** An App with empty `spec.source.providerRef` accepted webhook events from ANY registered provider. It now matches only while exactly one GitProvider is registered (the delivery necessarily came from it); with more, the app is skipped with an actionable log line naming the app and the fix. Fail-closed on provider-count errors. **This is a behavior change for multi-provider installs**: migration note under Breaking changes → Authentication in docs/migration-v1.md includes a jq one-liner listing affected apps; CHANGELOG entry calls it out. Option (b) (host-based repo matching) was rejected as it silently couples matching to provider host configuration — (a) is predictable and auditable.

**Deliberately not done:** the fifth #444 auth item (7-day JWT refresh leeway). Shrinking it silently logs out users returning after a weekend+ absence; #282 tracks the interface-level answer post-OIDC. Stated here so the omission is a decision, not an oversight.

## Tests

- `native_test.go`: counting-seam oracle tests for both paths, error-identity pinned.
- `loginlimit_test.go`: 7 cases — burst-then-throttle, refill decay, lockout slide + expiry, success reset, key independence, fail-open-when-full, key shape.
- `handler_test.go`: uniform-401 body-identity across the three failure modes; empty-providerRef policy matrix (single vs multiple providers, foreign non-empty refs).

## Gate

Fast legs green. Integration: 2 reds, both the tracked mo-j6k ready-ceiling shape, both **affirmatively cleared of branch involvement** — operator logs show zero limiter activity and zero policy skips (the new code paths never executed in integration), zero error-level forbidden — and both pass isolated with wide margins (86s/220s vs 491s/316s ceilings); occurrences on mo-j6k. E2E on the rebased tree: **166/166, zero flaky, 52.8s** (the pre-rebase run's single red was the tracked mainline #478×#479 assertion, fixed by #481 which is now underneath this branch).