### PR TITLE
fix(ui): render picker-added variables immediately instead of racing the reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Picker-added variables now render immediately** (mo-baq): a variable
+  added via the bindings/secret picker was written to the App spec but
+  frequently did not appear in the variables table until the drawer was
+  reopened — the single post-save refetch races the controller reconcile
+  that materializes the resolved env Secret (`GET /env` reads that Secret,
+  not the spec), and nothing refetched the section afterwards. The UI now
+  seeds the saved row locally (`ref → key` display, `binding`/`secret`
+  badge); a later fetch supplies the resolved value.
 - **Chart ClusterRole missing three finalizer grants** (#444): the chart
   granted `finalizers` update only for `apps` and `buildruns`, while the
   generated role also requires it for `gitproviders`, `platformconfigs`,

--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -161,6 +161,18 @@
 		}
 	}
 
+	// GET /env reads the resolved {app}-env Secret, which the controller only
+	// rewrites on its next reconcile of the spec change we just PUT — so the
+	// single refetch after a picker save can land before the new var exists
+	// server-side, and nothing refetches the section again. Guarantee the row
+	// the user just saved renders; a later fetch supplies the resolved value.
+	function ensureEnvEntry(entry: EnvEntry) {
+		if (envSection.entries.some((e) => e.name === entry.name)) return;
+		const byName = (a: EnvEntry, b: EnvEntry) => a.name.localeCompare(b.name);
+		envSection.entries = [...envSection.entries, entry].sort(byName);
+		envSection.originalEntries = [...envSection.originalEntries, { ...entry }].sort(byName);
+	}
+
 	async function loadShared() {
 		sharedSection.loading = true;
 		sharedSection.error = '';
@@ -263,6 +275,7 @@
 			envSection.newValue = '';
 			markStale();
 			await loadEnv(activeEnv);
+			ensureEnvEntry({ name: varName, value: '', source: 'binding', revealed: false, bindingRef: ref, bindingKey: key });
 		} catch (e) {
 			envSection.error = e instanceof Error ? e.message : 'Failed to add binding var';
 		} finally {
@@ -291,6 +304,7 @@
 			envSection.newValue = '';
 			markStale();
 			await loadEnv(activeEnv);
+			ensureEnvEntry({ name: varName, value: '', source: 'user', revealed: false, secretRef: secretName });
 		} catch (e) {
 			envSection.error = e instanceof Error ? e.message : 'Failed to add secret ref var';
 		} finally {


### PR DESCRIPTION
Fixes mo-baq.

## The bug

A variable added via the bindings/secret picker was written to the App spec but frequently never appeared in the variables table until the drawer was reopened. Occurrences back to 2026-08-10; on 2026-08-11 the e2e spec (`app-variables-full.spec.ts:680`) failed six consecutive runs, including fully isolated single-worker runs.

## The mechanism (corrected from the original filing)

The Playwright trace from a failing run shows the post-save `GET /env` response **byte-identical** to the pre-save one, 15ms after the PUT returned. The original bead blamed informer-cache staleness on the App read; implementation surfaced the real (wider) chain: `GET /env` reads the **resolved `{app}-env` Secret**, which only the app controller rewrites on its next reconcile of the spec change the picker just PUT — the App spec merely enriches names already present in the Secret with `bindingRef`/`bindingKey`. So the tab's single post-save refetch races CRD-write → informer → controller reconcile → Secret write → cached Secret read (~50–500ms), and nothing refetches the section afterwards: a lost race renders a permanently stale table.

Consequence worth the record: the filing's option (b) — a server-side APIReader — would **not** have fixed this. An uncached App read still lacks the not-yet-reconciled Secret. The assignment's recommended UI-side seed is the only cheap correct fix.

## The fix

`ensureEnvEntry` (merge-if-missing, sorted into place, mirrored into `originalEntries` so edit-tracking stays consistent) runs after the refetch in both picker paths, seeding the server's eventual representation exactly: `source=binding` + `bindingRef`/`bindingKey` for the bindings picker, `source=user` + `secretRef` for the secret picker. The unrevealed fromBinding row renders as `ref → key` — no resolved value needed for a correct display — and a later fetch supplies the value. When the refetch wins the race, the seed is a no-op.

**Deliberately not touched:** the adjacent single-refetch shape in `addEnvVar`/`importRawEnv`. Those write the env Secret directly through the API, so their window is informer-cache propagation only (~ms) with zero failure history. Stated so the omission is a decision, not an oversight.

## Verification

- The formerly-failing spec went 6-consecutive-fail (100% in isolation this morning) → **5/5 deterministic pass** on this fix, plus 17/17 on the full variables spec file serially. The existing spec is the regression test — no test changes needed.
- Full ci-local green (exit 0): unit+envtest, helm lint, vet+staticcheck, ui build, integration all-pass, e2e **164 passed / 0 failed** (2 flaky-recovered, both tracked mainline shapes: mo-e4y's redeploy spec and an environments spec; the fromBinding spec is clean under full-suite parallelism).
