### PR TITLE
build: run staticcheck in `make test`, and have CI invoke it via make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,12 @@ jobs:
         run: go vet ./...
 
       - name: staticcheck
-        # Direct pinned install instead of dominikh/staticcheck-action: the
-        # action's internal cache collides with setup-go's cache:true
-        # (deterministic 'File exists' tar errors on restore), and setup-go's
-        # module cache already covers the install.
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
-          staticcheck ./...
+        # Via make so the version pin lives in exactly one place and `make test`
+        # runs the identical check locally. Direct pinned install rather than
+        # dominikh/staticcheck-action: the action's internal cache collides
+        # with setup-go's cache:true (deterministic 'File exists' tar errors on
+        # restore), and setup-go's module cache already covers the install.
+        run: make staticcheck
 
   ui:
     name: UI typecheck + build

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,12 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: staticcheck
+staticcheck: staticcheck-bin ## Run staticcheck (the same check CI runs).
+	"$(STATICCHECK)" ./...
+
 .PHONY: test
-test: manifests generate fmt vet setup-envtest check-ui ## Run tests.
+test: manifests generate fmt vet staticcheck setup-envtest check-ui ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: check-ui
@@ -606,6 +610,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+STATICCHECK ?= $(LOCALBIN)/staticcheck
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.1
@@ -622,10 +627,18 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.8.0
+# Keep in step with the staticcheck job in .github/workflows/ci.yml, which
+# invokes `make staticcheck` so this is the single source of the pin.
+STATICCHECK_VERSION ?= v0.7.0
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+.PHONY: staticcheck-bin
+staticcheck-bin: $(STATICCHECK) ## Download staticcheck locally if necessary.
+$(STATICCHECK): $(LOCALBIN)
+	$(call go-install-tool,$(STATICCHECK),honnef.co/go/tools/cmd/staticcheck,$(STATICCHECK_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Follow-up #2 from the drain. Closes the local-vs-CI gap.

## The gap

CI ran `go vet` **and** `staticcheck`. `make test` ran only `go vet`.

So a `U1000` — an unused const in a test — passed a green local run and failed on PR #493. That's the **second** time in one session that "green locally" and "green in CI" turned out to be different claims; the first was the chart-drift check.

## The change

- Pinned `staticcheck` added to the existing `LOCALBIN` tool bootstrap, same `go-install-tool` pattern as controller-gen / envtest / kustomize.
- A `staticcheck` target, wired into `test`.
- **The CI job now runs `make staticcheck`** instead of installing and invoking it inline.

That last part matters more than it looks. Pinning the version in both `ci.yml` and the `Makefile` would have created a third copy of a value that must not drift — the same shape as the vendored chart tgz it took three separate failures to get rid of. One definition, both callers, and local is CI by construction rather than by two strings happening to match.

The original comment explaining *why* it's a direct pinned install (the staticcheck-action's cache collides with setup-go's) is preserved — that's hard-won and easy to undo by accident.

## Verification

Proved the check can **fail**, not just pass:

```
# planted an unused const
internal/controller/app_env_drift.go:47:7: const deliberatelyUnused is unused (U1000)
# removed it
CLEAN_AGAIN
```

A gate nobody has watched fail is not known to be a gate — which is most of what this session taught.

`make test` green end to end with staticcheck in the chain, controller package 76.9%.