### PR TITLE
fix(controller): store digests, not values, in the last-spec-env annotation (CAI-168)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -2776,7 +2776,7 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 		for _, e := range current {
 			if e.Source == "" || e.Source == "user" {
 				if _, stillInSpec := specEnvKeys[e.Name]; !stillInSpec {
-					if lastVal, tracked := lastSpec[e.Name]; tracked && e.Value == lastVal {
+					if lastVal, tracked := lastSpec[e.Name]; tracked && lastSpecEnvDigest(e.Value) == lastVal {
 						continue
 					}
 				}
@@ -2800,7 +2800,7 @@ func (r *AppReconciler) reconcileEnvSecret(ctx context.Context, app *mortisev1al
 			if sv.value == existingVal {
 				continue
 			}
-			if lastVal, tracked := lastSpec[sv.name]; tracked && existingVal == lastVal {
+			if lastVal, tracked := lastSpec[sv.name]; tracked && lastSpecEnvDigest(existingVal) == lastVal {
 				seed[sv.name] = envstore.Env{Name: sv.name, Value: sv.value, Source: sv.source}
 			}
 		}
@@ -2965,15 +2965,37 @@ func (r *AppReconciler) readLastSpecEnv(ctx context.Context, ns, appName string)
 	}, &sec); err != nil {
 		return nil
 	}
+	if raw := sec.Annotations[envstore.AnnotationLastSpecEnvDigest]; raw != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			return nil
+		}
+		return m
+	}
+	// Migration: the legacy annotation holds values, not digests. Hashing them
+	// yields exactly what the digest annotation would have held, so the first
+	// reconcile after upgrade compares correctly instead of seeing every key
+	// as user-overridden and silently freezing spec updates for all of them.
 	raw := sec.Annotations[envstore.AnnotationLastSpecEnv]
 	if raw == "" {
 		return nil
 	}
-	var m map[string]string
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+	var legacy map[string]string
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
 		return nil
 	}
+	m := make(map[string]string, len(legacy))
+	for k, v := range legacy {
+		m[k] = lastSpecEnvDigest(v)
+	}
 	return m
+}
+
+// lastSpecEnvDigest is the stored form of a spec env value: a SHA-256 hex
+// digest, never the value.
+func lastSpecEnvDigest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
 }
 
 func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string, envVars map[string]string) error {
@@ -2987,11 +3009,17 @@ func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string
 		}
 		return fmt.Errorf("get env secret for last-spec annotation: %w", err)
 	}
