### PR TITLE
fix(controller): honour resource limits from platform defaults and limit-only specs (CAI-163)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -4276,17 +4276,24 @@ func normalizeStructPointers(v reflect.Value) {
 
 func (r *AppReconciler) effectiveResources(ctx context.Context, env *mortisev1alpha1.Environment) mortisev1alpha1.ResourceRequirements {
 	res := env.Resources
-	if res.CPU == "" && res.Memory == "" {
+	// Take the whole platform default, limits included. Copying only CPU and
+	// Memory meant a cpuLimit/memoryLimit set on PlatformConfig validated,
+	// stored, and was silently dropped.
+	if res.CPU == "" && res.Memory == "" && res.CPULimit == "" && res.MemoryLimit == "" {
 		var pc mortisev1alpha1.PlatformConfig
 		if err := r.Get(ctx, types.NamespacedName{Name: "platform"}, &pc); err == nil {
-			res.CPU = pc.Spec.Defaults.Resources.CPU
-			res.Memory = pc.Spec.Defaults.Resources.Memory
+			res = pc.Spec.Defaults.Resources
 		}
 	}
-	if res.CPU == "" {
+	// Only default the reservation when nothing was said about this resource
+	// at all. Someone who sets just a limit means "cap it here", and injecting
+	// a 100m request under a 50m limit turns that into a validation error
+	// about a request they never wrote. With no request, Kubernetes defaults
+	// it to the limit, which is what they meant.
+	if res.CPU == "" && res.CPULimit == "" {
 		res.CPU = "100m"
 	}
-	if res.Memory == "" {
+	if res.Memory == "" && res.MemoryLimit == "" {
 		res.Memory = "256Mi"
 	}
 	return res

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -9609,3 +9609,85 @@ var _ = Describe("a secretRef that breaks after resolving (CAI-162 follow-up)", 
 		}
 	})
 })
+
+var _ = Describe("effectiveResources with limits (CAI-163 follow-up)", func() {
+	const namespace = "pj-default-project"
+	ctx := context.Background()
+
+	newReconciler := func(objs ...client.Object) *AppReconciler {
+		scheme := k8sClient.Scheme()
+		b := fake.NewClientBuilder().WithScheme(scheme)
+		if len(objs) > 0 {
+			b = b.WithObjects(objs...)
+		}
+		return &AppReconciler{Client: b.Build(), Scheme: scheme}
+	}
+
+	platformWith := func(res mortisev1alpha1.ResourceRequirements) *mortisev1alpha1.PlatformConfig {
+		return &mortisev1alpha1.PlatformConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+			Spec: mortisev1alpha1.PlatformConfigSpec{
+				Defaults: mortisev1alpha1.DefaultsConfig{Resources: res},
+			},
+		}
+	}
+
+	// The field is in the CRD schema, so it validates and stores. Dropping it
+	// on the floor is the platform accepting configuration and ignoring it.
+	It("carries platform default limits, not just requests", func() {
+		r := newReconciler(platformWith(mortisev1alpha1.ResourceRequirements{
+			CPU: "200m", CPULimit: "800m",
+			Memory: "512Mi", MemoryLimit: "2Gi",
+		}))
+		got := r.effectiveResources(ctx, &mortisev1alpha1.Environment{Name: "production"})
+		Expect(got.CPU).To(Equal("200m"))
+		Expect(got.CPULimit).To(Equal("800m"), "platform cpuLimit was silently dropped")
+		Expect(got.Memory).To(Equal("512Mi"))
+		Expect(got.MemoryLimit).To(Equal("2Gi"), "platform memoryLimit was silently dropped")
+	})
+
+	It("lets an env override win over the platform default", func() {
+		r := newReconciler(platformWith(mortisev1alpha1.ResourceRequirements{CPU: "200m"}))
+		got := r.effectiveResources(ctx, &mortisev1alpha1.Environment{
+			Name:      "production",
+			Resources: mortisev1alpha1.ResourceRequirements{CPU: "50m"},
+		})
+		Expect(got.CPU).To(Equal("50m"))
+	})
+
+	// Someone setting only a limit means "cap it here". Injecting the 100m
+	// default request under a 50m limit made that a validation error about a
+	// request they never wrote -- and "memory means cap" is exactly the wrong
+	// mental model CAI-163 exists to correct, so this is the likely mistake.
+	It("does not inject a default request under a lower explicit limit", func() {
+		r := newReconciler()
+		got := r.effectiveResources(ctx, &mortisev1alpha1.Environment{
+			Name:      "production",
+			Resources: mortisev1alpha1.ResourceRequirements{CPULimit: "50m"},
+		})
+		Expect(got.CPU).To(BeEmpty(), "a default request was injected above the explicit limit")
+		Expect(got.CPULimit).To(Equal("50m"))
+
+		req, err := toResourceRequirements(got)
+		Expect(err).NotTo(HaveOccurred(), "the limit-only case must not fail validation")
+		Expect(req.Limits.Cpu().String()).To(Equal("50m"))
+	})
+
+	It("still defaults both when nothing is specified", func() {
+		r := newReconciler()
+		got := r.effectiveResources(ctx, &mortisev1alpha1.Environment{Name: "production"})
+		Expect(got.CPU).To(Equal("100m"))
+		Expect(got.Memory).To(Equal("256Mi"))
+	})
+
+	It("defaults the unmentioned resource only", func() {
+		r := newReconciler()
+		got := r.effectiveResources(ctx, &mortisev1alpha1.Environment{
+			Name:      "production",
+			Resources: mortisev1alpha1.ResourceRequirements{MemoryLimit: "1Gi"},
+		})
+		Expect(got.CPU).To(Equal("100m"), "cpu was unmentioned and should still default")
+		Expect(got.Memory).To(BeEmpty())
+		Expect(got.MemoryLimit).To(Equal("1Gi"))
+	})
+})

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -9611,7 +9611,6 @@ var _ = Describe("a secretRef that breaks after resolving (CAI-162 follow-up)", 
 })
 
 var _ = Describe("effectiveResources with limits (CAI-163 follow-up)", func() {
-	const namespace = "pj-default-project"
 	ctx := context.Background()
 
 	newReconciler := func(objs ...client.Object) *AppReconciler {


### PR DESCRIPTION
Two bugs **in my own CAI-163 change**, found while reviewing what reached `main` without a PR. Both would have shipped.

## 1. Platform default limits were silently discarded

`effectiveResources` copied only `CPU` and `Memory` out of `PlatformConfig.Defaults.Resources`.

Adding `CPULimit`/`MemoryLimit` to `ResourceRequirements` also put them in the **PlatformConfig** CRD schema (that struct is embedded there). So an admin setting `defaults.resources.cpuLimit` got a field that validates, stores, appears in `kubectl get platformconfig -o yaml` — and is dropped on the floor by the operator.

That is the platform accepting configuration and ignoring it: the exact defect class this project exists to fix, freshly introduced by the fix for another instance of it.

Now takes the whole defaults struct rather than two named fields, so a future field can't be dropped the same way.

## 2. A limit-only spec failed validation with an error about a request the user never wrote

The `100m`/`256Mi` request fallback didn't know about limits. An App setting only:

```yaml
resources:
  cpuLimit: 50m
```

got a `100m` request injected underneath, then failed with `cpu limit 50m is below the request 100m`.

This is the *likely* mistake, not an exotic one. "Memory means cap" is precisely the wrong mental model CAI-163 exists to correct — so someone holding it reaches for the limit field alone, and the new field punishes them for it.

Now the reservation defaults only when nothing was said about that resource at all. With no request, Kubernetes defaults it to the limit, which is what they meant.

## Verification

Reverted the production change while keeping the tests — **3 of 5 fail**:

```
[FAILED] platform cpuLimit was silently dropped
[FAILED] a default request was injected above the explicit limit
FAIL! -- 2 Passed | 3 Failed
```

Restored: green. Full `make test` green, controller package 76.8%.

## Note

CAI-163 is on `main` unreviewed, along with six other commits — see #491/#492 and CAI-164. This is the first fruit of reviewing them properly. I'd rather these land as PRs than have anyone release what's currently there.