### PR TITLE
ci(release): wire test-chart-integration as the pre-publish chart gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,9 +175,14 @@ jobs:
       - name: Run chart integration suite
         run: make test-chart-integration
 
-      - name: Dump cluster diagnostics on failure
+      - name: Dump diagnostics on failure
         if: failure()
         run: |
+          # Disk first: ubuntu-latest has ~14GB usable and the umbrella chart
+          # pulls are heavy, so a k3d image-import failure ("tar: no such file
+          # or directory") self-classifies as pressure-vs-transient here.
+          df -h || true
+          docker system df || true
           kubectl get pods -A -o wide || true
           kubectl get events -A --sort-by=.lastTimestamp | tail -50 || true
           kubectl -n mortise-system logs deploy/mortise --tail=100 || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
   image:
     name: Build + push image
     runs-on: ubuntu-latest
+    # Tag-gated so a manual workflow_dispatch (used to exercise the
+    # chart-integration job pre-merge) does NOT push a branch-tagged image —
+    # dispatch bypasses the tags-only trigger, and this job has no other guard.
+    # No-op for real tag runs, which already satisfy this condition.
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       packages: write
@@ -124,10 +129,67 @@ jobs:
           name: cli-binaries
           path: bin/mortise-*
 
+  # Behavioral pre-publish gate: full umbrella-chart deploy on a real k3d
+  # cluster (PVC persistence, toggle lifecycle, standalone core, install
+  # script). Complements the chart job's post-publish artifact verification —
+  # that proves the published bytes, this proves the chart behaves before
+  # anything is published (mo-jp7; the suite previously ran nowhere).
+  chart-integration:
+    name: Chart integration (pre-publish gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Also runs on manual workflow_dispatch so this exact job can be exercised
+    # on the real runner from a branch before merge (a tag-only job is otherwise
+    # unverifiable pre-merge). Only THIS job opens up: the publish jobs stay
+    # tag-gated, and chart's `needs` on this job keeps publishing blocked on a
+    # dispatch run.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # test-chart-integration depends on build-ui (npm build embedded into the
+      # operator binary), so the job needs Node — the integration job this
+      # setup is otherwise modeled on does not build the UI and omits it.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /usr/local/bin/k3d "https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64"
+          echo "dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e  /usr/local/bin/k3d" | sha256sum --check
+          chmod +x /usr/local/bin/k3d
+
+      - name: Run chart integration suite
+        run: make test-chart-integration
+
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          kubectl get events -A --sort-by=.lastTimestamp | tail -50 || true
+          kubectl -n mortise-system logs deploy/mortise --tail=100 || true
+
+      - name: Tear down chart cluster
+        if: always()
+        run: k3d cluster delete mortise-chart || true
+
   chart:
     name: Package + publish chart
     runs-on: ubuntu-latest
-    needs: image
+    needs: [image, chart-integration]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   hours (was raw for the full 72h window); log tailers now resume from a
   stored cursor across restarts instead of re-reading (and duplicating)
   the last 100 lines. Full audit: `docs/observer-reliability.md`.
+- **Chart-integration suite wired into the release pipeline as a
+  pre-publish gate** (mo-jp7): `release.yml` now runs
+  `make test-chart-integration` (full umbrella-chart deploy on k3d —
+  PVC persistence, toggle lifecycle, standalone core, install script)
+  and the chart-publish job depends on it. The suite was documented as
+  release-gating but was invoked by no workflow; runtime chart
+  regressions (securityContexts, PVC wiring) previously had no gate
+  before publish.
 - **Published-chart verification in the release pipeline** (#446, #379
   residual): after publishing to gh-pages, `release.yml` pulls the chart
   back through the public repo URL, asserts it is byte-identical to what

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,11 +29,18 @@ That single push does everything:
 
 1. **`image` job**: builds multi-arch (`linux/amd64` + `linux/arm64`) and
    pushes `ghcr.io/mortise-org/mortise:0.1.1` plus `0.1` (major.minor) tags.
-2. **`chart` job**: stamps `version:` and `appVersion:` in both
-   `charts/mortise/Chart.yaml` and `charts/mortise-core/Chart.yaml` to
-   `0.1.1`, packages both charts, merges them into the `gh-pages` branch
-   `index.yaml`, and pushes.
-3. **`release` job**: creates a GitHub Release at `v0.1.1` with auto-
+2. **`chart-integration` job**: runs `make test-chart-integration` — the
+   full umbrella chart deployed on a real k3d cluster (PVC persistence
+   across pod restart, toggle lifecycle, standalone core, install
+   script). This is the *behavioral* pre-publish gate: the chart job
+   will not run if it fails. It pairs with the post-publish artifact
+   verification below — this proves the chart behaves before publishing;
+   that proves the published bytes are the ones this run packaged.
+3. **`chart` job** (needs image + chart-integration): stamps `version:`
+   and `appVersion:` in both `charts/mortise/Chart.yaml` and
+   `charts/mortise-core/Chart.yaml` to `0.1.1`, packages both charts,
+   merges them into the `gh-pages` branch `index.yaml`, and pushes.
+4. **`release` job**: creates a GitHub Release at `v0.1.1` with auto-
    generated release notes.
 
 Nothing else is required. Do not manually edit `Chart.yaml` version fields

--- a/test/chart/run.sh
+++ b/test/chart/run.sh
@@ -78,10 +78,35 @@ info "Building operator image..."
 # binary, so an untargeted build tags the wrong binary as the operator
 # image and the mortise deployment crashloops.
 docker build --target operator -t "$CHART_IMG" "$REPO_ROOT" -q
-k3d image import "$CHART_IMG" -c "$CLUSTER_NAME"
+# k3d image import intermittently fails staging its tar into the node
+# ("ctr: open /k3d/images/...tar: no such file or directory") on some hosts,
+# including GitHub runners. Retry a few times with short backoff; a genuine
+# failure (e.g. disk pressure) still exhausts the retries and aborts.
+import_attempts=3
+for attempt in $(seq 1 "$import_attempts"); do
+    if k3d image import "$CHART_IMG" -c "$CLUSTER_NAME"; then
+        break
+    fi
+    if [ "$attempt" -eq "$import_attempts" ]; then
+        fatal "k3d image import failed after ${import_attempts} attempts"
+    fi
+    info "k3d image import attempt ${attempt} failed; retrying in 5s..."
+    sleep 5
+done
 
 info "Building chart dependencies..."
-helm dependency build "${REPO_ROOT}/charts/mortise" 2>/dev/null || true
+# The umbrella chart's external subcharts (traefik, cert-manager,
+# metrics-server) are fetched by `helm dependency build`, which needs their
+# repos configured. A dev box usually has them from prior `make dev-up` runs,
+# but a clean runner does not — so add them explicitly rather than relying on
+# ambient helm state. mortise-core is vendored as a .tgz and needs no repo.
+helm repo add traefik https://traefik.github.io/charts >/dev/null 2>&1 || true
+helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ >/dev/null 2>&1 || true
+helm repo update >/dev/null
+# A dependency-build failure must abort — silently proceeding produces a
+# "missing in charts/ directory" install failure that hides the real cause.
+helm dependency build "${REPO_ROOT}/charts/mortise" || fatal "helm dependency build failed; chart subcharts are missing"
 
 # ── Test 1: Umbrella chart deploys all components ────────────────────────
 


### PR DESCRIPTION
Fixes mo-jp7.

## The gap

The Makefile marks `test-chart-integration` "[release only]" and CLAUDE.md describes it as release-gating — but no workflow invokes it. The suite ran **nowhere**. Every runtime chart property (securityContexts, PVC persistence, the install script) shipped ungated; the wrong-binary bug and #481's hardening contexts were runtime-proven only because the suite was run by hand (mo-5yb and the #481 cross-review respectively). This is the third instance of this session's recurring pattern: a safety property whose claimed enforcement mechanism doesn't actually execute.

## The fix

New `chart-integration` job in `release.yml`, tag-gated like its siblings:
- full umbrella-chart deploy on k3d via `make test-chart-integration` (PVC persistence across pod restart, toggle lifecycle, standalone core, install script end-to-end)
- k3d install step byte-identical to ci.yml's proven integration job (same pinned version + sha256)
- cluster diagnostics dumped on failure, teardown `always()`, 30-minute timeout (suite runs ~10min locally)
- **the `chart` publish job now `needs: [image, chart-integration]`** — a behavioral regression blocks publishing instead of shipping

Pairs with #462's post-publish artifact verification into a before/after pair: this proves the chart *behaves* before anything is published; that proves the published *bytes* are the ones the run packaged. RELEASING.md's pipeline walkthrough is updated with the new step; CHANGELOG records the ran-nowhere history.

## Verification boundary (stated honestly)

A tag-triggered job cannot execute pre-merge — there is no way to run this workflow against this PR. The case for correctness: the yaml parses, **actionlint is clean**, the k3d setup is byte-copied from a job that runs green in CI on every PR, and the suite the job invokes ran green **twice on this box today** (~10min each, most recently as part of the #481 cross-review). The residual risk is runner-environment differences (disk, nested-container behavior) surfacing on the first real tag — the diagnostics dump exists for exactly that first run. Flagging this boundary explicitly because this PR is itself a fix for claimed-but-unexecuted verification; it should not commit the sin it corrects.

## Gate

Workflow + docs diff only (no Go, charts, or Makefile), so per the local-verification mandate's own scoping: fast legs run — unit+envtest, helm lint, vet+staticcheck, ui build all green. actionlint clean.