-	data, err := json.Marshal(envVars)
-	if err != nil {
-		return fmt.Errorf("marshal last-spec env: %w", err)
+	digests := make(map[string]string, len(envVars))
+	for name, value := range envVars {
+		digests[name] = lastSpecEnvDigest(value)
 	}
-	if sec.Annotations != nil && sec.Annotations[envstore.AnnotationLastSpecEnv] == string(data) {
+	data, err := json.Marshal(digests)
+	if err != nil {
+		return fmt.Errorf("marshal last-spec env digests: %w", err)
+	}
+	_, hasLegacy := sec.Annotations[envstore.AnnotationLastSpecEnv]
+	if !hasLegacy && sec.Annotations != nil &&
+		sec.Annotations[envstore.AnnotationLastSpecEnvDigest] == string(data) {
 		return nil
 	}
 	if err := envstore.UpdateWithConflictRetry(ctx, r.Client, types.NamespacedName{
@@ -3003,10 +3031,14 @@ func (r *AppReconciler) writeLastSpecEnv(ctx context.Context, ns, appName string
 		if sec.Annotations == nil {
 			sec.Annotations = make(map[string]string)
 		}
-		if sec.Annotations[envstore.AnnotationLastSpecEnv] == string(data) {
+		_, legacy := sec.Annotations[envstore.AnnotationLastSpecEnv]
+		if !legacy && sec.Annotations[envstore.AnnotationLastSpecEnvDigest] == string(data) {
 			return false, nil
 		}
-		sec.Annotations[envstore.AnnotationLastSpecEnv] = string(data)
+		// Removing the legacy annotation is the point of the change, not a
+		// tidy-up: it is where the plaintext lived.
+		delete(sec.Annotations, envstore.AnnotationLastSpecEnv)
+		sec.Annotations[envstore.AnnotationLastSpecEnvDigest] = string(data)
 		return true, nil
 	}); err != nil {
 		return fmt.Errorf("write last-spec-env annotation: %w", err)

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -7586,13 +7586,23 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(envData).To(HaveKeyWithValue("R2_BUCKET_NAME", "new-value"), "CRD spec change should propagate to Secret")
 			Expect(envData).To(HaveKeyWithValue("STATIC_VAR", "unchanged"))
 
-			// Verify the last-applied annotation was written.
+			// Verify the last-applied annotation was written, as digests.
 			var sec corev1.Secret
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      envstore.AppEnvSecretName(appName),
 				Namespace: envNsProduction,
 			}, &sec)).To(Succeed())
-			Expect(sec.Annotations).To(HaveKey(envstore.AnnotationLastSpecEnv))
+			Expect(sec.Annotations).To(HaveKey(envstore.AnnotationLastSpecEnvDigest))
+			Expect(sec.Annotations).NotTo(HaveKey(envstore.AnnotationLastSpecEnv),
+				"the legacy plaintext annotation should not be written")
+			// The tracking annotation must never carry the values themselves
+			// (CAI-168) -- that is the whole point of storing digests.
+			for k, v := range sec.Annotations {
+				Expect(v).NotTo(ContainSubstring("new-value"),
+					"a spec env value leaked into annotation %q", k)
+				Expect(v).NotTo(ContainSubstring("unchanged"),
+					"a spec env value leaked into annotation %q", k)
+			}
 		})
 
 		It("preserves user-overridden values even when CRD spec changes", func() {

--- a/internal/controller/app_last_spec_env_test.go
+++ b/internal/controller/app_last_spec_env_test.go
@@ -1,0 +1,152 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/mortise-org/mortise/internal/envstore"
+)
+
+// The last-spec-env annotation exists to answer one question: does the live
+// value still match what the spec last set? It answered it by storing the
+// value, which put resolved credentials in plaintext on the derived Secret --
+// including ones deliberately moved out of the CRD into a Secret (CAI-168).
+// A digest answers the same question without keeping the credential.
+func TestLastSpecEnvDigest(t *testing.T) {
+	const secret = "sk_live_do_not_persist_me"
+
+	t.Run("never returns the value", func(t *testing.T) {
+		got := lastSpecEnvDigest(secret)
+		if strings.Contains(got, secret) || got == secret {
+			t.Fatal("the digest contains the value")
+		}
+		if len(got) != 64 {
+			t.Errorf("expected a 64-char sha256 hex digest, got %d chars", len(got))
+		}
+	})
+
+	t.Run("is the real SHA-256 of the value", func(t *testing.T) {
+		// A known vector rather than comparing the function to itself, which
+		// asserts nothing about what it computes.
+		if got, want := lastSpecEnvDigest("hunter2"),
+			"f52fbd32b2b3b86ff88ef6c490628285f482af15ddcb29541f94bcf526a3f6c7"; got != want {
+			t.Errorf("expected %s, got %s", want, got)
+		}
+	})
+
+	t.Run("different values do not collide", func(t *testing.T) {
+		if lastSpecEnvDigest(secret) == lastSpecEnvDigest(secret+"x") {
+			t.Error("different values produced the same digest")
+		}
+	})
+}
+
+func TestLastSpecEnvAnnotation(t *testing.T) {
+	scheme := gcTestScheme(t)
+	const ns = "pj-demo-production"
+	const app = "demo"
+	const plaintext = "sk_live_abc123_plaintext"
+	key := types.NamespacedName{Name: envstore.AppEnvSecretName(app), Namespace: ns}
+
+	newSecret := func(annotations map[string]string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Annotations: annotations},
+			Data:       map[string][]byte{"API_KEY": []byte(plaintext)},
+		}
+	}
+
+	t.Run("writes digests, never values", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newSecret(nil)).Build()
+		r := &AppReconciler{Client: c, Scheme: scheme}
+		if err := r.writeLastSpecEnv(context.Background(), ns, app,
+			map[string]string{"API_KEY": plaintext}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var got corev1.Secret
+		if err := c.Get(context.Background(), key, &got); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		raw := got.Annotations[envstore.AnnotationLastSpecEnvDigest]
+		if raw == "" {
+			t.Fatal("digest annotation was not written")
+		}
+		if strings.Contains(raw, plaintext) {
+			t.Error("the plaintext value is in the annotation")
+		}
+		var m map[string]string
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatalf("annotation is not JSON: %v", err)
+		}
+		if m["API_KEY"] != lastSpecEnvDigest(plaintext) {
+			t.Error("stored digest does not match the value's digest")
+		}
+	})
+
+	// The legacy annotation is where the plaintext lived, so removing it is
+	// the fix, not housekeeping.
+	t.Run("deletes the legacy plaintext annotation", func(t *testing.T) {
+		legacy, _ := json.Marshal(map[string]string{"API_KEY": plaintext})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newSecret(map[string]string{envstore.AnnotationLastSpecEnv: string(legacy)})).Build()
+		r := &AppReconciler{Client: c, Scheme: scheme}
+		if err := r.writeLastSpecEnv(context.Background(), ns, app,
+			map[string]string{"API_KEY": plaintext}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var got corev1.Secret
+		if err := c.Get(context.Background(), key, &got); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if _, still := got.Annotations[envstore.AnnotationLastSpecEnv]; still {
+			t.Error("the legacy plaintext annotation survived")
+		}
+		for k, v := range got.Annotations {
+			if strings.Contains(v, plaintext) {
+				t.Errorf("plaintext still present in annotation %q", k)
+			}
+		}
+	})
+
+	// Without this, the first reconcile after upgrade would see every key as
+	// user-overridden and silently stop propagating spec changes for all of
+	// them -- a far worse failure than the leak being fixed.
+	t.Run("migrates by hashing the legacy values, so comparisons hold immediately", func(t *testing.T) {
+		legacy, _ := json.Marshal(map[string]string{"API_KEY": plaintext})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newSecret(map[string]string{envstore.AnnotationLastSpecEnv: string(legacy)})).Build()
+		r := &AppReconciler{Client: c, Scheme: scheme}
+
+		got := r.readLastSpecEnv(context.Background(), ns, app)
+		if got["API_KEY"] != lastSpecEnvDigest(plaintext) {
+			t.Fatalf("legacy value was not migrated to its digest: %v", got["API_KEY"])
+		}
+	})
+
+	t.Run("prefers the digest annotation when both are present", func(t *testing.T) {
+		legacy, _ := json.Marshal(map[string]string{"API_KEY": "stale-value"})
+		digests, _ := json.Marshal(map[string]string{"API_KEY": lastSpecEnvDigest(plaintext)})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newSecret(map[string]string{
+			envstore.AnnotationLastSpecEnv:       string(legacy),
+			envstore.AnnotationLastSpecEnvDigest: string(digests),
+		})).Build()
+		r := &AppReconciler{Client: c, Scheme: scheme}
+		if got := r.readLastSpecEnv(context.Background(), ns, app); got["API_KEY"] != lastSpecEnvDigest(plaintext) {
+			t.Error("the stale legacy annotation won over the digest annotation")
+		}
+	})
+
+	t.Run("no annotation at all reports nothing tracked", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newSecret(nil)).Build()
+		r := &AppReconciler{Client: c, Scheme: scheme}
+		if got := r.readLastSpecEnv(context.Background(), ns, app); len(got) != 0 {
+			t.Errorf("expected nothing tracked, got %v", got)
+		}
+	})
+}

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -50,10 +50,27 @@ const (
 	AnnotationGeneratedKeys = "mortise.dev/generated-keys"
 	AnnotationSharedKeys    = "mortise.dev/shared-keys"
 
-	// AnnotationLastSpecEnv stores the JSON-encoded CRD spec env vars that
-	// were last applied by the controller. Used to detect CRD spec changes
-	// vs out-of-band user edits to the Secret.
+	// AnnotationLastSpecEnv stores the JSON-encoded CRD spec env VALUES that
+	// were last applied by the controller.
+	//
+	// LEGACY. Superseded by AnnotationLastSpecEnvDigest: it held resolved
+	// credential values in plaintext on the derived Secret, so a value moved
+	// out of the CRD into a Secret was written straight back out one field
+	// over (CAI-168). The controller reads it only to migrate, and deletes it
+	// on the next write.
+	//
+	// Not marked Deprecated: the migration path must keep referencing it, and
+	// a deprecation marker would make staticcheck flag the very code doing the
+	// removal.
 	AnnotationLastSpecEnv = "mortise.dev/last-spec-env"
+
+	// AnnotationLastSpecEnvDigest stores a JSON map of env var name to a
+	// SHA-256 digest of the value the controller last applied from the spec.
+	//
+	// A digest answers the only question this annotation exists to answer --
+	// "does the live value still match what the spec last set?" -- exactly as
+	// well as the value does, without persisting the credential.
+	AnnotationLastSpecEnvDigest = "mortise.dev/last-spec-env-digest"
 )
 
 // AppEnvSecretName returns the Secret name for an app's env vars.


