### PR TITLE
fix(api): retry conflicts in App-mutating REST handlers (the user-facing 409 class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Spurious 409s from App-mutating REST handlers under load** (mo-e4y):
+  handlers that did read→modify→write on an App or its Deployment without
+  a conflict retry surfaced controller-write races as raw HTTP 409s — a
+  user clicking Redeploy (or adding a domain, setting build args, etc.)
+  during normal controller activity could get a spurious failure. The
+  Redeploy/RedeployStale, AddDomain/RemoveDomain, deploy, build-args, and
+  pull-credential handlers now wrap their writes in
+  `retry.RetryOnConflict` with the Get inside the closure, matching the
+  house pattern already used by rollback and app update.
 - **Chart ClusterRole missing three finalizer grants** (#444): the chart
   granted `finalizers` update only for `apps` and `buildruns`, while the
   generated role also requires it for `gitproviders`, `platformconfigs`,

--- a/internal/api/build_args.go
+++ b/internal/api/build_args.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
@@ -88,10 +90,20 @@ func (s *Server) PutBuildArgs(w http.ResponseWriter, r *http.Request) {
 		args[v.Name] = v.Value
 	}
 
-	env := ensureEnvironment(app, envName)
-	env.BuildArgs = args
-
-	if err := s.client.Update(r.Context(), app); err != nil {
+	// Re-read inside the retry so a concurrent App write (controller or
+	// another request) doesn't surface as a user-facing 409.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+			return err
+		}
+		ensureEnvironment(&fresh, envName).BuildArgs = args
+		if err := s.client.Update(r.Context(), &fresh); err != nil {
+			return err
+		}
+		*app = fresh
+		return nil
+	}); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/internal/api/deploy.go
+++ b/internal/api/deploy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
@@ -133,13 +134,20 @@ func (s *Server) Deploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Environment != "" {
-		env := ensureEnvironment(&app, req.Environment)
-		env.Image = req.Image
-	} else {
-		app.Spec.Source.Image = req.Image
-	}
-	if err := s.client.Update(r.Context(), &app); err != nil {
+	// Re-read inside the retry so a concurrent App write doesn't surface as a
+	// user-facing 409. The participation/authz checks above stay outside.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &fresh); err != nil {
+			return err
+		}
+		if req.Environment != "" {
+			ensureEnvironment(&fresh, req.Environment).Image = req.Image
+		} else {
+			fresh.Spec.Source.Image = req.Image
+		}
+		return s.client.Update(r.Context(), &fresh)
+	}); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 
 	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
@@ -145,8 +147,22 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	env.CustomDomains = append(env.CustomDomains, req.Domain)
-	if err := s.client.Update(r.Context(), app); err != nil {
+	// Re-read inside the retry so a concurrent App write (controller or
+	// another request) doesn't surface as a user-facing 409. The collision
+	// check above stays outside — a conflict on our own App doesn't change it.
+	var custom []string
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+			return err
+		}
+		fenv := ensureEnvironment(&fresh, envName)
+		if !slices.Contains(fenv.CustomDomains, req.Domain) {
+			fenv.CustomDomains = append(fenv.CustomDomains, req.Domain)
+		}
+		custom = fenv.CustomDomains
+		return s.client.Update(r.Context(), &fresh)
+	}); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -155,7 +171,7 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, domainsResponse{
 		Primary: env.Domain,
-		Custom:  env.CustomDomains,
+		Custom:  custom,
 		Auto:    autoDomain,
 	})
 }
@@ -193,14 +209,29 @@ func (s *Server) RemoveDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idx := slices.Index(env.CustomDomains, domain)
-	if idx < 0 {
+	if !slices.Contains(env.CustomDomains, domain) {
 		writeJSON(w, http.StatusNotFound, errorResponse{"domain not found"})
 		return
 	}
 
-	env.CustomDomains = slices.Delete(env.CustomDomains, idx, idx+1)
-	if err := s.client.Update(r.Context(), app); err != nil {
+	// Re-read inside the retry so a concurrent App write doesn't surface as a
+	// user-facing 409.
+	var custom []string
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh mortisev1alpha1.App
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
+			return err
+		}
+		fenv := findEnvironment(&fresh, envName)
+		if fenv == nil {
+			return nil
+		}
+		if idx := slices.Index(fenv.CustomDomains, domain); idx >= 0 {
+			fenv.CustomDomains = slices.Delete(fenv.CustomDomains, idx, idx+1)
+		}
+		custom = fenv.CustomDomains
+		return s.client.Update(r.Context(), &fresh)
+	}); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -209,7 +240,7 @@ func (s *Server) RemoveDomain(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, domainsResponse{
 		Primary: env.Domain,
-		Custom:  env.CustomDomains,
+		Custom:  custom,
 		Auto:    statusAutoDomain(app, envName),
 	})
 }

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -157,9 +157,12 @@ func (s *Server) AddDomain(w http.ResponseWriter, r *http.Request) {
 			return err
 		}
 		fenv := ensureEnvironment(&fresh, envName)
