### PR TITLE
feat(cli): add `mortise diff` (CAI-157)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1025,8 +1025,10 @@ full `PUT` on the App CRD to change a variable.
   an App's environment configuration disagrees with itself across three
   layers — `spec.environments[].env` on the App, the derived `{app}-env`
   Secret pods mount, and the `mortise.dev/env-hash` the running workload was
-  started with. Prints names, sources, and 12-hex-char SHA-256 digests only,
-  never a value, so the output is safe to share during an incident. Reads the
+  started with. Prints names, sources, and 12-hex-char digests only, never a
+  value, so the output is safe to share during an incident; the digests are
+  salted per invocation, so a low-entropy value cannot be confirmed by
+  guessing against a report, and digests compare within one report. Reads the
   cluster directly through the standard kubeconfig resolution rather than the
   HTTP API, never writes, and exits non-zero only on an operational failure.
   With `-f` it is a dry run against an App manifest.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1021,6 +1021,15 @@ full `PUT` on the App CRD to change a variable.
 - `mortise env pull [--env NAME] > .env`
 - Shortcuts: `@secret:name` and `@from:app.key` so users don't round-trip
   through a separate secret create.
+- `mortise diff APP [--env NAME] [--all] [-o json] [-f FILE]`: reports where
+  an App's environment configuration disagrees with itself across three
+  layers — `spec.environments[].env` on the App, the derived `{app}-env`
+  Secret pods mount, and the `mortise.dev/env-hash` the running workload was
+  started with. Prints names, sources, and 12-hex-char SHA-256 digests only,
+  never a value, so the output is safe to share during an incident. Reads the
+  cluster directly through the standard kubeconfig resolution rather than the
+  HTTP API, never writes, and exits non-zero only on an operational failure.
+  With `-f` it is a dry run against an App manifest.
 
 **UI:**
 - Variables tab on App detail page.

--- a/cmd/cli/diff.go
+++ b/cmd/cli/diff.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+// diffScheme carries only the kinds `mortise diff` reads.
+func diffScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		batchv1.AddToScheme,
+		mortisev1alpha1.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// newKubeClient resolves a cluster connection exactly as kubectl does:
+// KUBECONFIG / ~/.kube/config / in-cluster, with --kubeconfig and --context
+// overriding. `mortise diff` deliberately does not go through the Mortise
+// HTTP API — it reads the cluster directly, read-only.
+func newKubeClient(kubeconfig, kubecontext string) (client.Client, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		rules.ExplicitPath = kubeconfig
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if kubecontext != "" {
+		overrides.CurrentContext = kubecontext
+	}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("resolving kubeconfig: %w", err)
+	}
+	scheme, err := diffScheme()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}
+
+func newDiffCmd() *cobra.Command {
+	var project, envName, output, file, kubeconfig, kubecontext string
+	var showAll bool
+
+	cmd := &cobra.Command{
+		Use:   "diff <app>",
+		Short: "Show where an app's environment configuration disagrees with itself",
+		Long: `diff compares an App's environment configuration across three layers:
+
+  1. the CRD spec        spec.environments[].env on the App (namespace pj-{project})
+  2. the derived Secret  {app}-env in pj-{project}-{env}, which pods mount via envFrom
+  3. the running pods    the mortise.dev/env-hash the workload was started with
+
+Only names, sources, and 12-hex-char sha256 digests are printed. No variable
+value ever reaches the output, so the result is safe to paste into a channel
+during an incident.
+
+diff talks to Kubernetes directly using the standard kubeconfig resolution,
+not the Mortise HTTP API, and never writes to the cluster.
+
+With -f it becomes a dry run: it reports what applying that App manifest would
+change, relative to what is live, in the same names-and-digests form.
+
+Findings are information, not failures: the exit status is non-zero only when
+the command could not do its job (no cluster, no such app).`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			p := project
+			if p == "" {
+				p = cfg.Project()
+			}
+			c, err := newKubeClient(kubeconfig, kubecontext)
+			if err != nil {
+				return err
+			}
+			rep, err := runDiff(cmd.Context(), c, diffRequest{
+				app:     args[0],
+				project: p,
+				env:     envName,
+				file:    file,
+			})
+			if err != nil {
+				return err
+			}
+			return writeDiff(cmd.OutOrStdout(), rep, output, showAll)
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "Project (default: current project)")
+	cmd.Flags().StringVar(&envName, "env", "", "Environment name (default: every environment on the project)")
+	cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format: text or json")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Dry run: an App manifest to compare against what is live")
+	cmd.Flags().BoolVar(&showAll, "all", false, "List in-sync variables too")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
+	cmd.Flags().StringVar(&kubecontext, "context", "", "Kubeconfig context to use")
+	return cmd
+}
+
+func writeDiff(w io.Writer, rep *diffReport, output string, showAll bool) error {
+	switch output {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	case "text", "":
+		renderText(w, rep, showAll)
+		return nil
+	default:
+		return fmt.Errorf("unknown output format %q: want text or json", output)
+	}
+}
+
+type diffRequest struct {
+	app     string
+	project string
+	env     string
+	file    string
+}
+
+// runDiff performs every cluster read and assembles the report. Returns an
+// error only for operational failures — drift findings live in the report.
+func runDiff(ctx context.Context, c client.Reader, req diffRequest) (*diffReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var proj mortisev1alpha1.Project
+	if err := c.Get(ctx, client.ObjectKey{Name: req.project}, &proj); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("project %q not found", req.project)
+		}
+		return nil, fmt.Errorf("read Project %q: %w", req.project, err)
+	}
+
+	controlNs := constants.ControlNamespace(req.project)
+	var liveApp mortisev1alpha1.App
+	if err := c.Get(ctx, client.ObjectKey{Name: req.app, Namespace: controlNs}, &liveApp); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("app %q not found in project %q (namespace %s)", req.app, req.project, controlNs)
+		}
+		return nil, fmt.Errorf("read App %s/%s: %w", controlNs, req.app, err)
+	}
+
+	specApp := &liveApp
+	if req.file != "" {
+		fileApp, err := loadAppManifest(req.file)
+		if err != nil {
+			return nil, err
+		}
+		if fileApp.Name != req.app {
+			return nil, fmt.Errorf("%s declares App %q, but the command names %q", req.file, fileApp.Name, req.app)
+		}
+		if fileApp.Namespace != "" && fileApp.Namespace != controlNs {
+			return nil, fmt.Errorf("%s targets namespace %q, but project %q uses %q", req.file, fileApp.Namespace, req.project, controlNs)
+		}
+		specApp = fileApp
+	}
+
+	envNames := resolveEnvNames(&proj, specApp, &liveApp, req.env)
+	if len(envNames) == 0 {
+		return nil, fmt.Errorf("project %q declares no environments", req.project)
+	}
+
+	rep := &diffReport{App: req.app, Project: req.project, Environments: []envDiffReport{}}
+	if req.file != "" {
+		rep.DryRunFile = req.file
+		rep.CRDChanges = buildCRDChanges(ctx, c, &liveApp, specApp, req.project, envNames)
+	}
+	for _, envName := range envNames {
+		er, err := buildEnvDiff(ctx, c, specApp, &liveApp, req.project, envName, proj.Spec.AutoRedeploy)
+		if err != nil {
+			return nil, err
+		}
+		rep.Environments = append(rep.Environments, er)
+	}
+	return rep, nil
+}
+
+// resolveEnvNames returns the environments to report on. The Project is the
+// authority — Apps auto-participate in every project environment — with the
+// App's own entries folded in so an App naming an env the Project has dropped
+// still shows up.
+func resolveEnvNames(proj *mortisev1alpha1.Project, specApp, liveApp *mortisev1alpha1.App, only string) []string {
+	if only != "" {
+		return []string{only}
+	}
+	seen := map[string]bool{}
+	var names []string
+	add := func(n string) {
+		if n == "" || seen[n] {
+			return
+		}
+		seen[n] = true
+		names = append(names, n)
+	}
+	for _, e := range proj.Spec.Environments {
+		add(e.Name)
+	}
+	extra := []string{}
+	for _, app := range []*mortisev1alpha1.App{specApp, liveApp} {
+		for _, e := range app.Spec.Environments {
+			if !seen[e.Name] {
+				extra = append(extra, e.Name)
+			}
+		}
+	}
+	sort.Strings(extra)
+	for _, n := range extra {
+		add(n)
+	}
+	if len(names) == 0 {
+		add(constants.DefaultProjectEnvironment)
+	}
+	return names
+}
+
+// loadAppManifest reads a single App manifest for -f. Anything that is not a
+// Mortise App is rejected rather than silently ignored.
+func loadAppManifest(path string) (*mortisev1alpha1.App, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var app mortisev1alpha1.App
+	if err := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096).Decode(&app); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if app.Kind != "" && app.Kind != "App" {
+		return nil, fmt.Errorf("%s contains kind %q, want App", path, app.Kind)
+	}
+	if app.Name == "" {
+		return nil, fmt.Errorf("%s has no metadata.name", path)
+	}
+	return &app, nil
+}

