### PR TITLE
docs: correct five comments that credit the removed admission webhook (CAI-161 follow-up)

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -378,8 +378,13 @@ type ProbeConfig struct {
 }
 
 type Environment struct {
-	// Name references a `ProjectEnvironment.Name` on the parent Project. The
-	// admission webhook rejects names not present on the parent Project.
+	// Name references a `ProjectEnvironment.Name` on the parent Project.
+	//
+	// A name not declared on the parent Project is SILENTLY IGNORED, not
+	// rejected: resolveEnvs walks the Project's environments and only picks up
+	// an override whose name matches one, so an override for an unknown
+	// environment is never read and the apply still succeeds. Check the name
+	// against the Project if an override appears to have no effect.
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
@@ -558,7 +563,8 @@ type AppSpec struct {
 	// the parent `Project.Spec.Environments`. Any App auto-exists in every
 	// project env; entries here only tune behavior for a specific env or opt
 	// out via `Enabled: false`. Names must match a `ProjectEnvironment.Name`
-	// on the parent Project (enforced by the admission webhook).
+	// on the parent Project; an entry naming anything else is silently
+	// ignored rather than rejected (see Environment.Name).
 	Environments []Environment `json:"environments,omitempty"`
 }
 

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -129,7 +129,8 @@ spec:
                   the parent `Project.Spec.Environments`. Any App auto-exists in every
                   project env; entries here only tune behavior for a specific env or opt
                   out via `Enabled: false`. Names must match a `ProjectEnvironment.Name`
-                  on the parent Project (enforced by the admission webhook).
+                  on the parent Project; an entry naming anything else is silently
+                  ignored rather than rejected (see Environment.Name).
                 items:
                   properties:
                     annotations:
@@ -326,8 +327,13 @@ spec:
                       type: object
                     name:
                       description: |-
-                        Name references a `ProjectEnvironment.Name` on the parent Project. The
-                        admission webhook rejects names not present on the parent Project.
+                        Name references a `ProjectEnvironment.Name` on the parent Project.
+
+                        A name not declared on the parent Project is SILENTLY IGNORED, not
+                        rejected: resolveEnvs walks the Project's environments and only picks up
+                        an override whose name matches one, so an override for an unknown
+                        environment is never read and the apply still succeeds. Check the name
+                        against the Project if an override appears to have no effect.
                       type: string
                     readinessProbe:
                       description: |-

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -129,7 +129,8 @@ spec:
                   the parent `Project.Spec.Environments`. Any App auto-exists in every
                   project env; entries here only tune behavior for a specific env or opt
                   out via `Enabled: false`. Names must match a `ProjectEnvironment.Name`
-                  on the parent Project (enforced by the admission webhook).
+                  on the parent Project; an entry naming anything else is silently
+                  ignored rather than rejected (see Environment.Name).
                 items:
                   properties:
                     annotations:
@@ -326,8 +327,13 @@ spec:
                       type: object
                     name:
                       description: |-
-                        Name references a `ProjectEnvironment.Name` on the parent Project. The
-                        admission webhook rejects names not present on the parent Project.
+                        Name references a `ProjectEnvironment.Name` on the parent Project.
+
+                        A name not declared on the parent Project is SILENTLY IGNORED, not
+                        rejected: resolveEnvs walks the Project's environments and only picks up
+                        an override whose name matches one, so an override for an unknown
+                        environment is never read and the apply still succeeds. Check the name
+                        against the Project if an override appears to have no effect.
                       type: string
                     readinessProbe:
                       description: |-

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1421,7 +1421,8 @@ definitions:
           the parent `Project.Spec.Environments`. Any App auto-exists in every
           project env; entries here only tune behavior for a specific env or opt
           out via `Enabled: false`. Names must match a `ProjectEnvironment.Name`
-          on the parent Project (enforced by the admission webhook).
+          on the parent Project; an entry naming anything else is silently
+          ignored rather than rejected (see Environment.Name).
         items:
           $ref: '#/definitions/v1alpha1.Environment'
         type: array
@@ -1936,8 +1937,13 @@ definitions:
         $ref: '#/definitions/v1alpha1.ProbeConfig'
       name:
         description: |-
-          Name references a `ProjectEnvironment.Name` on the parent Project. The
-          admission webhook rejects names not present on the parent Project.
+          Name references a `ProjectEnvironment.Name` on the parent Project.
+
+          A name not declared on the parent Project is SILENTLY IGNORED, not
+          rejected: resolveEnvs walks the Project's environments and only picks up
+          an override whose name matches one, so an override for an unknown
+          environment is never read and the apply still succeeds. Check the name
+          against the Project if an override appears to have no effect.
           +kubebuilder:validation:Required
         type: string
       readinessProbe:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1421,7 +1421,8 @@ definitions:
           the parent `Project.Spec.Environments`. Any App auto-exists in every
           project env; entries here only tune behavior for a specific env or opt
           out via `Enabled: false`. Names must match a `ProjectEnvironment.Name`
-          on the parent Project (enforced by the admission webhook).
+          on the parent Project; an entry naming anything else is silently
+          ignored rather than rejected (see Environment.Name).
         items:
           $ref: '#/definitions/v1alpha1.Environment'
         type: array
@@ -1936,8 +1937,13 @@ definitions:
         $ref: '#/definitions/v1alpha1.ProbeConfig'
       name:
         description: |-
-          Name references a `ProjectEnvironment.Name` on the parent Project. The
-          admission webhook rejects names not present on the parent Project.
+          Name references a `ProjectEnvironment.Name` on the parent Project.
+
+          A name not declared on the parent Project is SILENTLY IGNORED, not
+          rejected: resolveEnvs walks the Project's environments and only picks up
+          an override whose name matches one, so an override for an unknown
+          environment is never read and the apply still succeeds. Check the name
+          against the Project if an override appears to have no effect.
           +kubebuilder:validation:Required
         type: string
       readinessProbe:

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -229,9 +229,11 @@ func (s *Server) createProjectEnvironment(ctx context.Context, projectName strin
 }
 
 // UpdateProjectEnvironment edits the display order and/or renames an env.
-// Renaming cascades to App overrides in the project namespace so the
-// admission webhook's "override names must exist on project" rule stays
-// satisfied after the update lands.
+// Renaming cascades to App overrides in the project namespace so those
+// overrides keep matching a declared environment. An override whose name
+// matches nothing on the Project is silently ignored by the reconciler --
+// not rejected -- so failing to cascade would leave overrides that look
+// applied and do nothing.
 //
 // PATCH /api/projects/{project}/environments/{name}  { "name": "stage", "displayOrder": 2 }
 //
@@ -294,9 +296,11 @@ func (s *Server) UpdateProjectEnvironment(w http.ResponseWriter, r *http.Request
 			writeError(w, r, err)
 			return
 		}
-		// Rename App overrides first so the admission webhook doesn't reject
-		// the project update when its post-state includes an env name that
-		// disappeared from overrides.
+		// Rename App overrides first so no override is ever left pointing at
+		// an environment name the Project no longer declares. Such an
+		// override is silently ignored rather than rejected, so the window
+		// matters: an App reconciling mid-rename would drop it without a
+		// word.
 		if err := s.renameAppOverrides(r.Context(), projectName, projectNs(project), envName, *req.Name); err != nil {
 			_ = s.deleteProjectEnvNamespace(r.Context(), project, *req.Name)
 			writeError(w, r, err)
@@ -766,8 +770,9 @@ func indexOfEnv(project *mortisev1alpha1.Project, name string) int {
 
 // renameAppOverrides walks every App in the project namespace and rewrites
 // any spec.environments[].name == oldName to newName. Called before updating
-// the Project so the admission webhook's "overrides must exist on project"
-// invariant is preserved throughout the transition.
+// the Project so that no override is ever left naming an environment the
+// Project does not declare -- the reconciler ignores those silently, so the
+// invariant has to hold throughout the transition, not just at the end.
 func (s *Server) renameAppOverrides(ctx context.Context, projectName, ns, oldName, newName string) error {
 	var apps mortisev1alpha1.AppList
 	if err := s.client.List(ctx, &apps, client.InNamespace(ns)); err != nil {


### PR DESCRIPTION
Surfaced by the CAI-157 subagent while building the diff command. Removing the validators in #504 orphaned every comment that named them as the enforcer.

## Two in `api/v1alpha1/app_types.go`

They said the admission webhook *"rejects names not present on the parent Project"*.

It doesn't — and **it didn't before the removal either**, because the webhook was never deployed. What actually happens: `resolveEnvs` walks the **Project's** environments and only picks up an override whose name matches one. An override naming an unknown environment is never read. **Silently ignored, apply succeeds, nothing reports it.**

That's the third silent-drop in this area, and the one a user is most likely to hit by typo, so it's now documented as what it is rather than as a rejection that never happens.

## Three in `internal/api/project_envs.go`

They justified renaming App overrides before updating a Project with *"so the admission webhook doesn't reject the project update"*.

**The ordering is still right and still load-bearing** — but for a better reason than the one given: an override left naming an environment the Project no longer declares is silently ignored, so any gap in the transition drops it without a word. The comments now say that.

## Why this is worth a PR rather than a cleanup someday

A comment that credits a non-existent enforcer is worse than no comment: the next person reads "the webhook rejects this" and doesn't add the check that's actually missing. Two of these were wrong before #504 and became unambiguously wrong after it — the removal didn't create the error, it just removed the last excuse for it.

## Verification

No behaviour change; the rename-first ordering is untouched. `grep -rc "admission webhook"` is now 0 across `api/` and `internal/`. `make test` green, controller 77.0%, api 65.8%.