-		if !slices.Contains(fenv.CustomDomains, req.Domain) {
-			fenv.CustomDomains = append(fenv.CustomDomains, req.Domain)
+		if slices.Contains(fenv.CustomDomains, req.Domain) {
+			// Added by a concurrent request — skip the no-op Update.
+			custom = fenv.CustomDomains
+			return nil
 		}
+		fenv.CustomDomains = append(fenv.CustomDomains, req.Domain)
 		custom = fenv.CustomDomains
 		return s.client.Update(r.Context(), &fresh)
 	}); err != nil {
@@ -224,11 +227,19 @@ func (s *Server) RemoveDomain(w http.ResponseWriter, r *http.Request) {
 		}
 		fenv := findEnvironment(&fresh, envName)
 		if fenv == nil {
+			// Env deleted concurrently: nothing to remove, and no write to make.
+			custom = []string{}
 			return nil
 		}
-		if idx := slices.Index(fenv.CustomDomains, domain); idx >= 0 {
-			fenv.CustomDomains = slices.Delete(fenv.CustomDomains, idx, idx+1)
+		idx := slices.Index(fenv.CustomDomains, domain)
+		if idx < 0 {
+			// Already removed by a concurrent request — skip the no-op Update
+			// (it would bump resourceVersion and churn the retry loop for
+			// nothing) and return the current list.
+			custom = fenv.CustomDomains
+			return nil
 		}
+		fenv.CustomDomains = slices.Delete(fenv.CustomDomains, idx, idx+1)
 		custom = fenv.CustomDomains
 		return s.client.Update(r.Context(), &fresh)
 	}); err != nil {

--- a/internal/api/pull_credentials.go
+++ b/internal/api/pull_credentials.go
@@ -298,9 +298,20 @@ func (s *Server) DeletePullCredentials(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Clear PullSecretRef only if it points to the Mortise-managed secret.
+	// Re-read inside the retry so a concurrent App write doesn't surface as a
+	// user-facing 409.
 	if app.Spec.Source.PullSecretRef == secretName {
-		app.Spec.Source.PullSecretRef = ""
-		if err := s.client.Update(r.Context(), &app); err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var fresh mortisev1alpha1.App
+			if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &fresh); err != nil {
+				return err
+			}
+			if fresh.Spec.Source.PullSecretRef != secretName {
+				return nil
+			}
+			fresh.Spec.Source.PullSecretRef = ""
+			return s.client.Update(r.Context(), &fresh)
+		}); err != nil {
 			writeError(w, r, err)
 			return
 		}