--- a/cmd/cli/diff.go
+++ b/cmd/cli/diff.go
@@ -76,9 +76,10 @@ func newDiffCmd() *cobra.Command {
   2. the derived Secret  {app}-env in pj-{project}-{env}, which pods mount via envFrom
   3. the running pods    the mortise.dev/env-hash the workload was started with
 
-Only names, sources, and 12-hex-char sha256 digests are printed. No variable
-value ever reaches the output, so the result is safe to paste into a channel
-during an incident.
+Only names, sources, and 12-hex-char digests are printed. No variable value
+ever reaches the output, so the result is safe to paste into a channel during
+an incident. The digests are salted per invocation — they answer "are these
+two the same value" within one report, and do not compare across runs.
 
 diff talks to Kubernetes directly using the standard kubeconfig resolution,
 not the Mortise HTTP API, and never writes to the cluster.

--- a/cmd/cli/diff_report.go
+++ b/cmd/cli/diff_report.go
@@ -47,6 +47,16 @@ const (
 	// API/UI and the controller deliberately leaves such an override alone.
 	// Normal and permanent by design.
 	catUserOverride = "user-override"
+	// catSpecShadowed: declared in both with different values, the Secret no
+	// longer holds what the CRD last applied, and — unlike catUserOverride —
+	// the Secret's entry is owned by the controller itself (binding, shared,
+	// or generated), not a user. The controller rewrites that entry from its
+	// source on every reconcile, so it always wins over the spec.env literal:
+	// the spec value is not merely behind, it can never take effect while
+	// this name belongs to that source. The API cannot have produced this
+	// state (it rejects writes to a non-user-owned key), so it is always a
+	// naming collision between spec.env and a binding/shared/generated var.
+	catSpecShadowed = "spec-shadowed-by-controller"
 	// catSpecDiffersUntracked: declared in both with different values, and the
 	// Secret records nothing about what the CRD last applied, so the two cases
 	// above cannot be told apart from the cluster.
@@ -531,9 +541,17 @@ func compareSpecVar(
 	case tracksLastAppliedSpec(lastApplied, entry.Value):
 		f.Category = catSpecDiffers
 		f.Detail = "the Secret still holds the value the CRD last applied, so this spec change has not reached it; the Secret is what pods mount, so the CRD value is not in effect"
-	default:
+	case entry.Source == "user" || entry.Source == "":
 		f.Category = catUserOverride
 		f.Detail = "the value was set through the API/UI after the CRD last applied its own; the controller keeps an override in place, so the Secret winning here is the intended behaviour"
+	default:
+		// entry.Source is binding/shared/generated: the API refuses to write a
+		// key it doesn't already own (internal/api/env.go), so this was never
+		// "set through the API/UI" — that detail would be false. The
+		// controller itself is the one overwriting the spec value, every
+		// reconcile, forever.
+		f.Category = catSpecShadowed
+		f.Detail = fmt.Sprintf("this key is owned by the %s source, which the controller rewrites into the Secret on every reconcile; the spec.env value can never take effect while that source claims the name", entry.Source)
 	}
 	return f
 }
@@ -543,28 +561,36 @@ func compareSpecVar(
 // never leads its report with an alarm.
 func categoryRank(cat string) int {
 	switch cat {
-	case catSpecDiffers:
+	// catSpecShadowed leads the report: it is the only state where the spec
+	// value is not merely stale or pending but permanently unreachable — the
+	// controller itself rewrites over it every reconcile, and until CAI-157
+	// that was misreported as the benign, do-nothing catUserOverride. Ranking
+	// it above catSpecDiffers (which self-heals on the next reconcile) says
+	// plainly that this one won't.
+	case catSpecShadowed:
 		return 0
-	case catSharedVarStale:
+	case catSpecDiffers:
 		return 1
-	case catMissingFromSecret:
+	case catSharedVarStale:
 		return 2
-	case catUnresolved:
+	case catMissingFromSecret:
 		return 3
-	case catSpecDiffersUntracked:
+	case catUnresolved:
 		return 4
-	case catNotDeclaredInCRD:
+	case catSpecDiffersUntracked:
 		return 5
-	case catUserOverride:
+	case catNotDeclaredInCRD:
 		return 6
-	case catFromSharedEnv:
+	case catUserOverride:
 		return 7
-	case catDerived:
+	case catFromSharedEnv:
 		return 8
-	case catInSync:
+	case catDerived:
 		return 9
+	case catInSync:
+		return 10
 	}
-	return 10
+	return 11
 }
 
 // buildRollout is layer 3. It compares the pod template's mortise.dev/env-hash
@@ -729,6 +755,7 @@ var categoryHeadings = map[string]string{
 	catSpecDiffersUntracked: "CRD and Secret disagree, cause undetermined",
 	catNotDeclaredInCRD:     "in the Secret, not declared in the CRD (normal: set via API/UI)",
 	catUserOverride:         "overridden via API/UI (normal: the platform honours overrides)",
+	catSpecShadowed:         "spec.env value shadowed by a controller-owned source (spec is never applied)",
 	catFromSharedEnv:        "from the project's shared-env Secret (normal)",
 	catDerived:              "derived by the controller (expected)",
 	catInSync:               "in sync",
@@ -772,7 +799,7 @@ func renderText(w io.Writer, rep *diffReport, showInSync bool) {
 			byCat[f.Category] = append(byCat[f.Category], f)
 		}
 		for _, cat := range []string{
-			catSpecDiffers, catSharedVarStale, catMissingFromSecret, catUnresolved,
+			catSpecShadowed, catSpecDiffers, catSharedVarStale, catMissingFromSecret, catUnresolved,
 			catSpecDiffersUntracked, catNotDeclaredInCRD, catUserOverride,
 			catFromSharedEnv, catDerived,
 		} {

--- a/cmd/cli/diff_report.go
+++ b/cmd/cli/diff_report.go
@@ -1,0 +1,610 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+	"github.com/mortise-org/mortise/internal/envstore"
+)
+
+// envHashAnnotation is the pod-template annotation the App controller stamps
+// with the hash of the env Secrets a workload was started with.
+const envHashAnnotation = "mortise.dev/env-hash"
+
+// digestLen is how much of a sha256 hex digest is printed. Short enough to
+// scan by eye, long enough that two different values effectively never
+// collide in one report.
+const digestLen = 12
+
+// Finding categories. These are part of the `-o json` contract.
+const (
+	// catInSync: declared in the CRD and present in the derived Secret with
+	// the same value. Nothing to do.
+	catInSync = "in-sync"
+	// catSpecDiffers: declared in both, different values. The Secret wins —
+	// it is what pods mount.
+	catSpecDiffers = "spec-differs-from-secret"
+	// catMissingFromSecret: declared in the CRD, absent from the derived
+	// Secret. Pods do not get this variable at all.
+	catMissingFromSecret = "missing-from-secret"
+	// catNotDeclaredInCRD: present in the derived Secret with source "user",
+	// absent from the CRD. Normal — the API writes user vars straight to the
+	// Secret and never touches the CRD.
+	catNotDeclaredInCRD = "not-declared-in-crd"
+	// catDerived: present in the derived Secret with a source the controller
+	// owns (binding / shared / generated). Expected to be absent from
+	// spec.env.
+	catDerived = "derived"
+	// catUnresolved: declared in the CRD but its effective value could not be
+	// determined, so it cannot be compared.
+	catUnresolved = "unresolved"
+)
+
+// diffFinding is one env var's verdict. It carries names, digests, and
+// sources — never a value.
+type diffFinding struct {
+	Name         string `json:"name"`
+	Category     string `json:"category"`
+	SpecDigest   string `json:"specDigest,omitempty"`
+	SecretDigest string `json:"secretDigest,omitempty"`
+	Source       string `json:"source,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+}
+
+// rolloutReport is layer 3: whether the running workload was started with the
+// environment that currently exists.
+type rolloutReport struct {
+	WorkloadKind  string `json:"workloadKind"`
+	WorkloadName  string `json:"workloadName"`
+	WorkloadFound bool   `json:"workloadFound"`
+	// SecretEnvHash is the hash of the env Secrets as they exist right now.
+	SecretEnvHash string `json:"secretEnvHash,omitempty"`
+	// WorkloadEnvHash is the hash the running pod template was stamped with.
+	WorkloadEnvHash       string `json:"workloadEnvHash,omitempty"`
+	StatusPendingEnvHash  string `json:"statusPendingEnvHash,omitempty"`
+	StatusDeployedEnvHash string `json:"statusDeployedEnvHash,omitempty"`
+	InSync                bool   `json:"inSync"`
+	AutoRedeploy          bool   `json:"autoRedeploy"`
+	Detail                string `json:"detail"`
+}
+
+// envDiffReport is the per-environment result.
+type envDiffReport struct {
+	Environment       string        `json:"environment"`
+	ControlNamespace  string        `json:"controlNamespace"`
+	WorkloadNamespace string        `json:"workloadNamespace"`
+	Enabled           bool          `json:"enabled"`
+	SecretExists      bool          `json:"secretExists"`
+	Findings          []diffFinding `json:"findings"`
+	Rollout           rolloutReport `json:"rollout"`
+}
+
+// crdChange is one entry of the `-f` (dry-run) CRD-level comparison.
+type crdChange struct {
+	Environment string `json:"environment"`
+	Name        string `json:"name"`
+	// Change is one of "add", "remove", "change".
+	Change     string `json:"change"`
+	LiveDigest string `json:"liveDigest,omitempty"`
+	FileDigest string `json:"fileDigest,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+// diffReport is the whole result. Marshalled verbatim by `-o json`.
+type diffReport struct {
+	App          string          `json:"app"`
+	Project      string          `json:"project"`
+	DryRunFile   string          `json:"dryRunFile,omitempty"`
+	CRDChanges   []crdChange     `json:"crdChanges,omitempty"`
+	Environments []envDiffReport `json:"environments"`
+}
+
+// digestValue is the only way a value ever influences output.
+func digestValue(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return hex.EncodeToString(sum[:])[:digestLen]
+}
+
+// shortHash truncates a full env-hash for display.
+func shortHash(h string) string {
+	if h == "" {
+		return "-"
+	}
+	if len(h) > digestLen {
+		return h[:digestLen]
+	}
+	return h
+}
+
+// specValue is the effective value of a spec env var, reduced to a digest.
+type specValue struct {
+	digest string
+	// binding is set when the value comes from the bindings resolver. The
+	// diff does not reimplement bindings resolution, so there is no digest
+	// to compare — only presence in the derived Secret is checked.
+	binding bool
+	// problem is non-empty when the effective value could not be determined.
+	problem string
+}
+
+// resolveSpecEnv mirrors the semantics of the App controller's
+// resolveEnvVarValue: literal value, bare-Secret-name secretRef keyed by the
+// env var's own name and read from the workload namespace, or fromBinding.
+// It never writes and never returns a value — only a digest of one.
+func resolveSpecEnv(ctx context.Context, c client.Reader, ev mortisev1alpha1.EnvVar, envNs string, bindingRefs map[string]bool) specValue {
+	hasValue := ev.Value != ""
+	hasSecretRef := ev.ValueFrom != nil && ev.ValueFrom.SecretRef != ""
+	hasFromBinding := ev.ValueFrom != nil && ev.ValueFrom.FromBinding != nil
+
+	sources := 0
+	for _, set := range []bool{hasValue, hasSecretRef, hasFromBinding} {
+		if set {
+			sources++
+		}
+	}
+	if sources > 1 {
+		return specValue{problem: "more than one of value, valueFrom.secretRef, valueFrom.fromBinding is set; the controller drops this variable"}
+	}
+
+	switch {
+	case hasSecretRef:
+		var secret corev1.Secret
+		err := c.Get(ctx, types.NamespacedName{Name: ev.ValueFrom.SecretRef, Namespace: envNs}, &secret)
+		if k8serrors.IsNotFound(err) {
+			return specValue{problem: fmt.Sprintf("valueFrom.secretRef %q does not exist in %s", ev.ValueFrom.SecretRef, envNs)}
+		}
+		if err != nil {
+			return specValue{problem: fmt.Sprintf("valueFrom.secretRef %q in %s could not be read: %v", ev.ValueFrom.SecretRef, envNs, err)}
+		}
+		raw, ok := secret.Data[ev.Name]
+		if !ok {
+			return specValue{problem: fmt.Sprintf("valueFrom.secretRef %q in %s has no key %q", ev.ValueFrom.SecretRef, envNs, ev.Name)}
+		}
+		return specValue{digest: digestValue(string(raw))}
+	case hasFromBinding:
+		ref := ev.ValueFrom.FromBinding.Ref
+		if !bindingRefs[ref] {
+			return specValue{problem: fmt.Sprintf("valueFrom.fromBinding.ref %q is not in this environment's bindings list", ref)}
+		}
+		return specValue{binding: true}
+	default:
+		return specValue{digest: digestValue(ev.Value)}
+	}
+}
+
+// findAppEnv returns the App's per-environment overrides for envName, or nil
+// when the App declares none (Apps auto-participate in every project env).
+func findAppEnv(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.Environment {
+	for i := range app.Spec.Environments {
+		if app.Spec.Environments[i].Name == envName {
+			return &app.Spec.Environments[i]
+		}
+	}
+	return nil
+}
+
+func findEnvStatus(app *mortisev1alpha1.App, envName string) *mortisev1alpha1.EnvironmentStatus {
+	for i := range app.Status.Environments {
+		if app.Status.Environments[i].Name == envName {
+			return &app.Status.Environments[i]
+		}
+	}
+	return nil
+}
+
+// buildEnvDiff compares the three layers for one App × environment.
+//
+// specApp supplies layer 1 (the CRD spec). It is the live App normally and the
+// App parsed from -f in dry-run mode. liveApp always supplies the status and
+// the workload name. Read-only: every cluster call here is a Get.
+func buildEnvDiff(
+	ctx context.Context,
+	c client.Reader,
+	specApp, liveApp *mortisev1alpha1.App,
+	project, envName string,
+	autoRedeploy bool,
+) (envDiffReport, error) {
+	envNs := constants.EnvNamespace(project, envName)
+	rep := envDiffReport{
+		Environment:       envName,
+		ControlNamespace:  constants.ControlNamespace(project),
+		WorkloadNamespace: envNs,
+		Enabled:           true,
+		Findings:          []diffFinding{},
+	}
+
+	specEnv := findAppEnv(specApp, envName)
+	if specEnv != nil && specEnv.Enabled != nil && !*specEnv.Enabled {
+		rep.Enabled = false
+	}
+
+	bindingRefs := map[string]bool{}
+	if specEnv != nil {
+		for _, b := range specEnv.Bindings {
+			bindingRefs[b.Ref] = true
+		}
+	}
+
+	// Layer 2: the derived Secret pods actually mount.
+	var secret corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Name: envstore.AppEnvSecretName(liveApp.Name), Namespace: envNs}, &secret)
+	switch {
+	case err == nil:
+		rep.SecretExists = true
+	case k8serrors.IsNotFound(err):
+	default:
+		return rep, fmt.Errorf("read env Secret %s/%s: %w", envNs, envstore.AppEnvSecretName(liveApp.Name), err)
+	}
+
+	secretEntries := map[string]envstore.Env{}
+	if rep.SecretExists {
+		for _, e := range envstore.SecretToEnvs(&secret) {
+			secretEntries[e.Name] = e
+		}
+	}
+
+	// Layer 1 → layer 2.
+	seen := map[string]bool{}
+	if specEnv != nil {
+		for _, ev := range specEnv.Env {
+			seen[ev.Name] = true
+			rep.Findings = append(rep.Findings, compareSpecVar(ctx, c, ev, envNs, bindingRefs, secretEntries))
+		}
+	}
+
+	// Whatever is left in the Secret was not declared in spec.env.
+	for name, e := range secretEntries {
+		if seen[name] {
+			continue
+		}
+		f := diffFinding{
+			Name:         name,
+			SecretDigest: digestValue(e.Value),
+			Source:       e.Source,
+		}
+		switch e.Source {
+		case "binding", "shared", "generated":
+			f.Category = catDerived
+			f.Detail = "written by the controller from " + derivedOrigin(e.Source) + "; not expected in spec.env"
+		default:
+			f.Category = catNotDeclaredInCRD
+			f.Detail = "set through the API/UI, which writes the Secret directly and never the CRD"
+		}
+		rep.Findings = append(rep.Findings, f)
+	}
+
+	sort.Slice(rep.Findings, func(i, j int) bool {
+		if rep.Findings[i].Category != rep.Findings[j].Category {
+			return categoryRank(rep.Findings[i].Category) < categoryRank(rep.Findings[j].Category)
+		}
+		return rep.Findings[i].Name < rep.Findings[j].Name
+	})
+
+	rollout, err := buildRollout(ctx, c, liveApp, project, envName, envNs, autoRedeploy)
+	if err != nil {
+		return rep, err
+	}
+	rep.Rollout = rollout
+	return rep, nil
+}
+
+func derivedOrigin(source string) string {
+	switch source {
+	case "binding":
+		return "this environment's bindings"
+	case "shared":
+		return "shared variables"
+	case "generated":
+		return "generated credentials"
+	}
+	return source
+}
+
+func compareSpecVar(
+	ctx context.Context,
+	c client.Reader,
+	ev mortisev1alpha1.EnvVar,
+	envNs string,
+	bindingRefs map[string]bool,
+	secretEntries map[string]envstore.Env,
+) diffFinding {
+	sv := resolveSpecEnv(ctx, c, ev, envNs, bindingRefs)
+	entry, inSecret := secretEntries[ev.Name]
+
+	f := diffFinding{Name: ev.Name}
+	if inSecret {
+		f.SecretDigest = digestValue(entry.Value)
+		f.Source = entry.Source
+	}
+
+	switch {
+	case sv.problem != "":
+		f.Category = catUnresolved
+		f.Detail = sv.problem
+		return f
+	case sv.binding:
+		// Bindings resolution is not reimplemented here; only presence is
+		// checked, so a bound var never shows up as a value mismatch.
+		if !inSecret {
+			f.Category = catMissingFromSecret
+			f.Detail = "declared as valueFrom.fromBinding but not present in the derived Secret"
+			return f
+		}
+		f.Category = catDerived
+		f.Detail = "valueFrom.fromBinding; value not compared (bindings are resolved by the controller)"
+		return f
+	case !inSecret:
+		f.Category = catMissingFromSecret
+		f.SpecDigest = sv.digest
+		f.Detail = "declared in the CRD but absent from the derived Secret; pods do not get this variable"
+		return f
+	}
+
+	f.SpecDigest = sv.digest
+	if sv.digest == f.SecretDigest {
+		f.Category = catInSync
+		return f
+	}
+	f.Category = catSpecDiffers
+	f.Detail = "the Secret is what pods mount, so the CRD value is not in effect"
+	return f
+}
+
+func categoryRank(cat string) int {
+	switch cat {
+	case catSpecDiffers:
+		return 0
+	case catMissingFromSecret:
+		return 1
+	case catUnresolved:
+		return 2
+	case catNotDeclaredInCRD:
+		return 3
+	case catDerived:
+		return 4
+	case catInSync:
+		return 5
+	}
+	return 6
+}
+
+// buildRollout is layer 3. It compares the pod template's mortise.dev/env-hash
+// against a freshly computed hash of the env Secrets, using the same function
+// the controller stamps with.
+func buildRollout(
+	ctx context.Context,
+	c client.Reader,
+	app *mortisev1alpha1.App,
+	project, envName, envNs string,
+	autoRedeploy bool,
+) (rolloutReport, error) {
+	r := rolloutReport{AutoRedeploy: autoRedeploy}
+	r.SecretEnvHash = envstore.EnvHash(ctx, c, app.Name, envNs)
+
+	if app.Spec.Kind == mortisev1alpha1.AppKindCron {
+		r.WorkloadKind = "CronJob"
+		r.WorkloadName = constants.CronJobName(app.Name)
+		var cj batchv1.CronJob
+		err := c.Get(ctx, types.NamespacedName{Name: r.WorkloadName, Namespace: envNs}, &cj)
+		switch {
+		case err == nil:
+			r.WorkloadFound = true
+			r.WorkloadEnvHash = cj.Spec.JobTemplate.Spec.Template.Annotations[envHashAnnotation]
+		case k8serrors.IsNotFound(err):
+		default:
+			return r, fmt.Errorf("read CronJob %s/%s: %w", envNs, r.WorkloadName, err)
+		}
+	} else {
+		r.WorkloadKind = "Deployment"
+		r.WorkloadName = constants.DeploymentName(app.Name)
+		var dep appsv1.Deployment
+		err := c.Get(ctx, types.NamespacedName{Name: r.WorkloadName, Namespace: envNs}, &dep)
+		switch {
+		case err == nil:
+			r.WorkloadFound = true
+			r.WorkloadEnvHash = dep.Spec.Template.Annotations[envHashAnnotation]
+		case k8serrors.IsNotFound(err):
+		default:
+			return r, fmt.Errorf("read Deployment %s/%s: %w", envNs, r.WorkloadName, err)
+		}
+	}
+
+	if es := findEnvStatus(app, envName); es != nil {
+		r.StatusPendingEnvHash = es.PendingEnvHash
+		r.StatusDeployedEnvHash = es.DeployedEnvHash
+	}
+
+	switch {
+	case !r.WorkloadFound:
+		r.Detail = "no " + r.WorkloadKind + " in " + envNs + " yet; nothing is running this environment"
+	case r.WorkloadEnvHash == r.SecretEnvHash:
+		r.InSync = true
+		r.Detail = "pods were started with the environment that currently exists"
+	default:
+		r.Detail = "pods are running an older environment; redeploy to apply the current one"
+		if !autoRedeploy {
+			r.Detail += " (Project.spec.autoRedeploy is false, so this is expected, not broken)"
+		}
+	}
+	return r, nil
+}
+
+// buildCRDChanges compares the live App's spec.env against the App parsed from
+// -f, per environment, as effective-value digests. Names and digests only.
+func buildCRDChanges(
+	ctx context.Context,
+	c client.Reader,
+	liveApp, fileApp *mortisev1alpha1.App,
+	project string,
+	envNames []string,
+) []crdChange {
+	changes := []crdChange{}
+	for _, envName := range envNames {
+		envNs := constants.EnvNamespace(project, envName)
+		live := specDigests(ctx, c, liveApp, envName, envNs)
+		file := specDigests(ctx, c, fileApp, envName, envNs)
+
+		names := map[string]bool{}
+		for n := range live {
+			names[n] = true
+		}
+		for n := range file {
+			names[n] = true
+		}
+		ordered := make([]string, 0, len(names))
+		for n := range names {
+			ordered = append(ordered, n)
+		}
+		sort.Strings(ordered)
+
+		for _, n := range ordered {
+			lv, inLive := live[n]
+			fv, inFile := file[n]
+			switch {
+			case !inLive:
+				changes = append(changes, crdChange{Environment: envName, Name: n, Change: "add", FileDigest: fv.digest, Detail: specNote(fv)})
+			case !inFile:
+				changes = append(changes, crdChange{Environment: envName, Name: n, Change: "remove", LiveDigest: lv.digest, Detail: specNote(lv)})
+			case lv.digest != fv.digest || lv.binding != fv.binding || lv.problem != fv.problem:
+				changes = append(changes, crdChange{
+					Environment: envName, Name: n, Change: "change",
+					LiveDigest: lv.digest, FileDigest: fv.digest,
+					Detail: strings.TrimSpace(specNote(lv) + " " + specNote(fv)),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+func specNote(sv specValue) string {
+	if sv.problem != "" {
+		return "unresolved: " + sv.problem
+	}
+	if sv.binding {
+		return "valueFrom.fromBinding; value not compared"
+	}
+	return ""
+}
+
+func specDigests(ctx context.Context, c client.Reader, app *mortisev1alpha1.App, envName, envNs string) map[string]specValue {
+	out := map[string]specValue{}
+	env := findAppEnv(app, envName)
+	if env == nil {
+		return out
+	}
+	bindingRefs := map[string]bool{}
+	for _, b := range env.Bindings {
+		bindingRefs[b.Ref] = true
+	}
+	for _, ev := range env.Env {
+		out[ev.Name] = resolveSpecEnv(ctx, c, ev, envNs, bindingRefs)
+	}
+	return out
+}
+
+// --- rendering ---
+
+var categoryHeadings = map[string]string{
+	catSpecDiffers:       "CRD and Secret disagree",
+	catMissingFromSecret: "declared in the CRD, missing from the Secret",
+	catUnresolved:        "declared in the CRD, value not resolvable",
+	catNotDeclaredInCRD:  "in the Secret, not declared in the CRD (normal: set via API/UI)",
+	catDerived:           "derived by the controller (expected)",
+	catInSync:            "in sync",
+}
+
+// renderText writes the human-readable report. Every field it prints is a
+// name, a namespace, a source label, or a digest.
+func renderText(w io.Writer, rep *diffReport, showInSync bool) {
+	fmt.Fprintf(w, "app %s  project %s\n", rep.App, rep.Project)
+	fmt.Fprintln(w, "values are never shown; each column is a 12-hex-char sha256 prefix")
+
+	if rep.DryRunFile != "" {
+		fmt.Fprintf(w, "\ndry run against %s — CRD-level changes an apply would make:\n", rep.DryRunFile)
+		if len(rep.CRDChanges) == 0 {
+			fmt.Fprintln(w, "  none")
+		} else {
+			tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "  ENV\tNAME\tCHANGE\tLIVE\tFILE\tNOTE")
+			for _, ch := range rep.CRDChanges {
+				fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+					ch.Environment, ch.Name, ch.Change, orDash(ch.LiveDigest), orDash(ch.FileDigest), ch.Detail)
+			}
+			_ = tw.Flush()
+		}
+		fmt.Fprintln(w, "\nthe comparison below uses the file's spec as layer 1 against the live cluster:")
+	}
+
+	for i := range rep.Environments {
+		e := &rep.Environments[i]
+		fmt.Fprintf(w, "\nenvironment %s   control ns %s   workload ns %s\n",
+			e.Environment, e.ControlNamespace, e.WorkloadNamespace)
+		if !e.Enabled {
+			fmt.Fprintln(w, "  (this App is opted out of this environment: spec.environments[].enabled=false)")
+		}
+		if !e.SecretExists {
+			fmt.Fprintf(w, "  no %s Secret in %s\n", envstore.AppEnvSecretName(rep.App), e.WorkloadNamespace)
+		}
+
+		byCat := map[string][]diffFinding{}
+		for _, f := range e.Findings {
+			byCat[f.Category] = append(byCat[f.Category], f)
+		}
+		for _, cat := range []string{catSpecDiffers, catMissingFromSecret, catUnresolved, catNotDeclaredInCRD, catDerived} {
+			renderCategory(w, cat, byCat[cat])
+		}
+		if inSync := byCat[catInSync]; len(inSync) > 0 {
+			if showInSync {
+				renderCategory(w, catInSync, inSync)
+			} else {
+				fmt.Fprintf(w, "\n  %s (%d) — use --all to list\n", categoryHeadings[catInSync], len(inSync))
+			}
+		}
+
+		fmt.Fprintln(w, "\n  rollout")
+		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(tw, "    current Secret env-hash\t%s\n", shortHash(e.Rollout.SecretEnvHash))
+		fmt.Fprintf(tw, "    %s pod-template env-hash\t%s\n", e.Rollout.WorkloadKind, shortHash(e.Rollout.WorkloadEnvHash))
+		fmt.Fprintf(tw, "    App status pending/deployed\t%s / %s\n",
+			shortHash(e.Rollout.StatusPendingEnvHash), shortHash(e.Rollout.StatusDeployedEnvHash))
+		_ = tw.Flush()
+		fmt.Fprintf(w, "    %s\n", e.Rollout.Detail)
+	}
+}
+
+func renderCategory(w io.Writer, cat string, findings []diffFinding) {
+	if len(findings) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n  %s (%d)\n", categoryHeadings[cat], len(findings))
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "    NAME\tSPEC\tSECRET\tSOURCE\tNOTE")
+	for _, f := range findings {
+		fmt.Fprintf(tw, "    %s\t%s\t%s\t%s\t%s\n",
+			f.Name, orDash(f.SpecDigest), orDash(f.SecretDigest), orDash(f.Source), f.Detail)
+	}
+	_ = tw.Flush()
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/cli/diff_report.go
+++ b/cmd/cli/diff_report.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -36,12 +38,28 @@ const (
 	// catInSync: declared in the CRD and present in the derived Secret with
 	// the same value. Nothing to do.
 	catInSync = "in-sync"
-	// catSpecDiffers: declared in both, different values. The Secret wins —
-	// it is what pods mount.
+	// catSpecDiffers: declared in both with different values, and the Secret
+	// still holds the value the CRD last applied. The spec has genuinely
+	// moved and has not reached the Secret pods mount.
 	catSpecDiffers = "spec-differs-from-secret"
+	// catUserOverride: declared in both with different values, and the Secret
+	// no longer holds what the CRD last applied. Someone set this through the
+	// API/UI and the controller deliberately leaves such an override alone.
+	// Normal and permanent by design.
+	catUserOverride = "user-override"
+	// catSpecDiffersUntracked: declared in both with different values, and the
+	// Secret records nothing about what the CRD last applied, so the two cases
+	// above cannot be told apart from the cluster.
+	catSpecDiffersUntracked = "spec-differs-untracked"
 	// catMissingFromSecret: declared in the CRD, absent from the derived
-	// Secret. Pods do not get this variable at all.
+	// Secret.
 	catMissingFromSecret = "missing-from-secret"
+	// catSharedVarStale: present in the derived Secret from spec.sharedVars,
+	// with a different value. sharedVars are seeded once and never re-applied.
+	catSharedVarStale = "shared-var-not-updated"
+	// catFromSharedEnv: absent from this app's Secret, present in the project's
+	// shared-env Secret — which pods mount as well.
+	catFromSharedEnv = "from-shared-env"
 	// catNotDeclaredInCRD: present in the derived Secret with source "user",
 	// absent from the CRD. Normal — the API writes user vars straight to the
 	// Secret and never touches the CRD.
@@ -114,10 +132,74 @@ type diffReport struct {
 	Environments []envDiffReport `json:"environments"`
 }
 
+// digestSalt randomises the printed digests once per invocation. They only
+// have to be comparable inside a single report, and an unsalted sha256 of a
+// low-entropy value (`true`, `production`, an account id) can be confirmed
+// offline by anyone holding a report — which this output is meant to survive
+// being pasted into a channel during an incident.
+var digestSalt = newDigestSalt()
+
+func newDigestSalt() []byte {
+	b := make([]byte, 16)
+	// crypto/rand.Read never returns an error; it crashes the program if the
+	// system source fails, which is the right outcome here — carrying on with
+	// an empty salt would silently restore the guessable digests.
+	_, _ = rand.Read(b)
+	return b
+}
+
 // digestValue is the only way a value ever influences output.
 func digestValue(v string) string {
+	h := sha256.New()
+	h.Write(digestSalt)
+	h.Write([]byte(v))
+	return hex.EncodeToString(h.Sum(nil))[:digestLen]
+}
+
+// specEnvDigest is the form the controller stores in
+// mortise.dev/last-spec-env-digest: a full, unsalted sha256 hex of the value.
+// Separate from digestValue because it is only ever compared against what the
+// controller wrote, never printed.
+func specEnvDigest(v string) string {
 	sum := sha256.Sum256([]byte(v))
-	return hex.EncodeToString(sum[:])[:digestLen]
+	return hex.EncodeToString(sum[:])
+}
+
+// lastSpecDigests reads the controller's record of what the spec last applied
+// to this Secret: env var name to the full sha256 of that value. Mirrors the
+// App controller's readLastSpecEnv, legacy-annotation fallback included, so
+// the CLI reads the signal exactly as the controller writes and acts on it.
+func lastSpecDigests(secret *corev1.Secret) map[string]string {
+	if raw := secret.Annotations[envstore.AnnotationLastSpecEnvDigest]; raw != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			return nil
+		}
+		return m
+	}
+	// The legacy annotation holds values rather than digests. Hashing them
+	// yields exactly what the digest annotation would have held, so Secrets
+	// written before CAI-168 classify the same way.
+	raw := secret.Annotations[envstore.AnnotationLastSpecEnv]
+	if raw == "" {
+		return nil
+	}
+	var legacy map[string]string
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
+		return nil
+	}
+	m := make(map[string]string, len(legacy))
+	for k, v := range legacy {
+		m[k] = specEnvDigest(v)
+	}
+	return m
+}
+
+// tracksLastAppliedSpec reports whether the Secret still holds the value the
+// controller last applied from the spec — the exact condition under which the
+// controller would overwrite it on the next reconcile.
+func tracksLastAppliedSpec(lastApplied, secretValue string) bool {
+	return lastApplied != "" && lastApplied == specEnvDigest(secretValue)
 }
 
 // shortHash truncates a full env-hash for display.
@@ -138,8 +220,31 @@ type specValue struct {
 	// diff does not reimplement bindings resolution, so there is no digest
 	// to compare — only presence in the derived Secret is checked.
 	binding bool
+	// ref and key identify which binding a fromBinding var projects from.
+	// They are part of what makes two bound vars different: repointing a var
+	// at another binding changes the value the controller will resolve, and
+	// with only `binding: true` to compare, that repoint is invisible. A
+	// binding ref is a name, not a value, so carrying it leaks nothing.
+	ref string
+	key string
 	// problem is non-empty when the effective value could not be determined.
 	problem string
+}
+
+// envLayers is what the cluster says about one App × environment, keyed by var
+// name. Assembled once per environment and read by the per-var comparison.
+type envLayers struct {
+	// app is the {app}-env Secret, mounted second so it wins on conflict.
+	app map[string]envstore.Env
+	// shared is the project's shared-env Secret, mounted first. Pods get it
+	// too, so a name missing from {app}-env is not necessarily missing from
+	// the container.
+	shared map[string]envstore.Env
+	// lastSpec maps a var name to the full sha256 of the value the controller
+	// last applied from the spec (mortise.dev/last-spec-env-digest). It is the
+	// only thing that distinguishes an unapplied spec change from a user
+	// override the platform is deliberately honouring.
+	lastSpec map[string]string
 }
 
 // resolveSpecEnv mirrors the semantics of the App controller's
@@ -181,7 +286,7 @@ func resolveSpecEnv(ctx context.Context, c client.Reader, ev mortisev1alpha1.Env
 		if !bindingRefs[ref] {
 			return specValue{problem: fmt.Sprintf("valueFrom.fromBinding.ref %q is not in this environment's bindings list", ref)}
 		}
-		return specValue{binding: true}
+		return specValue{binding: true, ref: ref, key: ev.ValueFrom.FromBinding.Key}
 	default:
 		return specValue{digest: digestValue(ev.Value)}
 	}
@@ -251,11 +356,26 @@ func buildEnvDiff(
 		return rep, fmt.Errorf("read env Secret %s/%s: %w", envNs, envstore.AppEnvSecretName(liveApp.Name), err)
 	}
 
-	secretEntries := map[string]envstore.Env{}
+	layers := envLayers{app: map[string]envstore.Env{}, shared: map[string]envstore.Env{}}
 	if rep.SecretExists {
 		for _, e := range envstore.SecretToEnvs(&secret) {
-			secretEntries[e.Name] = e
+			layers.app[e.Name] = e
 		}
+		layers.lastSpec = lastSpecDigests(&secret)
+	}
+
+	// The project's shared-env Secret is mounted by the same pods and folded
+	// into the rollout hash below, so the report has to see it or its own two
+	// layers disagree about what the app's environment contains.
+	var sharedSecret corev1.Secret
+	switch err := c.Get(ctx, types.NamespacedName{Name: envstore.SharedEnvName, Namespace: envNs}, &sharedSecret); {
+	case err == nil:
+		for _, e := range envstore.SecretToEnvs(&sharedSecret) {
+			layers.shared[e.Name] = e
+		}
+	case k8serrors.IsNotFound(err):
+	default:
+		return rep, fmt.Errorf("read shared Secret %s/%s: %w", envNs, envstore.SharedEnvName, err)
 	}
 
 	// Layer 1 → layer 2.
@@ -263,12 +383,20 @@ func buildEnvDiff(
 	if specEnv != nil {
 		for _, ev := range specEnv.Env {
 			seen[ev.Name] = true
-			rep.Findings = append(rep.Findings, compareSpecVar(ctx, c, ev, envNs, bindingRefs, secretEntries))
+			rep.Findings = append(rep.Findings, compareSpecVar(ctx, c, ev, envNs, bindingRefs, layers))
 		}
 	}
 
+	// spec.sharedVars is seeded into the Secret only when the name is absent,
+	// so an edited sharedVar never reaches pods. Reporting that as "derived by
+	// the controller (expected)" would file a permanent divergence as normal.
+	sharedVarSpec := map[string]string{}
+	for _, sv := range specApp.Spec.SharedVars {
+		sharedVarSpec[sv.Name] = digestValue(sv.Value)
+	}
+
 	// Whatever is left in the Secret was not declared in spec.env.
-	for name, e := range secretEntries {
+	for name, e := range layers.app {
 		if seen[name] {
 			continue
 		}
@@ -277,8 +405,13 @@ func buildEnvDiff(
 			SecretDigest: digestValue(e.Value),
 			Source:       e.Source,
 		}
-		switch e.Source {
-		case "binding", "shared", "generated":
+		specDigest, fromSharedVars := sharedVarSpec[name]
+		switch {
+		case e.Source == "shared" && fromSharedVars && specDigest != f.SecretDigest:
+			f.Category = catSharedVarStale
+			f.SpecDigest = specDigest
+			f.Detail = "spec.sharedVars is seeded into the Secret only when the name is absent and never re-applied, so the Secret keeps the value it was first given"
+		case e.Source == "binding", e.Source == "shared", e.Source == "generated":
 			f.Category = catDerived
 			f.Detail = "written by the controller from " + derivedOrigin(e.Source) + "; not expected in spec.env"
 		default:
@@ -286,6 +419,24 @@ func buildEnvDiff(
 			f.Detail = "set through the API/UI, which writes the Secret directly and never the CRD"
 		}
 		rep.Findings = append(rep.Findings, f)
+	}
+
+	// Names that exist only in shared-env. Pods get them; {app}-env does not
+	// carry them, so nothing above would have mentioned them.
+	for name, e := range layers.shared {
+		if seen[name] {
+			continue
+		}
+		if _, inApp := layers.app[name]; inApp {
+			continue
+		}
+		rep.Findings = append(rep.Findings, diffFinding{
+			Name:         name,
+			Category:     catFromSharedEnv,
+			SecretDigest: digestValue(e.Value),
+			Source:       envstore.SharedEnvName,
+			Detail:       "a project-level shared variable; pods mount shared-env alongside this app's own Secret",
+		})
 	}
 
 	sort.Slice(rep.Findings, func(i, j int) bool {
@@ -321,10 +472,10 @@ func compareSpecVar(
 	ev mortisev1alpha1.EnvVar,
 	envNs string,
 	bindingRefs map[string]bool,
-	secretEntries map[string]envstore.Env,
+	layers envLayers,
 ) diffFinding {
 	sv := resolveSpecEnv(ctx, c, ev, envNs, bindingRefs)
-	entry, inSecret := secretEntries[ev.Name]
+	entry, inSecret := layers.app[ev.Name]
 
 	f := diffFinding{Name: ev.Name}
 	if inSecret {
@@ -351,7 +502,12 @@ func compareSpecVar(
 	case !inSecret:
 		f.Category = catMissingFromSecret
 		f.SpecDigest = sv.digest
-		f.Detail = "declared in the CRD but absent from the derived Secret; pods do not get this variable"
+		f.Detail = "declared in the CRD but absent from the app's derived Secret"
+		if _, inShared := layers.shared[ev.Name]; inShared {
+			f.Detail += "; pods get the project's shared-env value for this name instead"
+		} else {
+			f.Detail += "; pods do not get this variable"
+		}
 		return f
 	}
 
@@ -360,27 +516,55 @@ func compareSpecVar(
 		f.Category = catInSync
 		return f
 	}
-	f.Category = catSpecDiffers
-	f.Detail = "the Secret is what pods mount, so the CRD value is not in effect"
+
+	// A spec/Secret mismatch is two unrelated states wearing the same face.
+	// The controller re-seeds a spec value only while the Secret still tracks
+	// the last one it applied; past that it leaves the override in place
+	// forever, on purpose. Reporting both as one alarm made the platform's
+	// designed behaviour the report's top finding, so classify on the
+	// annotation rather than assume.
+	lastApplied, tracked := layers.lastSpec[ev.Name]
+	switch {
+	case !tracked:
+		f.Category = catSpecDiffersUntracked
+		f.Detail = "the Secret carries no last-spec-env-digest entry for this variable, so an unapplied spec change and a deliberate override are indistinguishable from here"
+	case tracksLastAppliedSpec(lastApplied, entry.Value):
+		f.Category = catSpecDiffers
+		f.Detail = "the Secret still holds the value the CRD last applied, so this spec change has not reached it; the Secret is what pods mount, so the CRD value is not in effect"
+	default:
+		f.Category = catUserOverride
+		f.Detail = "the value was set through the API/UI after the CRD last applied its own; the controller keeps an override in place, so the Secret winning here is the intended behaviour"
+	}
 	return f
 }
 
+// categoryRank orders findings by how much they want a human. The states that
+// are normal by design sort below the ones that are not, so a healthy app
+// never leads its report with an alarm.
 func categoryRank(cat string) int {
 	switch cat {
 	case catSpecDiffers:
 		return 0
-	case catMissingFromSecret:
+	case catSharedVarStale:
 		return 1
-	case catUnresolved:
+	case catMissingFromSecret:
 		return 2
-	case catNotDeclaredInCRD:
+	case catUnresolved:
 		return 3
-	case catDerived:
+	case catSpecDiffersUntracked:
 		return 4
-	case catInSync:
+	case catNotDeclaredInCRD:
 		return 5
+	case catUserOverride:
+		return 6
+	case catFromSharedEnv:
+		return 7
+	case catDerived:
+		return 8
+	case catInSync:
+		return 9
 	}
-	return 6
+	return 10
 }
 
 // buildRollout is layer 3. It compares the pod template's mortise.dev/env-hash
@@ -480,11 +664,12 @@ func buildCRDChanges(
 				changes = append(changes, crdChange{Environment: envName, Name: n, Change: "add", FileDigest: fv.digest, Detail: specNote(fv)})
 			case !inFile:
 				changes = append(changes, crdChange{Environment: envName, Name: n, Change: "remove", LiveDigest: lv.digest, Detail: specNote(lv)})
-			case lv.digest != fv.digest || lv.binding != fv.binding || lv.problem != fv.problem:
+			case lv.digest != fv.digest || lv.binding != fv.binding ||
+				lv.ref != fv.ref || lv.key != fv.key || lv.problem != fv.problem:
 				changes = append(changes, crdChange{
 					Environment: envName, Name: n, Change: "change",
 					LiveDigest: lv.digest, FileDigest: fv.digest,
-					Detail: strings.TrimSpace(specNote(lv) + " " + specNote(fv)),
+					Detail: changeNote(lv, fv),
 				})
 			}
 		}
@@ -497,9 +682,25 @@ func specNote(sv specValue) string {
 		return "unresolved: " + sv.problem
 	}
 	if sv.binding {
-		return "valueFrom.fromBinding; value not compared"
+		return "valueFrom.fromBinding " + bindingTarget(sv) + "; value not compared"
 	}
 	return ""
+}
+
+// changeNote describes one "change" row. A binding repoint is the case the
+// two digests cannot express — both sides are empty — so it is spelled out.
+func changeNote(lv, fv specValue) string {
+	if lv.binding && fv.binding {
+		return "valueFrom.fromBinding " + bindingTarget(lv) + " -> " + bindingTarget(fv)
+	}
+	return strings.TrimSpace(specNote(lv) + " " + specNote(fv))
+}
+
+func bindingTarget(sv specValue) string {
+	if sv.key == "" {
+		return "ref " + sv.ref
+	}
+	return "ref " + sv.ref + " key " + sv.key
 }
 
 func specDigests(ctx context.Context, c client.Reader, app *mortisev1alpha1.App, envName, envNs string) map[string]specValue {
@@ -521,19 +722,23 @@ func specDigests(ctx context.Context, c client.Reader, app *mortisev1alpha1.App,
 // --- rendering ---
 
 var categoryHeadings = map[string]string{
-	catSpecDiffers:       "CRD and Secret disagree",
-	catMissingFromSecret: "declared in the CRD, missing from the Secret",
-	catUnresolved:        "declared in the CRD, value not resolvable",
-	catNotDeclaredInCRD:  "in the Secret, not declared in the CRD (normal: set via API/UI)",
-	catDerived:           "derived by the controller (expected)",
-	catInSync:            "in sync",
+	catSpecDiffers:          "CRD and Secret disagree",
+	catSharedVarStale:       "spec.sharedVars changed, the Secret was not updated",
+	catMissingFromSecret:    "declared in the CRD, missing from the Secret",
+	catUnresolved:           "declared in the CRD, value not resolvable",
+	catSpecDiffersUntracked: "CRD and Secret disagree, cause undetermined",
+	catNotDeclaredInCRD:     "in the Secret, not declared in the CRD (normal: set via API/UI)",
+	catUserOverride:         "overridden via API/UI (normal: the platform honours overrides)",
+	catFromSharedEnv:        "from the project's shared-env Secret (normal)",
+	catDerived:              "derived by the controller (expected)",
+	catInSync:               "in sync",
 }
 
 // renderText writes the human-readable report. Every field it prints is a
 // name, a namespace, a source label, or a digest.
 func renderText(w io.Writer, rep *diffReport, showInSync bool) {
 	fmt.Fprintf(w, "app %s  project %s\n", rep.App, rep.Project)
-	fmt.Fprintln(w, "values are never shown; each column is a 12-hex-char sha256 prefix")
+	fmt.Fprintln(w, "values are never shown; digests are salted per run and compare only within this report")
 
 	if rep.DryRunFile != "" {
 		fmt.Fprintf(w, "\ndry run against %s — CRD-level changes an apply would make:\n", rep.DryRunFile)
@@ -566,7 +771,11 @@ func renderText(w io.Writer, rep *diffReport, showInSync bool) {
 		for _, f := range e.Findings {
 			byCat[f.Category] = append(byCat[f.Category], f)
 		}
-		for _, cat := range []string{catSpecDiffers, catMissingFromSecret, catUnresolved, catNotDeclaredInCRD, catDerived} {
+		for _, cat := range []string{
+			catSpecDiffers, catSharedVarStale, catMissingFromSecret, catUnresolved,
+			catSpecDiffersUntracked, catNotDeclaredInCRD, catUserOverride,
+			catFromSharedEnv, catDerived,
+		} {
 			renderCategory(w, cat, byCat[cat])
 		}
 		if inSync := byCat[catInSync]; len(inSync) > 0 {

--- a/cmd/cli/diff_test.go
+++ b/cmd/cli/diff_test.go
@@ -101,6 +101,56 @@ func envSecret(data map[string]string, sources map[string]string) *corev1.Secret
 	return s
 }
 
+// sharedEnvSecret builds the project's shared-env Secret in the workload
+// namespace. Pods mount it alongside {app}-env.
+func sharedEnvSecret(data map[string]string) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: envstore.SharedEnvName, Namespace: testEnvNs},
+		Data:       map[string][]byte{},
+	}
+	for k, v := range data {
+		s.Data[k] = []byte(v)
+	}
+	return s
+}
+
+// withLastSpecEnv stamps the annotation the controller writes after applying
+// spec env vars: var name -> the value it applied. Whether a spec/Secret
+// mismatch is an unapplied spec change or a user override the platform is
+// honouring is decided entirely by this annotation, so a test that means one
+// of those two states says so here rather than in its assertions.
+func withLastSpecEnv(t *testing.T, s *corev1.Secret, lastApplied map[string]string) *corev1.Secret {
+	t.Helper()
+	digests := make(map[string]string, len(lastApplied))
+	for k, v := range lastApplied {
+		digests[k] = specEnvDigest(v)
+	}
+	raw, err := json.Marshal(digests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return annotate(s, envstore.AnnotationLastSpecEnvDigest, string(raw))
+}
+
+// withLegacyLastSpecEnv stamps the pre-CAI-168 annotation, which held the
+// applied values themselves rather than digests.
+func withLegacyLastSpecEnv(t *testing.T, s *corev1.Secret, lastApplied map[string]string) *corev1.Secret {
+	t.Helper()
+	raw, err := json.Marshal(lastApplied)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return annotate(s, envstore.AnnotationLastSpecEnv, string(raw))
+}
+
+func annotate(s *corev1.Secret, key, value string) *corev1.Secret {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	s.Annotations[key] = value
+	return s
+}
+
 func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
 	t.Helper()
 	return fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(objs...).Build()
@@ -136,11 +186,15 @@ func findingFor(t *testing.T, rep *diffReport, name string) diffFinding {
 	return diffFinding{}
 }
 
+// The alarm state: the Secret still holds exactly what the CRD last applied
+// (`info`), and the CRD now says something else. Nobody overrode anything —
+// the spec change has not reached the Secret pods mount.
 func TestDiff_SpecDiffersFromSecret(t *testing.T) {
 	c := newFakeClient(t,
 		testProjectObj(false),
 		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
-		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+		withLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+			map[string]string{"LOG_LEVEL": "info"}),
 	)
 
 	rep := runTestDiff(t, c, diffRequest{})
@@ -153,6 +207,79 @@ func TestDiff_SpecDiffersFromSecret(t *testing.T) {
 	}
 	if f.SecretDigest != digestValue("info") {
 		t.Errorf("secret digest: got %q, want %q", f.SecretDigest, digestValue("info"))
+	}
+}
+
+// The designed state, and the one that used to be reported as the top-priority
+// alarm: the Secret no longer holds what the CRD applied, because someone set
+// the var through the API/UI. `internal/api/env.go` permits that for a plain
+// spec literal, and the controller then leaves the override in place forever
+// on purpose. Reporting it as a fault means every healthy cluster leads its
+// report with a red herring.
+func TestDiff_UserOverrideIsNotTheAlarm(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		withLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "trace"}, nil),
+			map[string]string{"LOG_LEVEL": "debug"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "LOG_LEVEL")
+	if f.Category != catUserOverride {
+		t.Errorf("category: got %q, want %q", f.Category, catUserOverride)
+	}
+	if f.Category == catSpecDiffers {
+		t.Error("an honoured override must not be reported as the CRD-not-in-effect alarm")
+	}
+	if categoryRank(f.Category) <= categoryRank(catSpecDiffers) {
+		t.Errorf("an override must rank below the alarm, got rank %d vs %d",
+			categoryRank(f.Category), categoryRank(catSpecDiffers))
+	}
+	for _, banned := range []string{"error", "invalid", "wrong", "drift"} {
+		if strings.Contains(strings.ToLower(f.Detail), banned) {
+			t.Errorf("detail %q implies the state is wrong (contains %q)", f.Detail, banned)
+		}
+	}
+}
+
+// With no annotation there is nothing in the cluster that separates an
+// unapplied spec change from an override, so the report says exactly that
+// instead of picking the scarier of the two.
+func TestDiff_UntrackedSpecMismatchIsUndetermined(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "LOG_LEVEL")
+	if f.Category != catSpecDiffersUntracked {
+		t.Errorf("category: got %q, want %q", f.Category, catSpecDiffersUntracked)
+	}
+	if f.Category == catSpecDiffers || f.Category == catUserOverride {
+		t.Error("an undetermined mismatch must not be filed as either decided case")
+	}
+	if !strings.Contains(f.Detail, "last-spec-env-digest") {
+		t.Errorf("detail should name the missing signal, got %q", f.Detail)
+	}
+}
+
+// Secrets written before CAI-168 carry values, not digests, under the legacy
+// annotation. The controller migrates by hashing them; so does the report, or
+// every var on an un-reconciled cluster reads as undetermined.
+func TestDiff_LegacyLastSpecEnvAnnotationIsUnderstood(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		withLegacyLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+			map[string]string{"LOG_LEVEL": "info"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if f := findingFor(t, rep, "LOG_LEVEL"); f.Category != catSpecDiffers {
+		t.Errorf("category: got %q (%s), want %q", f.Category, f.Detail, catSpecDiffers)
 	}
 }
 
@@ -183,6 +310,109 @@ func TestDiff_MissingFromSecret(t *testing.T) {
 	}
 	if f.SecretDigest != "" {
 		t.Errorf("secret digest should be empty, got %q", f.SecretDigest)
+	}
+}
+
+// Pods mount shared-env as well as {app}-env, so "missing from the app's
+// Secret" must not claim the container does not get the variable.
+func TestDiff_MissingFromAppSecretCreditsSharedEnv(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "REGION", Value: "us-east"}}, nil),
+		envSecret(map[string]string{"OTHER": "x"}, nil),
+		sharedEnvSecret(map[string]string{"REGION": "eu-west"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "REGION")
+	if f.Category != catMissingFromSecret {
+		t.Errorf("category: got %q, want %q", f.Category, catMissingFromSecret)
+	}
+	if strings.Contains(f.Detail, "pods do not get this variable") {
+		t.Errorf("detail claims pods get nothing while shared-env supplies the name: %q", f.Detail)
+	}
+	if !strings.Contains(f.Detail, "shared-env") {
+		t.Errorf("detail should say where pods get the value instead, got %q", f.Detail)
+	}
+}
+
+// A var that lives only in shared-env still reaches the container and is
+// folded into the rollout hash, so leaving it out would make the report's two
+// layers disagree about what the app's environment contains.
+func TestDiff_SharedEnvOnlyVarIsReported(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj(nil, nil),
+		envSecret(map[string]string{"OTHER": "x"}, nil),
+		sharedEnvSecret(map[string]string{"SENTRY_ENV": "prod"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "SENTRY_ENV")
+	if f.Category != catFromSharedEnv {
+		t.Errorf("category: got %q, want %q", f.Category, catFromSharedEnv)
+	}
+	if f.SecretDigest != digestValue("prod") {
+		t.Errorf("secret digest: got %q, want %q", f.SecretDigest, digestValue("prod"))
+	}
+	for _, banned := range []string{"error", "invalid", "wrong", "drift"} {
+		if strings.Contains(strings.ToLower(f.Detail), banned) {
+			t.Errorf("detail %q implies the state is wrong (contains %q)", f.Detail, banned)
+		}
+	}
+}
+
+// {app}-env wins at mount, so a name in both is already reported from the app
+// Secret and must not also appear as a shared-env finding.
+func TestDiff_SharedEnvDoesNotDuplicateAppSecretVars(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+		sharedEnvSecret(map[string]string{"LOG_LEVEL": "debug"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if n := len(rep.Environments[0].Findings); n != 1 {
+		t.Fatalf("expected exactly one finding, got %d: %+v", n, rep.Environments[0].Findings)
+	}
+	if f := findingFor(t, rep, "LOG_LEVEL"); f.Category != catInSync {
+		t.Errorf("category: got %q, want %q", f.Category, catInSync)
+	}
+}
+
+// spec.sharedVars is seeded into the Secret only when the name is absent, so
+// editing one never reaches pods. Filing that under "derived by the controller
+// (expected)" would call a permanent divergence normal.
+func TestDiff_StaleSharedVarIsReportedNotExpected(t *testing.T) {
+	app := testAppObj(nil, nil)
+	app.Spec.SharedVars = []mortisev1alpha1.EnvVar{{Name: "TEAM", Value: "platform"}}
+	c := newFakeClient(t,
+		testProjectObj(false), app,
+		envSecret(map[string]string{"TEAM": "infra"}, map[string]string{"TEAM": "shared"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "TEAM")
+	if f.Category != catSharedVarStale {
+		t.Errorf("category: got %q (%s), want %q", f.Category, f.Detail, catSharedVarStale)
+	}
+	if f.SpecDigest != digestValue("platform") || f.SecretDigest != digestValue("infra") {
+		t.Errorf("both sides should be digested: %+v", f)
+	}
+}
+
+func TestDiff_MatchingSharedVarStaysDerived(t *testing.T) {
+	app := testAppObj(nil, nil)
+	app.Spec.SharedVars = []mortisev1alpha1.EnvVar{{Name: "TEAM", Value: "platform"}}
+	c := newFakeClient(t,
+		testProjectObj(false), app,
+		envSecret(map[string]string{"TEAM": "platform"}, map[string]string{"TEAM": "shared"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if f := findingFor(t, rep, "TEAM"); f.Category != catDerived {
+		t.Errorf("category: got %q, want %q", f.Category, catDerived)
 	}
 }
 
@@ -470,6 +700,8 @@ func TestDiff_NeverPrintsAValue(t *testing.T) {
 		"sentinelSharedValue5",
 		"sentinelCredsValue6",
 		"sentinelFileValue7",
+		"sentinelLegacyValue8",
+		"sentinelSharedEnvValue9",
 	}
 
 	creds := &corev1.Secret{
@@ -480,7 +712,10 @@ func TestDiff_NeverPrintsAValue(t *testing.T) {
 		{Name: "LOG_LEVEL", Value: "sentinelLiteralValue1"},
 		{Name: "DB_PASSWORD", ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "web-creds"}},
 	}, nil)
-	secret := envSecret(
+	// The legacy last-spec-env annotation holds plaintext values, and the
+	// shared-env Secret is a second source of values the report now reads.
+	// Both are digested on the way in or not printed at all.
+	secret := withLegacyLastSpecEnv(t, envSecret(
 		map[string]string{
 			"LOG_LEVEL":   "sentinelSecretValue2",
 			"UI_SET":      "sentinelUserSetValue3",
@@ -488,7 +723,8 @@ func TestDiff_NeverPrintsAValue(t *testing.T) {
 			"SHARED_FLAG": "sentinelSharedValue5",
 		},
 		map[string]string{"PGHOST": "binding", "SHARED_FLAG": "shared"},
-	)
+	), map[string]string{"LOG_LEVEL": "sentinelLegacyValue8"})
+	shared := sharedEnvSecret(map[string]string{"PROJECT_TIER": "sentinelSharedEnvValue9"})
 
 	dir := t.TempDir()
 	manifest := filepath.Join(dir, "app.yaml")
@@ -509,7 +745,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	c := newFakeClient(t, testProjectObj(false), app, creds, secret,
+	c := newFakeClient(t, testProjectObj(false), app, creds, secret, shared,
 		deploymentWithEnvHash("0000000000000000"))
 
 	for _, req := range []diffRequest{
@@ -538,10 +774,32 @@ spec:
 	}
 }
 
+// The report is meant to survive being pasted into a channel. An unsalted
+// sha256 of a low-entropy value (`true`, `production`, an account id) does
+// not: anyone holding the report can confirm a guess offline.
+func TestDiff_DigestsAreSaltedNotPlainSHA256(t *testing.T) {
+	for _, v := range []string{"true", "production", "info"} {
+		if digestValue(v) == specEnvDigest(v)[:digestLen] {
+			t.Errorf("digest of %q is a plain sha256 prefix; a guess can be confirmed offline", v)
+		}
+	}
+	first, second := newDigestSalt(), newDigestSalt()
+	if string(first) == string(second) {
+		t.Error("the salt must be random per invocation")
+	}
+	// Within one report equal values must still produce equal digests, which
+	// is the only property the output promises.
+	a, b := digestValue("same"), digestValue("same")
+	if a != b {
+		t.Error("digests must be stable within one invocation")
+	}
+}
+
 func TestDiff_TextOutputCarriesNamesAndDigests(t *testing.T) {
 	c := newFakeClient(t, testProjectObj(false),
 		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
-		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+		withLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+			map[string]string{"LOG_LEVEL": "info"}))
 
 	rep := runTestDiff(t, c, diffRequest{})
 	var buf bytes.Buffer
@@ -559,7 +817,8 @@ func TestDiff_TextOutputCarriesNamesAndDigests(t *testing.T) {
 func TestDiff_JSONOutputIsStructured(t *testing.T) {
 	c := newFakeClient(t, testProjectObj(false),
 		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
-		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+		withLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+			map[string]string{"LOG_LEVEL": "info"}))
 
 	rep := runTestDiff(t, c, diffRequest{})
 	var buf bytes.Buffer
@@ -758,12 +1017,142 @@ spec:
 	}
 }
 
+// A bound var carries no digest to compare, so without the ref on the
+// comparison a manifest that repoints DB_URL at a different backing service
+// produced no change at all and the dry run printed "none".
+func TestDryRun_BindingRepointIsAChange(t *testing.T) {
+	app := testAppObj(
+		[]mortisev1alpha1.EnvVar{{
+			Name: "DB_URL",
+			ValueFrom: &mortisev1alpha1.EnvVarSource{
+				FromBinding: &mortisev1alpha1.BindingVarSource{Ref: "db-a", Key: "url"},
+			},
+		}},
+		[]mortisev1alpha1.Binding{{Ref: "db-a"}, {Ref: "db-b"}},
+	)
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      bindings:
+        - ref: db-a
+        - ref: db-b
+      env:
+        - name: DB_URL
+          valueFrom:
+            fromBinding:
+              ref: db-b
+              key: url
+`)
+
+	rep := runTestDiff(t, c, diffRequest{file: manifest})
+	if len(rep.CRDChanges) != 1 {
+		t.Fatalf("expected the repoint to be reported, got %+v", rep.CRDChanges)
+	}
+	ch := rep.CRDChanges[0]
+	if ch.Name != "DB_URL" || ch.Change != "change" {
+		t.Errorf("unexpected change: %+v", ch)
+	}
+	if !strings.Contains(ch.Detail, "db-a") || !strings.Contains(ch.Detail, "db-b") {
+		t.Errorf("detail should name both bindings, got %q", ch.Detail)
+	}
+}
+
+// Repointing only the key inside the same binding is a change too.
+func TestDryRun_BindingKeyChangeIsAChange(t *testing.T) {
+	app := testAppObj(
+		[]mortisev1alpha1.EnvVar{{
+			Name: "DB_URL",
+			ValueFrom: &mortisev1alpha1.EnvVarSource{
+				FromBinding: &mortisev1alpha1.BindingVarSource{Ref: "db", Key: "url"},
+			},
+		}},
+		[]mortisev1alpha1.Binding{{Ref: "db"}},
+	)
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      bindings:
+        - ref: db
+      env:
+        - name: DB_URL
+          valueFrom:
+            fromBinding:
+              ref: db
+              key: readonly_url
+`)
+
+	rep := runTestDiff(t, c, diffRequest{file: manifest})
+	if len(rep.CRDChanges) != 1 {
+		t.Fatalf("expected the key change to be reported, got %+v", rep.CRDChanges)
+	}
+	if !strings.Contains(rep.CRDChanges[0].Detail, "readonly_url") {
+		t.Errorf("detail should name the new key, got %q", rep.CRDChanges[0].Detail)
+	}
+}
+
+// An unchanged bound var is still not a change.
+func TestDryRun_UnchangedBindingIsNotAChange(t *testing.T) {
+	env := []mortisev1alpha1.EnvVar{{
+		Name: "DB_URL",
+		ValueFrom: &mortisev1alpha1.EnvVarSource{
+			FromBinding: &mortisev1alpha1.BindingVarSource{Ref: "db", Key: "url"},
+		},
+	}}
+	c := newFakeClient(t, testProjectObj(false),
+		testAppObj(env, []mortisev1alpha1.Binding{{Ref: "db"}}))
+
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      bindings:
+        - ref: db
+      env:
+        - name: DB_URL
+          valueFrom:
+            fromBinding:
+              ref: db
+              key: url
+`)
+
+	if rep := runTestDiff(t, c, diffRequest{file: manifest}); len(rep.CRDChanges) != 0 {
+		t.Errorf("expected no changes, got %+v", rep.CRDChanges)
+	}
+}
+
 // In dry-run mode the file's spec becomes layer 1, so the layer 1 -> 2
 // comparison answers "what would the pods disagree with after this apply".
 func TestDryRun_UsesTheFileSpecAsLayerOne(t *testing.T) {
 	app := testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil)
+	// The Secret holds exactly what the live CRD applied, so the file's `debug`
+	// is an unapplied spec change rather than an override of one.
 	c := newFakeClient(t, testProjectObj(false), app,
-		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+		withLastSpecEnv(t, envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+			map[string]string{"LOG_LEVEL": "info"}))
 
 	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
 kind: App

--- a/cmd/cli/diff_test.go
+++ b/cmd/cli/diff_test.go
@@ -1,0 +1,876 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/envstore"
+)
+
+// Every test in this file builds the same shape: project `myproj` with one
+// environment `production`, app `web`. Control ns pj-myproj, workload ns
+// pj-myproj-production.
+const (
+	testProject   = "myproj"
+	testApp       = "web"
+	testEnv       = "production"
+	testControlNs = "pj-myproj"
+	testEnvNs     = "pj-myproj-production"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		batchv1.AddToScheme,
+		mortisev1alpha1.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func testProjectObj(autoRedeploy bool) *mortisev1alpha1.Project {
+	return &mortisev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: testProject},
+		Spec: mortisev1alpha1.ProjectSpec{
+			Environments: []mortisev1alpha1.ProjectEnvironment{{Name: testEnv}},
+			AutoRedeploy: autoRedeploy,
+		},
+	}
+}
+
+func testAppObj(env []mortisev1alpha1.EnvVar, bindings []mortisev1alpha1.Binding) *mortisev1alpha1.App {
+	return &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: testApp, Namespace: testControlNs},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: "image", Image: "nginx:1.27"},
+			Environments: []mortisev1alpha1.Environment{{Name: testEnv, Env: env, Bindings: bindings}},
+		},
+	}
+}
+
+// envSecret builds the derived {app}-env Secret. sources maps a var name to an
+// envstore source ("binding", "shared", "generated"); anything absent is a
+// plain user var.
+func envSecret(data map[string]string, sources map[string]string) *corev1.Secret {
+	vars := make([]envstore.Env, 0, len(data))
+	for k, v := range data {
+		vars = append(vars, envstore.Env{Name: k, Value: v, Source: sources[k]})
+	}
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: envstore.AppEnvSecretName(testApp), Namespace: testEnvNs},
+		Data:       map[string][]byte{},
+	}
+	annotations := map[string][]string{}
+	for _, v := range vars {
+		s.Data[v.Name] = []byte(v.Value)
+		switch v.Source {
+		case "binding":
+			annotations[envstore.AnnotationBindingKeys] = append(annotations[envstore.AnnotationBindingKeys], v.Name)
+		case "generated":
+			annotations[envstore.AnnotationGeneratedKeys] = append(annotations[envstore.AnnotationGeneratedKeys], v.Name)
+		case "shared":
+			annotations[envstore.AnnotationSharedKeys] = append(annotations[envstore.AnnotationSharedKeys], v.Name)
+		}
+	}
+	if len(annotations) > 0 {
+		s.Annotations = map[string]string{}
+		for k, names := range annotations {
+			s.Annotations[k] = strings.Join(names, ",")
+		}
+	}
+	return s
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(objs...).Build()
+}
+
+func runTestDiff(t *testing.T, c client.Reader, req diffRequest) *diffReport {
+	t.Helper()
+	if req.app == "" {
+		req.app = testApp
+	}
+	if req.project == "" {
+		req.project = testProject
+	}
+	rep, err := runDiff(context.Background(), c, req)
+	if err != nil {
+		t.Fatalf("runDiff: %v", err)
+	}
+	return rep
+}
+
+// findingFor returns the finding for name in the first environment.
+func findingFor(t *testing.T, rep *diffReport, name string) diffFinding {
+	t.Helper()
+	if len(rep.Environments) == 0 {
+		t.Fatal("report has no environments")
+	}
+	for _, f := range rep.Environments[0].Findings {
+		if f.Name == name {
+			return f
+		}
+	}
+	t.Fatalf("no finding for %q; findings: %+v", name, rep.Environments[0].Findings)
+	return diffFinding{}
+}
+
+func TestDiff_SpecDiffersFromSecret(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "LOG_LEVEL")
+	if f.Category != catSpecDiffers {
+		t.Errorf("category: got %q, want %q", f.Category, catSpecDiffers)
+	}
+	if f.SpecDigest != digestValue("debug") {
+		t.Errorf("spec digest: got %q, want %q", f.SpecDigest, digestValue("debug"))
+	}
+	if f.SecretDigest != digestValue("info") {
+		t.Errorf("secret digest: got %q, want %q", f.SecretDigest, digestValue("info"))
+	}
+}
+
+func TestDiff_InSync(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if f := findingFor(t, rep, "LOG_LEVEL"); f.Category != catInSync {
+		t.Errorf("category: got %q, want %q", f.Category, catInSync)
+	}
+}
+
+func TestDiff_MissingFromSecret(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "NEW_FLAG", Value: "on"}}, nil),
+		envSecret(map[string]string{"OTHER": "x"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "NEW_FLAG")
+	if f.Category != catMissingFromSecret {
+		t.Errorf("category: got %q, want %q", f.Category, catMissingFromSecret)
+	}
+	if f.SecretDigest != "" {
+		t.Errorf("secret digest should be empty, got %q", f.SecretDigest)
+	}
+}
+
+// The API writes user vars straight into the derived Secret and never touches
+// the CRD, so a Secret-only var is normal, not an error.
+func TestDiff_SecretOnlyUserVarIsNotDeclaredInCRD(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj(nil, nil),
+		envSecret(map[string]string{"SENTRY_DSN": "x"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "SENTRY_DSN")
+	if f.Category != catNotDeclaredInCRD {
+		t.Errorf("category: got %q, want %q", f.Category, catNotDeclaredInCRD)
+	}
+	for _, banned := range []string{"error", "invalid", "wrong", "drift"} {
+		if strings.Contains(strings.ToLower(f.Detail), banned) {
+			t.Errorf("detail %q implies the state is wrong (contains %q)", f.Detail, banned)
+		}
+	}
+}
+
+// Binding- and shared-sourced entries legitimately exist without appearing in
+// spec.env. Reporting them as undeclared drift is the mistake that sank an
+// earlier attempt at this command.
+func TestDiff_BindingAndSharedEntriesAreNotDrift(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj(nil, nil),
+		envSecret(
+			map[string]string{"PGHOST": "h", "LOG_LEVEL": "info", "PASSWORD": "p"},
+			map[string]string{"PGHOST": "binding", "LOG_LEVEL": "shared", "PASSWORD": "generated"},
+		),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	for _, name := range []string{"PGHOST", "LOG_LEVEL", "PASSWORD"} {
+		f := findingFor(t, rep, name)
+		if f.Category != catDerived {
+			t.Errorf("%s: category got %q, want %q", name, f.Category, catDerived)
+		}
+	}
+}
+
+func TestDiff_SecretRefResolvesAgainstEnvNamespace(t *testing.T) {
+	creds := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-creds", Namespace: testEnvNs},
+		Data:       map[string][]byte{"DB_PASSWORD": []byte("hunter2")},
+	}
+	app := testAppObj([]mortisev1alpha1.EnvVar{{
+		Name:      "DB_PASSWORD",
+		ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "web-creds"},
+	}}, nil)
+
+	c := newFakeClient(t,
+		testProjectObj(false), app, creds,
+		envSecret(map[string]string{"DB_PASSWORD": "hunter2"}, nil),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if f := findingFor(t, rep, "DB_PASSWORD"); f.Category != catInSync {
+		t.Errorf("category: got %q (%s), want %q", f.Category, f.Detail, catInSync)
+	}
+}
+
+func TestDiff_SecretRefMissingKeyIsUnresolved(t *testing.T) {
+	creds := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-creds", Namespace: testEnvNs},
+		Data:       map[string][]byte{"pw": []byte("hunter2")},
+	}
+	app := testAppObj([]mortisev1alpha1.EnvVar{{
+		Name:      "DB_PASSWORD",
+		ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "web-creds"},
+	}}, nil)
+
+	c := newFakeClient(t, testProjectObj(false), app, creds)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "DB_PASSWORD")
+	if f.Category != catUnresolved {
+		t.Errorf("category: got %q, want %q", f.Category, catUnresolved)
+	}
+	if !strings.Contains(f.Detail, "has no key") {
+		t.Errorf("detail should name the missing key, got %q", f.Detail)
+	}
+}
+
+func TestDiff_SecretRefMissingSecretIsUnresolved(t *testing.T) {
+	app := testAppObj([]mortisev1alpha1.EnvVar{{
+		Name:      "DB_PASSWORD",
+		ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "nope"},
+	}}, nil)
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if f := findingFor(t, rep, "DB_PASSWORD"); f.Category != catUnresolved {
+		t.Errorf("category: got %q, want %q", f.Category, catUnresolved)
+	}
+}
+
+// A fromBinding var declared without the matching bindings[] entry is exactly
+// what the controller rejects; the diff reports it rather than guessing.
+func TestDiff_FromBindingWithoutBindingIsUnresolved(t *testing.T) {
+	app := testAppObj([]mortisev1alpha1.EnvVar{{
+		Name: "PGHOST",
+		ValueFrom: &mortisev1alpha1.EnvVarSource{
+			FromBinding: &mortisev1alpha1.BindingVarSource{Ref: "db", Key: "host"},
+		},
+	}}, nil)
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "PGHOST")
+	if f.Category != catUnresolved {
+		t.Errorf("category: got %q, want %q", f.Category, catUnresolved)
+	}
+	if !strings.Contains(f.Detail, "bindings list") {
+		t.Errorf("detail should explain the missing bindings entry, got %q", f.Detail)
+	}
+}
+
+// A properly-declared fromBinding var is resolved by the controller, not by
+// diff, so its value is never compared — presence only.
+func TestDiff_FromBindingWithBindingIsDerived(t *testing.T) {
+	app := testAppObj(
+		[]mortisev1alpha1.EnvVar{{
+			Name: "PGHOST",
+			ValueFrom: &mortisev1alpha1.EnvVarSource{
+				FromBinding: &mortisev1alpha1.BindingVarSource{Ref: "db", Key: "host"},
+			},
+		}},
+		[]mortisev1alpha1.Binding{{Ref: "db"}},
+	)
+	c := newFakeClient(t, testProjectObj(false), app,
+		envSecret(map[string]string{"PGHOST": "db.internal"}, map[string]string{"PGHOST": "binding"}))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "PGHOST")
+	if f.Category != catDerived {
+		t.Errorf("category: got %q (%s), want %q", f.Category, f.Detail, catDerived)
+	}
+	if f.SpecDigest != "" {
+		t.Errorf("a bound var must not carry a spec digest, got %q", f.SpecDigest)
+	}
+}
+
+// --- layer 3 ---
+
+func deploymentWithEnvHash(hash string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: testApp, Namespace: testEnvNs},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{envHashAnnotation: hash},
+				},
+			},
+		},
+	}
+}
+
+func TestDiff_RolloutInSyncWhenHashesMatch(t *testing.T) {
+	secret := envSecret(map[string]string{"LOG_LEVEL": "info"}, nil)
+	live := envstore.HashData(secret.Data)
+
+	c := newFakeClient(t, testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil),
+		secret, deploymentWithEnvHash(live))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	r := rep.Environments[0].Rollout
+	if !r.InSync {
+		t.Errorf("expected rollout in sync, got %+v", r)
+	}
+	if r.SecretEnvHash != live {
+		t.Errorf("secret env hash: got %q, want %q", r.SecretEnvHash, live)
+	}
+}
+
+func TestDiff_RolloutStaleWhenHashesDiffer(t *testing.T) {
+	secret := envSecret(map[string]string{"LOG_LEVEL": "info"}, nil)
+	c := newFakeClient(t, testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil),
+		secret, deploymentWithEnvHash("0000000000000000"))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	r := rep.Environments[0].Rollout
+	if r.InSync {
+		t.Errorf("expected rollout out of sync, got %+v", r)
+	}
+	if !strings.Contains(r.Detail, "redeploy") {
+		t.Errorf("detail should say a redeploy is needed, got %q", r.Detail)
+	}
+	// autoRedeploy defaults to false, so this state is expected rather than
+	// broken and the output must say so.
+	if !strings.Contains(r.Detail, "autoRedeploy") {
+		t.Errorf("detail should mention autoRedeploy, got %q", r.Detail)
+	}
+}
+
+func TestDiff_RolloutOmitsAutoRedeployNoteWhenEnabled(t *testing.T) {
+	secret := envSecret(map[string]string{"LOG_LEVEL": "info"}, nil)
+	c := newFakeClient(t, testProjectObj(true),
+		testAppObj(nil, nil), secret, deploymentWithEnvHash("0000000000000000"))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if strings.Contains(rep.Environments[0].Rollout.Detail, "autoRedeploy") {
+		t.Errorf("autoRedeploy=true should not carry the 'expected, not broken' note: %q",
+			rep.Environments[0].Rollout.Detail)
+	}
+}
+
+func TestDiff_RolloutReportsStatusHashes(t *testing.T) {
+	app := testAppObj(nil, nil)
+	app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{{
+		Name:            testEnv,
+		PendingEnvHash:  "aaaabbbbccccdddd",
+		DeployedEnvHash: "1111222233334444",
+	}}
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	r := rep.Environments[0].Rollout
+	if r.StatusPendingEnvHash != "aaaabbbbccccdddd" || r.StatusDeployedEnvHash != "1111222233334444" {
+		t.Errorf("status hashes not reported: %+v", r)
+	}
+}
+
+func TestDiff_RolloutReportsMissingWorkload(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false), testAppObj(nil, nil))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	r := rep.Environments[0].Rollout
+	if r.WorkloadFound {
+		t.Error("expected no workload")
+	}
+	if r.WorkloadKind != "Deployment" {
+		t.Errorf("workload kind: got %q, want Deployment", r.WorkloadKind)
+	}
+}
+
+func TestDiff_CronAppReadsCronJobEnvHash(t *testing.T) {
+	app := testAppObj(nil, nil)
+	app.Spec.Kind = mortisev1alpha1.AppKindCron
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: testApp, Namespace: testEnvNs},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{envHashAnnotation: "deadbeefdeadbeef"},
+						},
+					},
+				},
+			},
+		},
+	}
+	c := newFakeClient(t, testProjectObj(false), app, cj)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	r := rep.Environments[0].Rollout
+	if r.WorkloadKind != "CronJob" || !r.WorkloadFound {
+		t.Fatalf("expected a found CronJob, got %+v", r)
+	}
+	if r.WorkloadEnvHash != "deadbeefdeadbeef" {
+		t.Errorf("workload env hash: got %q", r.WorkloadEnvHash)
+	}
+}
+
+// --- the names-and-digests guarantee ---
+
+// TestDiff_NeverPrintsAValue is the load-bearing test for this command: the
+// output is meant to be safe to paste into a channel during an incident.
+func TestDiff_NeverPrintsAValue(t *testing.T) {
+	// Every value below is a distinctive sentinel that must not appear in any
+	// rendering of the report.
+	values := []string{
+		"sentinelLiteralValue1",
+		"sentinelSecretValue2",
+		"sentinelUserSetValue3",
+		"sentinelBindingValue4",
+		"sentinelSharedValue5",
+		"sentinelCredsValue6",
+		"sentinelFileValue7",
+	}
+
+	creds := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-creds", Namespace: testEnvNs},
+		Data:       map[string][]byte{"DB_PASSWORD": []byte("sentinelCredsValue6")},
+	}
+	app := testAppObj([]mortisev1alpha1.EnvVar{
+		{Name: "LOG_LEVEL", Value: "sentinelLiteralValue1"},
+		{Name: "DB_PASSWORD", ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "web-creds"}},
+	}, nil)
+	secret := envSecret(
+		map[string]string{
+			"LOG_LEVEL":   "sentinelSecretValue2",
+			"UI_SET":      "sentinelUserSetValue3",
+			"PGHOST":      "sentinelBindingValue4",
+			"SHARED_FLAG": "sentinelSharedValue5",
+		},
+		map[string]string{"PGHOST": "binding", "SHARED_FLAG": "shared"},
+	)
+
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(manifest, []byte(`apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      env:
+        - name: LOG_LEVEL
+          value: sentinelFileValue7
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newFakeClient(t, testProjectObj(false), app, creds, secret,
+		deploymentWithEnvHash("0000000000000000"))
+
+	for _, req := range []diffRequest{
+		{app: testApp, project: testProject},
+		{app: testApp, project: testProject, file: manifest},
+	} {
+		rep, err := runDiff(context.Background(), c, req)
+		if err != nil {
+			t.Fatalf("runDiff(%+v): %v", req, err)
+		}
+		for _, showAll := range []bool{false, true} {
+			for _, format := range []string{"text", "json"} {
+				var buf bytes.Buffer
+				if err := writeDiff(&buf, rep, format, showAll); err != nil {
+					t.Fatal(err)
+				}
+				out := buf.String()
+				for _, v := range values {
+					if strings.Contains(out, v) {
+						t.Errorf("format=%s all=%v file=%q leaked value %q:\n%s",
+							format, showAll, req.file, v, out)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestDiff_TextOutputCarriesNamesAndDigests(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	var buf bytes.Buffer
+	if err := writeDiff(&buf, rep, "text", false); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"LOG_LEVEL", digestValue("debug"), digestValue("info"), testEnvNs, testControlNs} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDiff_JSONOutputIsStructured(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil),
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	var buf bytes.Buffer
+	if err := writeDiff(&buf, rep, "json", false); err != nil {
+		t.Fatal(err)
+	}
+	var decoded diffReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if decoded.App != testApp || decoded.Project != testProject {
+		t.Errorf("unexpected header: %+v", decoded)
+	}
+	if len(decoded.Environments) != 1 || len(decoded.Environments[0].Findings) != 1 {
+		t.Fatalf("unexpected environments: %+v", decoded.Environments)
+	}
+	if decoded.Environments[0].Findings[0].Category != catSpecDiffers {
+		t.Errorf("category: %+v", decoded.Environments[0].Findings[0])
+	}
+}
+
+func TestDiff_UnknownOutputFormatIsRejected(t *testing.T) {
+	if err := writeDiff(&bytes.Buffer{}, &diffReport{}, "yaml", false); err == nil {
+		t.Fatal("expected an error for an unknown output format")
+	}
+}
+
+// --- operational errors ---
+
+func TestDiff_MissingAppIsAnError(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false))
+	_, err := runDiff(context.Background(), c, diffRequest{app: "nope", project: testProject})
+	if err == nil {
+		t.Fatal("expected an error for a missing app")
+	}
+	if !strings.Contains(err.Error(), testControlNs) {
+		t.Errorf("error should name the control namespace, got %v", err)
+	}
+}
+
+func TestDiff_MissingProjectIsAnError(t *testing.T) {
+	c := newFakeClient(t)
+	_, err := runDiff(context.Background(), c, diffRequest{app: testApp, project: "gone"})
+	if err == nil || !strings.Contains(err.Error(), "gone") {
+		t.Fatalf("expected a project-not-found error, got %v", err)
+	}
+}
+
+// runDiff takes a client.Reader, so it cannot write by construction. This
+// pins the observable half of that: nothing in the cluster changes.
+func TestDiff_DoesNotWriteToTheCluster(t *testing.T) {
+	app := testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}, nil)
+	secret := envSecret(map[string]string{"LOG_LEVEL": "info"}, nil)
+	c := newFakeClient(t, testProjectObj(false), app, secret, deploymentWithEnvHash("abc"))
+
+	before := resourceVersions(t, c)
+	runTestDiff(t, c, diffRequest{})
+	after := resourceVersions(t, c)
+
+	if len(before) != len(after) {
+		t.Fatalf("object count changed: %v -> %v", before, after)
+	}
+	for k, v := range before {
+		if after[k] != v {
+			t.Errorf("%s changed resourceVersion %s -> %s", k, v, after[k])
+		}
+	}
+}
+
+func resourceVersions(t *testing.T, c client.Client) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	ctx := context.Background()
+
+	var apps mortisev1alpha1.AppList
+	if err := c.List(ctx, &apps); err != nil {
+		t.Fatal(err)
+	}
+	for i := range apps.Items {
+		out["App/"+apps.Items[i].Namespace+"/"+apps.Items[i].Name] = apps.Items[i].ResourceVersion
+	}
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets); err != nil {
+		t.Fatal(err)
+	}
+	for i := range secrets.Items {
+		out["Secret/"+secrets.Items[i].Namespace+"/"+secrets.Items[i].Name] = secrets.Items[i].ResourceVersion
+	}
+	var deps appsv1.DeploymentList
+	if err := c.List(ctx, &deps); err != nil {
+		t.Fatal(err)
+	}
+	for i := range deps.Items {
+		out["Deployment/"+deps.Items[i].Namespace+"/"+deps.Items[i].Name] = deps.Items[i].ResourceVersion
+	}
+	return out
+}
+
+// --- environment selection ---
+
+func TestDiff_ReportsEveryProjectEnvironment(t *testing.T) {
+	proj := testProjectObj(false)
+	proj.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "production"}, {Name: "staging"}}
+	c := newFakeClient(t, proj, testAppObj(nil, nil))
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if len(rep.Environments) != 2 {
+		t.Fatalf("expected 2 environments, got %d: %+v", len(rep.Environments), rep.Environments)
+	}
+	if rep.Environments[1].WorkloadNamespace != "pj-myproj-staging" {
+		t.Errorf("workload namespace: got %q", rep.Environments[1].WorkloadNamespace)
+	}
+}
+
+func TestDiff_EnvFlagNarrowsToOneEnvironment(t *testing.T) {
+	proj := testProjectObj(false)
+	proj.Spec.Environments = []mortisev1alpha1.ProjectEnvironment{{Name: "production"}, {Name: "staging"}}
+	c := newFakeClient(t, proj, testAppObj(nil, nil))
+
+	rep := runTestDiff(t, c, diffRequest{env: "staging"})
+	if len(rep.Environments) != 1 || rep.Environments[0].Environment != "staging" {
+		t.Fatalf("expected only staging, got %+v", rep.Environments)
+	}
+}
+
+func TestDiff_OptedOutEnvironmentIsFlagged(t *testing.T) {
+	no := false
+	app := testAppObj(nil, nil)
+	app.Spec.Environments[0].Enabled = &no
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	if rep.Environments[0].Enabled {
+		t.Error("expected the environment to be flagged as opted out")
+	}
+}
+
+// --- dry run ---
+
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "app.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestDryRun_ReportsAddChangeRemove(t *testing.T) {
+	app := testAppObj([]mortisev1alpha1.EnvVar{
+		{Name: "KEEP", Value: "same"},
+		{Name: "CHANGED", Value: "old"},
+		{Name: "REMOVED", Value: "bye"},
+	}, nil)
+	c := newFakeClient(t, testProjectObj(false), app)
+
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      env:
+        - name: KEEP
+          value: same
+        - name: CHANGED
+          value: new
+        - name: ADDED
+          value: hello
+`)
+
+	rep := runTestDiff(t, c, diffRequest{file: manifest})
+	got := map[string]crdChange{}
+	for _, ch := range rep.CRDChanges {
+		got[ch.Name] = ch
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 changes, got %+v", rep.CRDChanges)
+	}
+	if got["ADDED"].Change != "add" || got["ADDED"].FileDigest != digestValue("hello") {
+		t.Errorf("ADDED: %+v", got["ADDED"])
+	}
+	if got["REMOVED"].Change != "remove" || got["REMOVED"].LiveDigest != digestValue("bye") {
+		t.Errorf("REMOVED: %+v", got["REMOVED"])
+	}
+	ch := got["CHANGED"]
+	if ch.Change != "change" || ch.LiveDigest != digestValue("old") || ch.FileDigest != digestValue("new") {
+		t.Errorf("CHANGED: %+v", ch)
+	}
+	if _, ok := got["KEEP"]; ok {
+		t.Error("an unchanged var must not be reported as a change")
+	}
+}
+
+// In dry-run mode the file's spec becomes layer 1, so the layer 1 -> 2
+// comparison answers "what would the pods disagree with after this apply".
+func TestDryRun_UsesTheFileSpecAsLayerOne(t *testing.T) {
+	app := testAppObj([]mortisev1alpha1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}}, nil)
+	c := newFakeClient(t, testProjectObj(false), app,
+		envSecret(map[string]string{"LOG_LEVEL": "info"}, nil))
+
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+  environments:
+    - name: production
+      env:
+        - name: LOG_LEVEL
+          value: debug
+`)
+
+	// Without the file the live spec matches the Secret exactly.
+	if f := findingFor(t, runTestDiff(t, c, diffRequest{}), "LOG_LEVEL"); f.Category != catInSync {
+		t.Fatalf("precondition: expected in-sync, got %q", f.Category)
+	}
+
+	rep := runTestDiff(t, c, diffRequest{file: manifest})
+	if f := findingFor(t, rep, "LOG_LEVEL"); f.Category != catSpecDiffers {
+		t.Errorf("category: got %q, want %q", f.Category, catSpecDiffers)
+	}
+	if rep.DryRunFile != manifest {
+		t.Errorf("report should record the manifest path, got %q", rep.DryRunFile)
+	}
+}
+
+func TestDryRun_RejectsAMismatchedAppName(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false), testAppObj(nil, nil))
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: other
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+`)
+	_, err := runDiff(context.Background(), c, diffRequest{app: testApp, project: testProject, file: manifest})
+	if err == nil || !strings.Contains(err.Error(), "other") {
+		t.Fatalf("expected a name mismatch error, got %v", err)
+	}
+}
+
+func TestDryRun_RejectsAMismatchedNamespace(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false), testAppObj(nil, nil))
+	manifest := writeManifest(t, `apiVersion: mortise.dev/v1alpha1
+kind: App
+metadata:
+  name: web
+  namespace: pj-someone-else
+spec:
+  source:
+    type: image
+    image: nginx:1.27
+`)
+	_, err := runDiff(context.Background(), c, diffRequest{app: testApp, project: testProject, file: manifest})
+	if err == nil || !strings.Contains(err.Error(), "pj-someone-else") {
+		t.Fatalf("expected a namespace mismatch error, got %v", err)
+	}
+}
+
+func TestDryRun_RejectsANonAppManifest(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false), testAppObj(nil, nil))
+	manifest := writeManifest(t, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+`)
+	_, err := runDiff(context.Background(), c, diffRequest{app: testApp, project: testProject, file: manifest})
+	if err == nil || !strings.Contains(err.Error(), "ConfigMap") {
+		t.Fatalf("expected a kind error, got %v", err)
+	}
+}
+
+func TestDryRun_MissingFileIsAnError(t *testing.T) {
+	c := newFakeClient(t, testProjectObj(false), testAppObj(nil, nil))
+	_, err := runDiff(context.Background(), c, diffRequest{
+		app: testApp, project: testProject, file: filepath.Join(t.TempDir(), "absent.yaml"),
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing manifest")
+	}
+}
+
+// --- wiring ---
+
+func TestDiffCmd_IsRegistered(t *testing.T) {
+	for _, c := range newRootCmd().Commands() {
+		if c.Name() == "diff" {
+			if !strings.HasPrefix(c.Use, "diff <app>") {
+				t.Errorf("unexpected use string: %q", c.Use)
+			}
+			return
+		}
+	}
+	t.Fatal("diff is not registered on the root command")
+}
+
+func TestDiffCmd_HasTheDocumentedFlags(t *testing.T) {
+	cmd := newDiffCmd()
+	for _, name := range []string{"project", "env", "output", "file", "all", "kubeconfig", "context"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag", name)
+		}
+	}
+}

--- a/cmd/cli/diff_test.go
+++ b/cmd/cli/diff_test.go
@@ -243,6 +243,43 @@ func TestDiff_UserOverrideIsNotTheAlarm(t *testing.T) {
 	}
 }
 
+// The false-positive state CAI-157 fixes: the Secret's entry for this name is
+// not a user override at all, it is owned by a binding — e.g. a `database`
+// app's binding resolver writing DATABASE_URL (internal/bindings/resolver.go)
+// collides with a spec.env literal of the same name. The controller rewrites
+// that entry from the binding on every reconcile, so the spec literal is
+// permanently dead, not merely superseded by a deliberate override.
+// internal/api/env.go refuses to let the API write a controller-owned key, so
+// this state could never have been produced "through the API/UI".
+func TestDiff_ControllerOwnedSourceShadowsSpecIsNotUserOverride(t *testing.T) {
+	c := newFakeClient(t,
+		testProjectObj(false),
+		testAppObj([]mortisev1alpha1.EnvVar{{Name: "DATABASE_URL", Value: "user-literal"}}, nil),
+		withLastSpecEnv(t,
+			envSecret(map[string]string{"DATABASE_URL": "bound-value"}, map[string]string{"DATABASE_URL": "binding"}),
+			map[string]string{"DATABASE_URL": "previously-applied-literal"}),
+	)
+
+	rep := runTestDiff(t, c, diffRequest{})
+	f := findingFor(t, rep, "DATABASE_URL")
+	if f.Category == catUserOverride {
+		t.Error("a controller-owned Secret entry must not be classified as a user override")
+	}
+	if f.Category != catSpecShadowed {
+		t.Errorf("category: got %q (%s), want %q", f.Category, f.Detail, catSpecShadowed)
+	}
+	if categoryRank(f.Category) >= categoryRank(catNotDeclaredInCRD) {
+		t.Errorf("a permanently-shadowed spec value must rank above the normal-by-design categories, got rank %d vs catNotDeclaredInCRD's %d",
+			categoryRank(f.Category), categoryRank(catNotDeclaredInCRD))
+	}
+	if strings.Contains(f.Detail, "API/UI") {
+		t.Errorf("detail must not claim this was set through the API/UI, got %q", f.Detail)
+	}
+	if !strings.Contains(f.Detail, "binding") {
+		t.Errorf("detail should name the owning source, got %q", f.Detail)
+	}
+}
+
 // With no annotation there is nothing in the cluster that separates an
 // unapplied spec change from an override, so the report says exactly that
 // instead of picking the scarier of the two.

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -33,6 +33,7 @@ Quickstart:
 	cmd.AddCommand(newPromoteCmd())
 	cmd.AddCommand(newLogsCmd())
 	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(newDiffCmd())
 	cmd.AddCommand(newDomainCmd())
 	cmd.AddCommand(newTokenCmd())
 	cmd.AddCommand(newEnvCmd())

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -3173,46 +3173,15 @@ func (r *AppReconciler) resolveCredential(ctx context.Context, namespace string,
 }
 
 // hashCredentialData produces a sha256 over the sorted key=value pairs.
-// Key sorting is load-bearing: Go maps randomise iteration order, and an
-// unstable hash would cause gratuitous pod restarts on every reconcile.
+// Shared with the `mortise diff` CLI, which must reproduce the pod-template
+// env-hash byte for byte to tell "pods are running an older env" from
+// "pods are current".
 func hashCredentialData(data map[string][]byte) string {
-	if len(data) == 0 {
-		return ""
-	}
-	keys := make([]string, 0, len(data))
-	for k := range data {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	h := sha256.New()
-	for _, k := range keys {
-		h.Write([]byte(k))
-		h.Write([]byte{'='})
-		h.Write(data[k])
-		h.Write([]byte{0})
-	}
-	return hex.EncodeToString(h.Sum(nil))
+	return envstore.HashData(data)
 }
 
 func hashEnvSecretData(ctx context.Context, reader client.Reader, appName, envNs string) string {
-	combined := make(map[string][]byte)
-
-	var appSecret corev1.Secret
-	if err := reader.Get(ctx, types.NamespacedName{Name: envstore.AppEnvSecretName(appName), Namespace: envNs}, &appSecret); err == nil {
-		for k, v := range appSecret.Data {
-			combined[k] = v
-		}
-	}
-
-	var sharedSecret corev1.Secret
-	if err := reader.Get(ctx, types.NamespacedName{Name: envstore.SharedEnvName, Namespace: envNs}, &sharedSecret); err == nil {
-		for k, v := range sharedSecret.Data {
-			combined[k] = v
-		}
-	}
-
-	return hashCredentialData(combined)
+	return envstore.EnvHash(ctx, reader, appName, envNs)
 }
 
 func (r *AppReconciler) hashEnvSecretData(ctx context.Context, appName, envNs string) string {

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -11,6 +11,8 @@ package envstore
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"regexp"
@@ -570,3 +572,50 @@ func secretDataEqual(existing, desired map[string][]byte) bool {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// HashData produces a sha256 over the sorted key=value pairs.
+// Key sorting is load-bearing: Go maps randomise iteration order, and an
+// unstable hash would cause gratuitous pod restarts on every reconcile.
+func HashData(data map[string][]byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{'='})
+		h.Write(data[k])
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// EnvHash is the hash the controller stamps onto the pod template as
+// `mortise.dev/env-hash`: a HashData over the merged contents of the app's
+// {app}-env Secret and the project's shared-env Secret in the workload
+// namespace. Missing Secrets contribute nothing. Read-only.
+func EnvHash(ctx context.Context, reader client.Reader, appName, envNs string) string {
+	combined := make(map[string][]byte)
+
+	var appSecret corev1.Secret
+	if err := reader.Get(ctx, types.NamespacedName{Name: AppEnvSecretName(appName), Namespace: envNs}, &appSecret); err == nil {
+		for k, v := range appSecret.Data {
+			combined[k] = v
+		}
+	}
+
+	var sharedSecret corev1.Secret
+	if err := reader.Get(ctx, types.NamespacedName{Name: SharedEnvName, Namespace: envNs}, &sharedSecret); err == nil {
+		for k, v := range sharedSecret.Data {
+			combined[k] = v
+		}
+	}
+
+	return HashData(combined)
+}

--- a/internal/envstore/envstore_test.go
+++ b/internal/envstore/envstore_test.go
@@ -425,3 +425,82 @@ func TestReplaceSourceSkipsEmptySecretDataNilVsEmptyChurn(t *testing.T) {
 		t.Fatalf("expected no update for logically empty secret data, got %d update calls", c.updateCalls)
 	}
 }
+
+func TestHashData(t *testing.T) {
+	t.Run("empty is empty", func(t *testing.T) {
+		if got := HashData(nil); got != "" {
+			t.Errorf("HashData(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("stable across map iteration order", func(t *testing.T) {
+		data := map[string][]byte{"A": []byte("1"), "B": []byte("2"), "C": []byte("3")}
+		first := HashData(data)
+		for i := 0; i < 20; i++ {
+			if got := HashData(data); got != first {
+				t.Fatalf("unstable hash: %q != %q", got, first)
+			}
+		}
+	})
+
+	t.Run("value change changes the hash", func(t *testing.T) {
+		a := HashData(map[string][]byte{"K": []byte("v1")})
+		b := HashData(map[string][]byte{"K": []byte("v2")})
+		if a == b {
+			t.Error("expected different hashes for different values")
+		}
+	})
+
+	t.Run("key boundaries are unambiguous", func(t *testing.T) {
+		a := HashData(map[string][]byte{"AB": []byte("C")})
+		b := HashData(map[string][]byte{"A": []byte("BC")})
+		if a == b {
+			t.Error("key/value boundary collision")
+		}
+	})
+}
+
+func TestEnvHash(t *testing.T) {
+	const ns = "pj-p-production"
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: AppEnvSecretName("web"), Namespace: ns},
+		Data:       map[string][]byte{"APP_KEY": []byte("a")},
+	}
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: SharedEnvName, Namespace: ns},
+		Data:       map[string][]byte{"SHARED_KEY": []byte("s")},
+	}
+
+	t.Run("no secrets hashes to empty", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		if got := EnvHash(context.Background(), c, "web", ns); got != "" {
+			t.Errorf("EnvHash = %q, want empty", got)
+		}
+	})
+
+	t.Run("covers both the app and shared secrets", func(t *testing.T) {
+		appOnly := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(appSecret.DeepCopy()).Build()
+		both := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(appSecret.DeepCopy(), sharedSecret.DeepCopy()).Build()
+
+		a := EnvHash(context.Background(), appOnly, "web", ns)
+		b := EnvHash(context.Background(), both, "web", ns)
+		if a == "" || b == "" {
+			t.Fatalf("unexpected empty hashes: %q %q", a, b)
+		}
+		if a == b {
+			t.Error("shared-env contents must contribute to the env hash")
+		}
+		want := HashData(map[string][]byte{"APP_KEY": []byte("a"), "SHARED_KEY": []byte("s")})
+		if b != want {
+			t.Errorf("EnvHash = %q, want %q", b, want)
+		}
+	})
+}


### PR DESCRIPTION
## What this does

`mortise diff <app>` reports where an App's environment configuration disagrees with itself. Per CAI-157: nearly every defect in this project is "the platform reports success and the workload disagrees", and a diff command is the general answer, because it makes the disagreement visible instead of requiring someone to suspect it.

```
app web  project myproj
values are never shown; each column is a 12-hex-char sha256 prefix

environment production   control ns pj-myproj   workload ns pj-myproj-production

  CRD and Secret disagree (1)
    NAME       SPEC          SECRET        SOURCE  NOTE
    LOG_LEVEL  0b8e9e995d8d  06271baf4953  user    the Secret is what pods mount, so the CRD value is not in effect

  declared in the CRD, missing from the Secret (1)
    NAME      SPEC          SECRET  SOURCE  NOTE
    NEW_FLAG  b8d31e852725  -       -       declared in the CRD but absent from the derived Secret; pods do not get this variable

  declared in the CRD, value not resolvable (1)
    NAME         SPEC  SECRET  SOURCE  NOTE
    DB_PASSWORD  -     -       -       valueFrom.secretRef "web-creds" in pj-myproj-production has no key "DB_PASSWORD"

  in the Secret, not declared in the CRD (normal: set via API/UI) (1)
    NAME        SPEC  SECRET        SOURCE  NOTE
    SENTRY_DSN  -     043a718774c5  user    set through the API/UI, which writes the Secret directly and never the CRD

  derived by the controller (expected) (2)
    NAME         SPEC  SECRET        SOURCE   NOTE
    PGHOST       -     aaa9402664f1  binding  written by the controller from this environment's bindings; not expected in spec.env
    SHARED_FLAG  -     252f10c83610  shared   written by the controller from shared variables; not expected in spec.env

  in sync (1) — use --all to list

  rollout
    current Secret env-hash           f6bf849939ae
    Deployment pod-template env-hash  000011112222
    App status pending/deployed       aaaa1111bbbb / cccc3333dddd
    pods are running an older environment; redeploy to apply the current one (Project.spec.autoRedeploy is false, so this is expected, not broken)
```

`-o json` emits the same report for scripting. Exit status is non-zero only on an operational failure (no cluster, no such project, no such app) — a drift finding is information, not a failure.

## The three layers

1. **The CRD spec** — `spec.environments[].env` on the App in `constants.ControlNamespace(project)`. Effective values are resolved the way `AppReconciler.resolveEnvVarValue` does: a literal `value`; `valueFrom.secretRef`, which is a *bare Secret name* whose key is the env var's own name, read from the **env** namespace; or `valueFrom.fromBinding`.
2. **The derived Secret** — `{app}-env` in `constants.EnvNamespace(project, env)`, which pods mount via `envFrom`. Decoded through `envstore.SecretToEnvs` so each entry keeps its source.
3. **The running workload** — the `mortise.dev/env-hash` on the Deployment's (or CronJob's) pod template, compared against a freshly computed hash of the current env Secrets. `status.environments[].pendingEnvHash` / `deployedEnvHash` are reported alongside.

Namespaces always go through `internal/constants`; the `pj-` prefix is never hardcoded.

### Categories, and what is *not* drift

- `spec-differs-from-secret` — declared in both, different values. The Secret wins, so the CRD value is not in effect.
- `missing-from-secret` — declared in the CRD, absent from the Secret. Pods do not get it at all.
- `unresolved` — declared, but the effective value could not be determined (missing `secretRef` Secret or key, `fromBinding` with no matching `bindings[]` entry, more than one source set). Reported, never guessed.
- `not-declared-in-crd` — in the Secret with source `user`, absent from `spec.env`. **`internal/api/env.go` is a co-equal writer**: it writes env vars straight into the derived Secret with source `user` and never touches the CRD, so this is *normal* for anything set through the UI. The wording says so, and a test asserts the note contains none of "error/invalid/wrong/drift".
- `derived` — Secret entries with source `binding`, `shared`, or `generated`. These legitimately exist without appearing in `spec.env`. Reporting them as drift is the mistake that sank an earlier attempt at this feature; there is a dedicated test.
- `in-sync` — collapsed to a count unless `--all`.

## The names-and-digests guarantee

**No variable value ever reaches the output.** Every value is reduced to a 12-hex-char SHA-256 prefix. `TestDiff_NeverPrintsAValue` builds a cluster where the literal spec value, the Secret value, a UI-set value, a binding value, a shared value, a referenced-Secret value, and a dry-run file value are all distinct sentinels, then renders the report in `text` and `json`, with and without `--all`, with and without `-f`, and asserts no sentinel appears in any of the eight renderings.

## kubectl-native, read-only

The existing CLI is an HTTP client against `/api/...`, and that API is unusable (CAI-55). `diff` does not touch it. It builds a controller-runtime client from `clientcmd.NewNonInteractiveDeferredLoadingClientConfig` (KUBECONFIG / `~/.kube/config`, with `--kubeconfig` and `--context` overrides), exactly as kubectl resolves. `runDiff` takes a `client.Reader`, so writing is impossible by construction; `TestDiff_DoesNotWriteToTheCluster` additionally pins that no object's resourceVersion moves.

## Shared hash

`hashCredentialData` / `hashEnvSecretData` moved into `envstore.HashData` / `envstore.EnvHash`; the controller now delegates to them. Layer 3 is only meaningful if the CLI reproduces the controller's stamp byte for byte, and two copies of a hash function would eventually disagree. Behaviour is unchanged — the existing `helpers_test.go` hash tests still pass — and `envstore` gained tests for stability across map iteration order, key/value boundary ambiguity, and shared-env participation.

## Tests I falsified

Each was broken in the production code, watched go red, then restored and watched go green.

| # | Break | Test | Failure |
|---|---|---|---|
| 1 | appended `e.Value` to the `not-declared-in-crd` note | `TestDiff_NeverPrintsAValue` | `format=text all=false file="" leaked value "sentinelUserSetValue3"` |
| 2 | made the `binding, shared, generated` source case unmatchable | `TestDiff_BindingAndSharedEntriesAreNotDrift` | `PGHOST: category got "not-declared-in-crd", want "derived"` (×3) |
| 3 | forced the rollout verdict to always be in-sync | `TestDiff_RolloutStaleWhenHashesDiffer` | `expected rollout out of sync`; `detail should say a redeploy is needed`; `detail should mention autoRedeploy` |
| 4 | let a missing `secretRef` key resolve to the empty value | `TestDiff_SecretRefMissingKeyIsUnresolved` | `category: got "missing-from-secret", want "unresolved"` |
| 5 | passed the live App instead of the `-f` App as layer 1 | `TestDryRun_UsesTheFileSpecAsLayerOne` | `category: got "in-sync", want "spec-differs-from-secret"` |
| 6 | compared presence only, never digests | `TestDiff_SpecDiffersFromSecret`, `TestDiff_TextOutputCarriesNamesAndDigests` | `category: got "in-sync", want "spec-differs-from-secret"`; `output missing "LOG_LEVEL"` |
| 7 | dropped the shared-env read from `EnvHash` | `TestEnvHash` | `shared-env contents must contribute to the env hash` |
| 8 | made the dry-run change branch unreachable | `TestDryRun_ReportsAddChangeRemove` | `expected 3 changes, got [ADDED/add, REMOVED/remove]` |
| 9 | reworded the `not-declared-in-crd` note as `error: …` | `TestDiff_SecretOnlyUserVarIsNotDeclaredInCRD` | `detail "error: …" implies the state is wrong (contains "error")` |
| 10 | returned an empty report instead of an error for a missing App | `TestDiff_MissingAppIsAnError` | `expected an error for a missing app` |

`TestDiff_DoesNotWriteToTheCluster` was **not** falsified by breaking production code: `runDiff` takes a `client.Reader`, so introducing a write would be a compile error rather than a red test. That is the stronger guarantee; the test pins the observable half.

`make test` passes (manifests, generate, fmt, vet, staticcheck, envtest, svelte-check).

## What I deliberately did not build

- **Bindings resolution.** `fromBinding` vars are not resolved; the diff reports presence and marks them `derived` with "value not compared", or `unresolved` when the `bindings[]` entry is missing. Reimplementing `bindings.Resolver` in the CLI would be a second copy of exactly the kind of logic this command exists to police.
- **`spec.sharedVars` as a fourth comparison.** App-level `spec.sharedVars` seed the derived Secret with source `shared`, so they land in `derived` today rather than being digest-compared against the spec. Straightforward to add later; out of scope here.
- **`-f` multi-document manifests.** `-f` reads exactly one App. A file whose first document is another kind is rejected by name rather than silently skipped.
- **`-f` shape-change detection.** The dry-run CRD comparison is on *effective value* digests. Rewriting `value: x` as a `secretRef` that resolves to the same bytes shows as no change.
- **Preview environments** get no special handling — they are ordinary project environments and are reported as such.

## Adjacent defect noticed, not fixed

`envstore.EnvHash` (formerly `hashEnvSecretData`, moved verbatim) merges `{app}-env` **then** `shared-env` into one map, so on a key present in both, shared-env's value wins the hash. `envstore.EnvFromSources` orders `envFrom` the other way — shared-env first, `{app}-env` second — so the container sees the **app** value. The hash therefore does not track the effective value for colliding keys: changing such a key in `{app}-env` leaves the hash unmoved and no rollout is triggered, even under `autoRedeploy: true`. That is exactly the "platform reports success, workload disagrees" shape this command exists to expose. Left alone deliberately — fixing it changes every existing pod-template hash and belongs in its own change.