### PR TITLE
fix(platformconfig): surface pull-URL and restart-required drift as conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **PlatformConfig misconfiguration conditions** (#449): the PlatformConfig
+  status now surfaces two problems that previously lived only in operator
+  logs. `RegistryPullConfig=False/PullURLMissing` flags a cluster-internal
+  `spec.registry.url` (`*.svc` / `*.svc.cluster.local`, precise host-suffix
+  match instead of the old substring check) with no `spec.registry.pullURL` —
+  the config shape where kubelet image pulls fail. `ConfigApplied=False/
+  RestartRequired` flags that the running operator booted with a different
+  config than the current spec, naming the drifted sections in the message
+  (or that it started before the PlatformConfig existed, on env-var
+  fallback). The env-var fallback path also warns at boot when the registry
+  URL is cluster-internal. There is still no hot reload: conditions tell
+  you when a `rollout restart deployment/mortise` is needed
+  (docs/configuration.md).
+
 - **Bundled build-infra hardening** (#440, #113): the registry and its
   node-local proxy now run with restricted-style securityContexts by
   default (non-root, no privilege escalation, read-only rootfs, fsGroup

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ dev-up: build-ui ## Create k3d dev cluster with build infra, install Mortise, po
 	@echo "==> Applying dev PlatformConfig..."
 	kubectl --context $(DEV_KUBE_CONTEXT) apply -f test/dev/platform-config.yaml
 	@echo "==> Restarting operator to pick up config..."
+	# The operator consumes PlatformConfig registry/build settings once at
+	# boot (no hot reload; ConfigApplied=RestartRequired tracks drift).
 	kubectl --context $(DEV_KUBE_CONTEXT) -n mortise-system rollout restart deployment/mortise
 	kubectl --context $(DEV_KUBE_CONTEXT) -n mortise-system rollout status deployment/mortise --timeout=60s
 	@echo "==> Starting port-forward..."
@@ -506,6 +508,7 @@ dev-reload: build-ui ## Rebuild image, re-apply CRDs + chart, restart Mortise in
 		--set platformConfig.enabled=false \
 		--set cert-manager.enabled=false \
 		--set metrics-server.args='{--kubelet-insecure-tls}'
+	# Restart required: PlatformConfig registry/build settings load at boot only.
 	kubectl --context $(DEV_KUBE_CONTEXT) rollout restart deployment/mortise -n mortise-system
 	kubectl --context $(DEV_KUBE_CONTEXT) rollout status deployment/mortise -n mortise-system --timeout 60s
 	@-pkill -f "[k]ubectl port-forward.*8090" >/dev/null 2>&1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,6 +98,11 @@ type stacks struct {
 	registry *registry.OCIBackend
 	git      git.GitClient
 
+	// bootConfig is the resolved PlatformConfig these stacks were built
+	// from (nil on the env fallback). The PlatformConfig controller diffs
+	// it against the live spec to surface restart-required drift (#449).
+	bootConfig *platformconfig.Config
+
 	// TLS is the resolved cert-manager / TLS configuration from PlatformConfig.
 	// Currently only CertManagerClusterIssuer is consumed (by the App
 	// reconciler); kept as a struct so future TLS settings can land here
@@ -122,7 +127,9 @@ type stacks struct {
 func buildStacks(ctx context.Context, reader client.Reader, log logr.Logger) stacks {
 	cfg, err := platformconfig.Load(ctx, reader)
 	if err == nil {
-		return stacksFromPlatformConfig(cfg, log)
+		stk := stacksFromPlatformConfig(cfg, log)
+		stk.bootConfig = cfg
+		return stk
 	}
 	if errors.Is(err, platformconfig.ErrNotFound) {
 		log.Info("PlatformConfig \"platform\" not found; using env-var fallback. " +
@@ -159,7 +166,7 @@ func stacksFromPlatformConfig(cfg *platformconfig.Config, log logr.Logger) stack
 	// Kubelet resolves image refs via host DNS, so cluster-internal .svc
 	// registry URLs are unpullable from nodes. Without pullURL the pull ref
 	// falls back to the push URL and every fresh deploy ImagePullBackOffs.
-	if cfg.Registry.URL != "" && cfg.Registry.PullURL == "" && strings.Contains(cfg.Registry.URL, ".svc") {
+	if cfg.Registry.URL != "" && cfg.Registry.PullURL == "" && platformconfig.LooksClusterInternal(cfg.Registry.URL) {
 		log.Info("WARNING: spec.registry.pullURL is empty and spec.registry.url is cluster-internal; "+
 			"kubelet-facing image refs will use the push URL, which nodes typically cannot resolve. "+
 			"Set spec.registry.pullURL (and restart the operator) if pods fail to pull built images.",
@@ -188,6 +195,16 @@ func stacksFromPlatformConfig(cfg *platformconfig.Config, log logr.Logger) stack
 func stacksFromEnv(log logr.Logger) stacks {
 	buildkitAddr := envOrDefault("MORTISE_BUILDKIT_ADDR", "tcp://buildkitd.mortise-system.svc:1234")
 	registryURL := envOrDefault("MORTISE_REGISTRY_URL", "http://zot.mortise-system.svc:5000")
+
+	// Same kubelet-unpullable shape the PlatformConfig path warns about —
+	// and the env fallback has no pullURL at all, so it always applies to
+	// cluster-internal URLs (including this default).
+	if platformconfig.LooksClusterInternal(registryURL) {
+		log.Info("WARNING: registry URL is cluster-internal and the env fallback has no pull URL; "+
+			"kubelet-facing image refs will use it directly, which nodes typically cannot resolve. "+
+			"Create a PlatformConfig with spec.registry.pullURL and restart the operator.",
+			"url", registryURL)
+	}
 
 	var bc build.BuildClient
 	if bk, err := build.New(build.Config{Addr: buildkitAddr}); err != nil {
@@ -463,8 +480,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.PlatformConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		BootConfig: stk.bootConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "PlatformConfig")
 		os.Exit(1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,27 @@ set `registry.enabled: false` in your Helm values and configure
 `PlatformConfig.spec.registry` to point at your registry. The DaemonSet
 proxy is not deployed when the bundled registry is disabled.
 
+**Registry and build changes require an operator restart.** The operator
+reads `spec.registry` and `spec.build` once at startup. After editing
+them, restart it:
+
+```
+kubectl -n mortise-system rollout restart deployment/mortise
+```
+
+The PlatformConfig's status reports this state: `ConfigApplied=False`
+with reason `RestartRequired` means the running operator booted with
+different settings (or started before the PlatformConfig existed) and a
+restart is needed. `RegistryPullConfig=False` with reason
+`PullURLMissing` means `spec.registry.url` is a cluster-internal address
+(`*.svc` / `*.svc.cluster.local`) but `spec.registry.pullURL` is empty —
+kubelet cannot resolve cluster-internal DNS, so fresh deploys would fail
+to pull. Check with:
+
+```
+kubectl get platformconfig platform -o jsonpath='{.status.conditions}'
+```
+
 ## Environments
 
 Every project starts with a **production** environment. You can add more

--- a/internal/controller/platformconfig_controller.go
+++ b/internal/controller/platformconfig_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,15 +30,35 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/platformconfig"
 )
 
 // singletonName is the required metadata.name for the singleton PlatformConfig.
 const singletonName = "platform"
 
+// Condition types surfacing configuration problems on the CR itself instead
+// of only in operator logs (#449). No hot reload in v1 — these conditions
+// are the visibility half; the operator still consumes registry/build config
+// once at boot.
+const (
+	// pcRegistryPullConfigCondition is False when the registry URL is
+	// cluster-internal and no kubelet-facing pullURL is set: fresh deploys
+	// will ImagePullBackOff.
+	pcRegistryPullConfigCondition = "RegistryPullConfig"
+	// pcConfigAppliedCondition is False when the running operator booted
+	// from a different config than the current spec (or from the env
+	// fallback before this CR existed): a restart is required to apply.
+	pcConfigAppliedCondition = "ConfigApplied"
+)
+
 // PlatformConfigReconciler reconciles a PlatformConfig object
 type PlatformConfigReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// BootConfig is the resolved config the operator actually consumed at
+	// startup; nil means the operator booted on the env fallback (no
+	// PlatformConfig existed yet).
+	BootConfig *platformconfig.Config
 }
 
 // +kubebuilder:rbac:groups=mortise.mortise.dev,resources=platformconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -93,7 +114,67 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	r.setRegistryPullCondition(&pc)
+	r.setConfigAppliedCondition(ctx, &pc)
+
 	return ctrl.Result{}, r.markReady(ctx, &pc)
+}
+
+// setRegistryPullCondition mirrors (and sharpens) the boot-time warning: a
+// cluster-internal registry URL with no pullURL means kubelet-facing image
+// refs fall back to the push URL, which nodes cannot resolve.
+func (r *PlatformConfigReconciler) setRegistryPullCondition(pc *mortisev1alpha1.PlatformConfig) {
+	url := pc.Spec.Registry.URL
+	if url != "" && pc.Spec.Registry.PullURL == "" && platformconfig.LooksClusterInternal(url) {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               pcRegistryPullConfigCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PullURLMissing",
+			Message:            "spec.registry.url is cluster-internal and spec.registry.pullURL is empty; kubelet-facing image refs will use the push URL, which nodes cannot resolve — set spec.registry.pullURL, then restart the operator",
+			ObservedGeneration: pc.Generation,
+		})
+		return
+	}
+	meta.RemoveStatusCondition(&pc.Status.Conditions, pcRegistryPullConfigCondition)
+}
+
+// setConfigAppliedCondition compares the config the operator booted with
+// (snapshot handed over by main) against the current spec. Drift — or an
+// env-fallback boot from before this CR existed — surfaces as
+// ConfigApplied=False/RestartRequired. There is deliberately no hot reload.
+func (r *PlatformConfigReconciler) setConfigAppliedCondition(ctx context.Context, pc *mortisev1alpha1.PlatformConfig) {
+	if r.BootConfig == nil {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               pcConfigAppliedCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "RestartRequired",
+			Message:            "the operator started before this PlatformConfig existed and is running on environment-variable fallback config; restart the operator deployment to apply this configuration",
+			ObservedGeneration: pc.Generation,
+		})
+		return
+	}
+	current, err := platformconfig.Load(ctx, r.Client)
+	if err != nil {
+		// Can't compare — leave whatever state exists rather than flapping.
+		return
+	}
+	if changed := platformconfig.DiffSections(r.BootConfig, current); len(changed) > 0 {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               pcConfigAppliedCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "RestartRequired",
+			Message:            fmt.Sprintf("configuration changed since the operator started (changed: %s); the running operator still uses the old settings — restart the operator deployment to apply (kubectl -n mortise-system rollout restart deployment/mortise)", strings.Join(changed, ", ")),
+			ObservedGeneration: pc.Generation,
+		})
+		return
+	}
+	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+		Type:               pcConfigAppliedCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Applied",
+		Message:            "the running operator was started with this configuration",
+		ObservedGeneration: pc.Generation,
+	})
 }
 
 func (r *PlatformConfigReconciler) markReady(ctx context.Context, pc *mortisev1alpha1.PlatformConfig) error {

--- a/internal/controller/platformconfig_controller_test.go
+++ b/internal/controller/platformconfig_controller_test.go
@@ -23,11 +23,13 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/platformconfig"
 )
 
 var _ = Describe("PlatformConfig Controller", func() {
@@ -213,5 +215,112 @@ var _ = Describe("PlatformConfig Controller", func() {
 		It("returns nil without error", func() {
 			Expect(doReconcile("does-not-exist")).To(Succeed())
 		})
+	})
+})
+
+var _ = Describe("PlatformConfig conditions (#449)", func() {
+	ctx := context.Background()
+	const pcName = "platform"
+
+	cleanup := func() {
+		pc := &mortisev1alpha1.PlatformConfig{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, pc); err == nil {
+			Expect(k8sClient.Delete(ctx, pc)).To(Succeed())
+		}
+	}
+
+	reconcileWith := func(boot *platformconfig.Config) {
+		r := &PlatformConfigReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), BootConfig: boot}
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: pcName}})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	get := func() *mortisev1alpha1.PlatformConfig {
+		pc := &mortisev1alpha1.PlatformConfig{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, pc)).To(Succeed())
+		return pc
+	}
+
+	It("surfaces RegistryPullConfig=False for a cluster-internal URL without pullURL, and clears it when fixed", func() {
+		defer cleanup()
+		pc := &mortisev1alpha1.PlatformConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pcName},
+			Spec: mortisev1alpha1.PlatformConfigSpec{
+				Domain:   "example.com",
+				Registry: mortisev1alpha1.RegistryConfig{URL: "http://registry.mortise-deps.svc:5000"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+		reconcileWith(&platformconfig.Config{})
+		cond := meta.FindStatusCondition(get().Status.Conditions, pcRegistryPullConfigCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("PullURLMissing"))
+
+		fresh := get()
+		fresh.Spec.Registry.PullURL = "http://localhost:30500"
+		Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+		reconcileWith(&platformconfig.Config{})
+		Expect(meta.FindStatusCondition(get().Status.Conditions, pcRegistryPullConfigCondition)).To(BeNil())
+	})
+
+	It("does not flag an external registry URL", func() {
+		defer cleanup()
+		pc := &mortisev1alpha1.PlatformConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pcName},
+			Spec: mortisev1alpha1.PlatformConfigSpec{
+				Domain:   "example.com",
+				Registry: mortisev1alpha1.RegistryConfig{URL: "https://registry.example.com"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+		reconcileWith(&platformconfig.Config{})
+		Expect(meta.FindStatusCondition(get().Status.Conditions, pcRegistryPullConfigCondition)).To(BeNil())
+	})
+
+	It("sets ConfigApplied by comparing the boot fingerprint against the live spec", func() {
+		defer cleanup()
+		pc := &mortisev1alpha1.PlatformConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pcName},
+			Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+		}
+		Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+		// Boot snapshot matching the live spec → Applied.
+		booted, err := platformconfig.Load(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		reconcileWith(booted)
+		cond := meta.FindStatusCondition(get().Status.Conditions, pcConfigAppliedCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal("Applied"))
+
+		// Spec drifts from the booted config → RestartRequired, naming the
+		// drifted section.
+		fresh := get()
+		fresh.Spec.Registry.URL = "http://changed.mortise-deps.svc:5000"
+		fresh.Spec.Registry.PullURL = "http://localhost:30500"
+		Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+		reconcileWith(booted)
+		cond = meta.FindStatusCondition(get().Status.Conditions, pcConfigAppliedCondition)
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("RestartRequired"))
+		Expect(cond.Message).To(ContainSubstring("spec.registry"))
+	})
+
+	It("marks RestartRequired when the operator booted on the env fallback", func() {
+		defer cleanup()
+		pc := &mortisev1alpha1.PlatformConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pcName},
+			Spec:       mortisev1alpha1.PlatformConfigSpec{Domain: "example.com"},
+		}
+		Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+		reconcileWith(nil)
+		cond := meta.FindStatusCondition(get().Status.Conditions, pcConfigAppliedCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("RestartRequired"))
+		Expect(cond.Message).To(ContainSubstring("environment-variable fallback"))
 	})
 })