### PR DESCRIPTION
## The leak

`writeLastSpecEnv` marshalled the **resolved** env values into a plaintext JSON annotation on the derived `{app}-env` Secret — including values resolved from `valueFrom.secretRef`.

So a credential a user deliberately moved out of the CRD and into a Secret was written straight back out, in clear text, one field over. Same shape as CAI-151: the remediation looks complete and isn't.

The annotation exists to answer exactly one question — *does the live value still match what the spec last set?* A SHA-256 digest answers that as well as the value does, without persisting the credential.

## The migration is the delicate part

Comparing a stored plaintext against a fresh digest fails for **every** key, and the failure is silent and worse than the leak: each key would look user-overridden, so spec changes would stop propagating and removals would stop pruning — on every App at once.

So the reader prefers the new digest annotation and falls back to the legacy one, **hashing the values it finds there**. Hashing a stored plaintext produces exactly what the digest annotation would have held, so comparisons hold on the very first reconcile after upgrade. There is no window where everything looks overridden.

The writer then writes the digest annotation and **deletes the legacy one** — the fix, not tidy-up. The legacy key is where the plaintext lived.

## Two things worth flagging

**`AnnotationLastSpecEnv` is documented as legacy but deliberately not marked `Deprecated:`.** With the marker, staticcheck's `SA1019` flags the very migration code doing the removal. Caught by the staticcheck that landed an hour ago in #503 — the first thing it's earned.

It also caught `SA4000` in my own new test: I'd written `lastSpecEnvDigest(x) != lastSpecEnvDigest(x)`, comparing a function to itself, which asserts nothing about what it computes. Replaced with a known SHA-256 vector.

**The existing envtest asserted the old annotation key was present.** It now asserts the digest key is present, the legacy key is gone, and **no annotation contains any spec env value** — turning an assertion about plumbing into one that guards the fix.

## Verification

Disabled the migration path and confirmed the test fails:

```
--- FAIL: TestLastSpecEnvAnnotation/migrates_by_hashing_the_legacy_values…
    legacy value was not migrated to its digest:
```

Restored: green. Full `make test` green including staticcheck, controller package 77.0%.