--- a/internal/api/rebuild.go
+++ b/internal/api/rebuild.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
@@ -163,19 +164,7 @@ func (s *Server) Redeploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, app); err != nil {
-		writeError(w, r, err)
-		return
-	}
-
-	app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
-	for i := range app.Status.Environments {
-		if app.Status.Environments[i].Name == env {
-			app.Status.Environments[i].Phase = mortisev1alpha1.AppPhaseDeploying
-			break
-		}
-	}
-	if err := s.client.Status().Update(r.Context(), app); err != nil {
+	if err := s.setEnvsDeploying(r.Context(), ns, appName, map[string]bool{env: true}); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -246,21 +235,11 @@ func (s *Server) RedeployStale(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(restarted) > 0 {
-		if err := s.client.Get(r.Context(), types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
 		restartedSet := make(map[string]bool, len(restarted))
 		for _, name := range restarted {
 			restartedSet[name] = true
 		}
-		for i := range app.Status.Environments {
-			if restartedSet[app.Status.Environments[i].Name] {
-				app.Status.Environments[i].Phase = mortisev1alpha1.AppPhaseDeploying
-			}
-		}
-		if err := s.client.Status().Update(r.Context(), &app); err != nil {
+		if err := s.setEnvsDeploying(r.Context(), ns, appName, restartedSet); err != nil {
 			writeError(w, r, err)
 			return
 		}
@@ -283,18 +262,43 @@ func envStatusPendingHash(envStatuses []mortisev1alpha1.EnvironmentStatus, envNa
 	return ""
 }
 
+// restartDeployment stamps the rollout annotations that trigger a redeploy.
+// The app controller concurrently writes env-hash/rollout stamps to the same
+// Deployment, so the Get→mutate→Update runs inside RetryOnConflict — otherwise
+// a controller write between our Get and Update surfaces as a user-facing 409.
 func restartDeployment(ctx context.Context, c client.Client, namespace, appName, pendingEnvHash string, now time.Time) error {
-	var dep appsv1.Deployment
-	if err := c.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &dep); err != nil {
-		return err
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var dep appsv1.Deployment
+		if err := c.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &dep); err != nil {
+			return err
+		}
 
-	if dep.Spec.Template.Annotations == nil {
-		dep.Spec.Template.Annotations = make(map[string]string)
-	}
-	dep.Spec.Template.Annotations["mortise.dev/restartedAt"] = fmt.Sprintf("%d", now.UnixMilli())
-	if pendingEnvHash != "" {
-		dep.Spec.Template.Annotations["mortise.dev/env-hash"] = pendingEnvHash
-	}
-	return c.Update(ctx, &dep)
+		if dep.Spec.Template.Annotations == nil {
+			dep.Spec.Template.Annotations = make(map[string]string)
+		}
+		dep.Spec.Template.Annotations["mortise.dev/restartedAt"] = fmt.Sprintf("%d", now.UnixMilli())
+		if pendingEnvHash != "" {
+			dep.Spec.Template.Annotations["mortise.dev/env-hash"] = pendingEnvHash
+		}
+		return c.Update(ctx, &dep)
+	})
+}
+
+// setEnvsDeploying marks the App and the named environments as Deploying,
+// re-reading inside a conflict-retry loop so a concurrent controller status
+// write doesn't surface as a user-facing 409.
+func (s *Server) setEnvsDeploying(ctx context.Context, ns, appName string, envs map[string]bool) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var app mortisev1alpha1.App
+		if err := s.client.Get(ctx, types.NamespacedName{Name: appName, Namespace: ns}, &app); err != nil {
+			return err
+		}
+		app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
+		for i := range app.Status.Environments {
+			if envs[app.Status.Environments[i].Name] {
+				app.Status.Environments[i].Phase = mortisev1alpha1.AppPhaseDeploying
+			}
+		}
+		return s.client.Status().Update(ctx, &app)
+	})
 }