--- a/internal/platformconfig/loader.go
+++ b/internal/platformconfig/loader.go
@@ -23,6 +23,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -224,4 +227,66 @@ func resolveSecret(ctx context.Context, c client.Reader, ref mortisev1alpha1.Sec
 		return nil, fmt.Errorf("get secret %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 	return &secret, nil
+}
+
+// LooksClusterInternal reports whether rawURL's host is a cluster-internal
+// Service DNS name (…​.svc or …​.svc.cluster.local) — the shape kubelets
+// cannot resolve from the node's DNS, making it unusable as a pull URL.
+// Substring checks false-positive on external hosts that merely contain
+// ".svc" and miss ports; this anchors on the hostname suffix instead.
+func LooksClusterInternal(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		// Bare host[:port] without a scheme parses into Path.
+		if h, _, splitErr := net.SplitHostPort(rawURL); splitErr == nil {
+			host = h
+		} else {
+			host = rawURL
+		}
+	}
+	host = strings.TrimSuffix(host, ".")
+	return strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".svc.cluster.local")
+}
+
+// DiffSections compares the config the operator booted with against a
+// freshly resolved one and returns the top-level spec sections that differ
+// ("spec.registry", "spec.build", ...). Resolved secret material
+// participates, so rotating a referenced Secret reads as drift in its
+// section (names only — no values are exposed). A nil side compares as an
+// empty config. Boot stores its snapshot; the PlatformConfig controller
+// diffs it against the CURRENT spec to surface restart-required drift.
+func DiffSections(booted, current *Config) []string {
+	if booted == nil {
+		booted = &Config{}
+	}
+	if current == nil {
+		current = &Config{}
+	}
+	var changed []string
+	if booted.Domain != current.Domain {
+		changed = append(changed, "spec.domain")
+	}
+	if booted.Storage != current.Storage {
+		changed = append(changed, "spec.storage")
+	}
+	if booted.Registry != current.Registry {
+		changed = append(changed, "spec.registry")
+	}
+	if booted.Build != current.Build {
+		changed = append(changed, "spec.build")
+	}
+	if booted.TLS != current.TLS {
+		changed = append(changed, "spec.tls")
+	}
+	if booted.Observability != current.Observability {
+		changed = append(changed, "spec.observability")
+	}
+	if booted.DefaultCPU != current.DefaultCPU || booted.DefaultMemory != current.DefaultMemory {
+		changed = append(changed, "spec.defaultResources")
+	}
+	return changed
 }

