### PR TITLE
build: catch vendored-subchart CRD drift in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,40 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:webhook:dir=config/webhook
 	# Sync generated CRDs into the Helm chart so `helm install` ships the real schema.
 	cp config/crd/bases/*.yaml charts/mortise-core/crds/
+	@echo "==> CRDs regenerated. If charts/mortise-core/crds changed, run 'make vendor-chart'."
+
+.PHONY: vendor-chart
+vendor-chart: ## Repack mortise-core into the umbrella chart's vendored subchart (run after changing CRDs).
+	@command -v helm >/dev/null 2>&1 || { \
+		echo "helm not found: cannot repack the vendored mortise-core subchart." >&2; \
+		exit 1; \
+	}
+	@helm package charts/mortise-core -d charts/mortise/charts/ >/dev/null
+	@echo "==> Repacked charts/mortise/charts/mortise-core-*.tgz — commit it."
+
+.PHONY: verify-chart-crds
+verify-chart-crds: ## Fast check that the vendored subchart's CRDs match source (no helm required).
+	@# The umbrella chart vendors a packaged mortise-core. Regenerating CRDs
+	@# updates the chart source but not the vendored copy, and nothing local
+	@# caught the difference -- which left main red for an hour. This is the
+	@# cheap half of verify-chart-dependency-drift: CRDs only, tar and diff, no
+	@# helm, fast enough to belong in `make test`. The full check still runs in
+	@# `make test-charts`.
+	@subchart_version=$$(awk -F': ' '/^version:/ {print $$2; exit}' charts/mortise-core/Chart.yaml); \
+	tgz="charts/mortise/charts/mortise-core-$${subchart_version}.tgz"; \
+	if [ ! -f "$$tgz" ]; then echo "missing vendored subchart $$tgz — run 'make vendor-chart'" >&2; exit 1; fi; \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	tar -xzf "$$tgz" -C "$$tmpdir" 2>/dev/null; \
+	if ! diff -qr charts/mortise-core/crds "$$tmpdir/mortise-core/crds" >/dev/null; then \
+		echo "" >&2; \
+		echo "The vendored mortise-core subchart is out of date with charts/mortise-core/crds." >&2; \
+		echo "This is what CI's verify-chart-dependency-drift will fail on." >&2; \
+		echo "Fix: make vendor-chart && git add charts/mortise/charts/" >&2; \
+		echo "" >&2; \
+		diff -qr charts/mortise-core/crds "$$tmpdir/mortise-core/crds" >&2 || true; \
+		exit 1; \
+	fi
 
 .PHONY: generate
 generate: controller-gen generate-api ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -66,7 +100,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet setup-envtest check-ui ## Run tests.
+test: manifests generate fmt vet setup-envtest check-ui verify-chart-crds ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: check-ui


### PR DESCRIPTION
Stacked on #491 (base branch is `fix/mo-chart-vendor-drift`, not `main`), because it needs the repacked tgz to be green.

## Why

#491 fixes the drift that has `main` red. This stops it recurring.

Regenerating CRDs is two steps — `make manifests` updates `charts/mortise-core/crds/`, and the vendored tgz must be repacked separately. Nothing local checked the second one, so `make test` was green while CI was red. That's how I put main in this state.

## What

- **`vendor-chart`** — explicit repack target.
- **`verify-chart-crds`** — wired into `make test`. The cheap half of `verify-chart-dependency-drift`: CRDs only, `tar` + `diff`, **no helm**, so `make test` gains no new dependency. The full check still runs in `make test-charts` and CI.
- A reminder line from `manifests`.

Failure names the fix, not just the symptom:

```
The vendored mortise-core subchart is out of date with charts/mortise-core/crds.
This is what CI's verify-chart-dependency-drift will fail on.
Fix: make vendor-chart && git add charts/mortise/charts/
```

## Rejected: auto-repacking from `manifests`

That was my first implementation. `helm package` embeds a timestamp, so its output is not byte-stable — I verified two consecutive runs produce different SHAs. Auto-repacking inside `make test` would leave the tgz modified on **every run**, and a file that is always dirty is one people discard reflexively, including the times it matters. Verifying and failing loudly keeps the signal meaningful.

## Verification

- `make verify-chart-crds` against main's stale tgz → **fails**, listing the drifted CRDs
- against the repacked tgz from #491 → **passes**
- `make test` → green, and leaves the working tree clean

## Residual gap

`verify-chart-crds` covers CRDs, which is the class that broke. Drift in the subchart's `templates/` or `values.yaml` is still caught only by `make test-charts` and CI. Narrowing that would mean pulling helm into `make test`; I'd rather leave it than change what the fast gate depends on.