--- a/internal/api/rebuild_conflict_test.go
+++ b/internal/api/rebuild_conflict_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+// TestRedeployRetriesConflict proves the mo-e4y fix: a concurrent controller
+// write to either the Deployment (restartDeployment) or the App status
+// (setEnvsDeploying) must be retried, not surfaced as a user-facing 409. The
+// interceptor fires one synthetic conflict on the first Deployment update AND
+// one on the first App status update; the handler must still return 200.
+func TestRedeployRetriesConflict(t *testing.T) {
+	if err := mortisev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	ns := constants.ControlNamespace("default")
+	envNs := constants.EnvNamespace("default", "production")
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       mortisev1alpha1.ProjectSpec{Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}}},
+		Status:     mortisev1alpha1.ProjectStatus{Namespace: ns},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "redeploy-conflict", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.27"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Phase: mortisev1alpha1.AppPhaseReady,
+			Environments: []mortisev1alpha1.EnvironmentStatus{
+				{Name: "production", Phase: mortisev1alpha1.AppPhaseReady, CurrentImage: "nginx:1.27"},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "redeploy-conflict", Namespace: envNs},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "redeploy-conflict"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "redeploy-conflict"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "nginx:1.27"}}},
+			},
+		},
+	}
+
+	depConflictFired, statusConflictFired := false, false
+	base := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(project, app, dep).
+		WithStatusSubresource(app).
+		Build()
+	client := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, c ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok && !depConflictFired {
+				depConflictFired = true
+				return apierrors.NewConflict(appsv1.Resource("deployments"), obj.GetName(), fmt.Errorf("synthetic conflict"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+		SubResourceUpdate: func(ctx context.Context, c ctrlclient.Client, subResourceName string, obj ctrlclient.Object, opts ...ctrlclient.SubResourceUpdateOption) error {
+			if subResourceName == "status" && !statusConflictFired {
+				statusConflictFired = true
+				return apierrors.NewConflict(mortisev1alpha1.GroupVersion.WithResource("apps").GroupResource(), obj.GetName(), fmt.Errorf("synthetic conflict"))
+			}
+			return c.Status().Update(ctx, obj, opts...)
+		},
+	})
+
+	s := &Server{client: client, authz: allowAllAppsPolicy{}}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/default/apps/redeploy-conflict/redeploy?environment=production", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("project", "default")
+	routeCtx.URLParams.Add("app", "redeploy-conflict")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, principalKey, &auth.Principal{Email: "test@example.com", Role: auth.RoleAdmin})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.Redeploy(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("redeploy under conflict: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !depConflictFired {
+		t.Error("expected a synthetic conflict on the Deployment update")
+	}
+	if !statusConflictFired {
+		t.Error("expected a synthetic conflict on the App status update")
+	}
+
+	// The retried writes must have landed: annotation stamped, phase Deploying.
+	var gotDep appsv1.Deployment
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "redeploy-conflict", Namespace: envNs}, &gotDep); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if gotDep.Spec.Template.Annotations["mortise.dev/restartedAt"] == "" {
+		t.Error("expected restartedAt annotation after retried Deployment update")
+	}
+	var gotApp mortisev1alpha1.App
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "redeploy-conflict", Namespace: ns}, &gotApp); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if gotApp.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
+		t.Errorf("expected phase Deploying after retried status update, got %s", gotApp.Status.Phase)
+	}
+}
+
+// TestAddDomainRetriesConflict proves the domains.go AddDomain fix: a
+// concurrent App spec write is retried rather than surfaced as a 409.
+func TestAddDomainRetriesConflict(t *testing.T) {
+	if err := mortisev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	ns := constants.ControlNamespace("default")
+	project := &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       mortisev1alpha1.ProjectSpec{Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}}},
+		Status:     mortisev1alpha1.ProjectStatus{Namespace: ns},
+	}
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "domain-conflict", Namespace: ns},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: "nginx:1.27"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+		},
+	}
+
+	fired := false
+	base := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(project, app).Build()
+	s := &Server{client: &appUpdateConflictClient{Client: base, fired: &fired}, authz: allowAllAppsPolicy{}}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/default/apps/domain-conflict/domains?environment=production",
+		strings.NewReader(`{"domain":"app.example.com"}`))
+	req.Header.Set("Content-Type", "application/json")
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("project", "default")
+	routeCtx.URLParams.Add("app", "domain-conflict")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, principalKey, &auth.Principal{Email: "test@example.com", Role: auth.RoleAdmin})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.AddDomain(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("add domain under conflict: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !fired {
+		t.Error("expected a synthetic conflict on the App update")
+	}
+	var gotApp mortisev1alpha1.App
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "domain-conflict", Namespace: ns}, &gotApp); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if len(gotApp.Spec.Environments) == 0 || !contains(gotApp.Spec.Environments[0].CustomDomains, "app.example.com") {
+		t.Errorf("expected custom domain persisted after retry, got %+v", gotApp.Spec.Environments)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Part of #444.

## The bug

App-mutating REST handlers that did Get→mutate→Update with no conflict retry surfaced controller-write races as raw HTTP 409s to users. The app controller concurrently writes the same App status/spec and Deployment (env-hash/rollout stamps), so under load a user clicking **Redeploy** — or adding a domain, setting build args, deploying an image, clearing pull credentials — could get a spurious failure. Proven in e2e: `build-and-deploy.spec.ts:109` (redeploy) failed 3/3 in a full-suite run, 3/3 green isolated — load-dependent, exactly the conflict signature.

## The fix

Swept the class, wrapping each write in `retry.RetryOnConflict` with the Get **inside** the closure — the house pattern already used by `rollback.go` and `apps.go` `UpdateApp`:

- **rebuild.go**: `restartDeployment` (Deployment) self-retries; both Redeploy and RedeployStale route their App-status write through a new shared `setEnvsDeploying` helper (which also removes the duplicated status block).
- **domains.go**: `AddDomain` / `RemoveDomain` (App spec). The cross-app collision check stays **outside** the retry — a conflict on our own App doesn't invalidate it.
- **build_args.go** `PutBuildArgs`, **deploy.go** `Deploy`, **pull_credentials.go** `DeletePullCredentials` (App spec).

## Audited and deliberately excluded (with reasons)

- `apps.go` `UpdateApp` and `rollback.go` — already guarded; they're the reference pattern.
- `project_envs.go` clone/rename — already use a hand-rolled `IsConflict` retry loop (correct, just not `RetryOnConflict`).
- Secret upserts (`pull_credentials.go:364`, `project_envs.go`, `users.go`) — a different resource the App controller doesn't contend in its hot loop; not the proven 409 class. Wrapping them would be scope creep.

The class boundary is precisely: *writes App spec/status or the Deployment, which the App controller also writes.*

## Test

`TestRedeployRetriesConflict` drives the real Redeploy handler through an `interceptor.Funcs` client that fires one synthetic conflict on the **Deployment update** AND one on the **App status update** in a single flow — both race points the proven e2e failure hit — asserting 200 and that both writes land. `TestAddDomainRetriesConflict` covers the App-spec path. Both fail against the pre-fix code.

## Gate

Full `make ci-local` green on all six legs (isolated `-crew1` cluster): unit+envtest, helm lint, vet+staticcheck, ui build, integration (392s), ui-e2e (144s) — no flakes.