--- a/internal/platformconfig/loader_test.go
+++ b/internal/platformconfig/loader_test.go
@@ -258,3 +258,54 @@ func TestLoad_BuildTLS(t *testing.T) {
 		t.Errorf("Build.TLSKey = %q, want KEY", cfg.Build.TLSKey)
 	}
 }
+
+func TestLooksClusterInternal(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		// The shapes the old strings.Contains heuristic got right.
+		{"http://registry.mortise-deps.svc:5000", true},
+		{"http://registry.mortise-deps.svc.cluster.local:5000", true},
+		// The miss: bare host without scheme.
+		{"registry.mortise-deps.svc:5000", true},
+		// The false positive: external host merely containing ".svc".
+		{"https://my.svc.example.com", false},
+		{"https://registry.example.com", false},
+		{"http://localhost:30500", false},
+		// Trailing-dot FQDN form.
+		{"http://registry.mortise-deps.svc.", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := platformconfig.LooksClusterInternal(tc.url); got != tc.want {
+			t.Errorf("LooksClusterInternal(%q) = %v, want %v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestDiffSections(t *testing.T) {
+	a := &platformconfig.Config{Registry: platformconfig.RegistryConfig{URL: "http://r.svc:5000", PullURL: "http://localhost:30500"}}
+	b := &platformconfig.Config{Registry: platformconfig.RegistryConfig{URL: "http://r.svc:5000", PullURL: "http://localhost:30500"}}
+	if diff := platformconfig.DiffSections(a, b); len(diff) != 0 {
+		t.Errorf("identical configs must not diff, got %v", diff)
+	}
+	b.Registry.PullURL = ""
+	b.Build.BuildkitAddr = "tcp://elsewhere:1234"
+	diff := platformconfig.DiffSections(a, b)
+	if len(diff) != 2 || diff[0] != "spec.registry" || diff[1] != "spec.build" {
+		t.Errorf("want [spec.registry spec.build], got %v", diff)
+	}
+	// Secret-derived material participates: rotation reads as drift.
+	b = &platformconfig.Config{Registry: a.Registry}
+	b.Registry.Password = "rotated"
+	if diff := platformconfig.DiffSections(a, b); len(diff) != 1 || diff[0] != "spec.registry" {
+		t.Errorf("credential rotation must diff spec.registry, got %v", diff)
+	}
+	if diff := platformconfig.DiffSections(nil, nil); len(diff) != 0 {
+		t.Errorf("nil-vs-nil must not diff, got %v", diff)
+	}
+	if diff := platformconfig.DiffSections(nil, a); len(diff) == 0 {
+		t.Error("nil-vs-config must diff")
+	}
+}


### PR DESCRIPTION
Fixes #449.

## What changes

Two silent misconfigurations become visible on the PlatformConfig CR itself instead of only in operator logs (mo-wv2; scope per triage: part 1 + drift condition, **no hot reload** — deliberately):

- **`RegistryPullConfig=False/PullURLMissing`** when `spec.registry.url` is cluster-internal and `spec.registry.pullURL` is empty — the exact shape where kubelet-facing image refs fall back to the push URL and fresh deploys ImagePullBackOff. The cluster-internal heuristic is rewritten while being moved: `url.Parse`-based host-suffix matching on `*.svc` / `*.svc.cluster.local` (bare `host:port` values handled via `SplitHostPort`), replacing the old `strings.Contains(url, ".svc")`, which false-positived on external hosts like `my.svc.example.com` and missed bare in-cluster hostnames. The condition clears via `RemoveStatusCondition` when either field changes to a valid shape.
- **`ConfigApplied`** — `main` hands the reconciler the resolved config snapshot it actually consumed at boot; every reconcile diffs it (`platformconfig.DiffSections`) against a fresh `Load` of the current spec. Drift → `False/RestartRequired` with the changed sections **named in the message** (`spec.registry, spec.build, …` — resolved secret material participates, so credential rotation reads as drift; section names only, never values). Nil snapshot (operator booted on the env fallback before the CR existed) → `False/RestartRequired` with the env-fallback message. Match → `True/Applied`. A `Load` failure mid-reconcile leaves the existing condition rather than flapping.

Also: `stacksFromEnv` gains the same boot warning for cluster-internal registry URLs (the env fallback never has a pullURL, and its default `MORTISE_REGISTRY_URL` is exactly the unpullable shape); docs/configuration.md gains the "registry/build changes require an operator restart — the CR will tell you" section; the two Makefile rollout-restart workarounds are annotated with why they exist.

## Tests

- `loader_test.go`: table-driven `LooksClusterInternal` (both old-heuristic false-positive/miss shapes pinned) and `DiffSections` (identity, multi-section ordering, credential-rotation-as-drift, nil handling).
- `platformconfig_controller_test.go` (envtest): pull condition set on cluster-internal-without-pullURL and cleared when pullURL lands; external URL never flagged; `ConfigApplied` Applied-on-match, RestartRequired-naming-the-drifted-section on spec change, RestartRequired-env-fallback on nil boot snapshot.

## Gate (full ci-local, INT_CLUSTER/DEV_CLUSTER isolated per mo-qxt)

unit+envtest (204 controller specs), helm lint, vet + staticcheck v0.7.0, ui build: **green**. Integration: **57 pass / 0 fail**. E2E: 163–164/166 across runs — the recurring reds are two **mainline** races, both affirmatively cleared of branch involvement and filed with mechanism-level evidence: **mo-baq** (fromBinding picker: `GetEnv` reads the App via the informer cache while the UI refetches exactly once ~15ms after the PUT — Playwright trace shows the post-PUT response byte-identical to the pre-PUT one; failed 6× then passed on the *identical* binary) and **mo-e4y** (Redeploy handler's unguarded `Get→mutate→Update` on Deployment + App status surfaces 409s to the client under suite churn; 3/3 red in-suite, 3/3 green isolated). Neither path is touched by this diff; occurrences recorded on mo-j6k.
