### PR TITLE
fix(test): make port-forward readiness prove the tunnel works (CAI-173)

### DIFF
--- a/test/helpers/mortise_api.go
+++ b/test/helpers/mortise_api.go
@@ -10,6 +10,31 @@ import (
 	"time"
 )
 
+// doWithRetry issues an HTTP request built by newReq, retrying on transport
+// errors (connection reset, EOF, etc.) a bounded number of times. PortForward
+// proves the tunnel serves a request before handing back its port, but
+// kubectl can still drop and re-establish the tunnel in the window right
+// after that, so a single reset on the very next request shouldn't be fatal.
+// newReq rebuilds the request each attempt since a request with a body can't
+// be replayed.
+func doWithRetry(client *http.Client, newReq func() (*http.Request, error)) (*http.Response, error) {
+	const attempts = 5
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		req, err := newReq()
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil, lastErr
+}
+
 // LoginAsAdmin returns a Mortise JWT for an admin principal identified by
 // (email, password), bootstrapping first-user setup if necessary. Idempotent
 // across test reruns: if setup has already been completed (409 from
@@ -30,10 +55,14 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 		"email":    email,
 		"password": password,
 	})
-	setupReq, _ := http.NewRequest(http.MethodPost, base+"/api/auth/setup",
-		bytes.NewReader(setupBody))
-	setupReq.Header.Set("Content-Type", "application/json")
-	setupResp, err := client.Do(setupReq)
+	setupResp, err := doWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest(http.MethodPost, base+"/api/auth/setup", bytes.NewReader(setupBody))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		t.Fatalf("mortise: POST /api/auth/setup: %v", err)
 	}
@@ -73,9 +102,14 @@ func LoginAsAdmin(t *testing.T, baseURL, email, password string) string {
 			"email":    c.email,
 			"password": c.password,
 		})
-		loginReq, _ := http.NewRequest(http.MethodPost, base+"/api/auth/login", bytes.NewReader(loginBody))
-		loginReq.Header.Set("Content-Type", "application/json")
-		loginResp, err := client.Do(loginReq)
+		loginResp, err := doWithRetry(client, func() (*http.Request, error) {
+			req, err := http.NewRequest(http.MethodPost, base+"/api/auth/login", bytes.NewReader(loginBody))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			return req, nil
+		})
 		if err != nil {
 			return "", 0, "", err
 		}

--- a/test/helpers/portforward.go
+++ b/test/helpers/portforward.go
@@ -3,7 +3,9 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os/exec"
 	"testing"
 	"time"
@@ -41,16 +43,10 @@ func PortForward(t *testing.T, namespace, service string, remotePort int) int {
 		t.Fatalf("portforward: kubectl start: %v", err)
 	}
 
-	// Wait until the local port is accepting connections.
+	// Wait until the tunnel actually proxies traffic to the pod, not just
+	// until kubectl has bound the local port.
 	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
-	RequireEventually(t, 30*time.Second, func() bool {
-		c, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
-		if err != nil {
-			return false
-		}
-		_ = c.Close()
-		return true
-	})
+	waitForTunnel(t, addr, 30*time.Second)
 
 	t.Cleanup(func() {
 		cancel()
@@ -58,6 +54,47 @@ func PortForward(t *testing.T, namespace, service string, remotePort int) int {
 	})
 
 	return localPort
+}
+
+// waitForTunnel blocks until addr answers a full HTTP round trip, or fails
+// the test once timeout elapses.
+//
+// kubectl port-forward binds and listens on the local port immediately, then
+// separately establishes the tunnel to the pod — the two are not atomic. A
+// bare TCP dial succeeds as soon as kubectl has bound the socket, which
+// proves kubectl is running but not that anything is reachable through the
+// tunnel: the very next read can come back "connection reset by peer" while
+// the tunnel is still coming up. Only a completed HTTP response proves the
+// path end to end, so probe with a real request instead of a dial.
+func waitForTunnel(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		err := probeTunnel(client, addr)
+		if err == nil {
+			return
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("portforward: tunnel to %s never served a request within %s: %v", addr, timeout, lastErr)
+}
+
+// probeTunnel issues a single HTTP request over addr and reports whether a
+// full response came back. The request path and status code don't matter —
+// even a 404 proves the tunnel round-trips — only whether the round trip
+// completed without a transport error.
+func probeTunnel(client *http.Client, addr string) error {
+	resp, err := client.Get("http://" + addr + "/")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	return err
 }
 
 func pickFreePort() (int, error) {

--- a/test/helpers/portforward_test.go
+++ b/test/helpers/portforward_test.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// startFlakyListener mimics what kubectl port-forward actually does: it binds
+// and accepts connections immediately, but for resetFor the tunnel to the pod
+// isn't up yet, so every connection gets a hard RST instead of a response.
+// After resetFor elapses it starts serving real (if minimal) HTTP responses.
+func startFlakyListener(t *testing.T, resetFor time.Duration) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	deadline := time.Now().Add(resetFor)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			if time.Now().Before(deadline) {
+				if tc, ok := conn.(*net.TCPConn); ok {
+					_ = tc.SetLinger(0) // force RST on close, like a dead tunnel
+				}
+				_ = conn.Close()
+				continue
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+				buf := make([]byte, 1024)
+				_, _ = c.Read(buf) // drain the request; content doesn't matter
+				_, _ = c.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+// TestWaitForTunnelSurvivesInitialResets reproduces the CAI-173 race: a
+// listener that behaves exactly like a not-yet-tunneling kubectl port-forward
+// (accepting connections but resetting them) for a fixed window, then
+// starting to actually serve. A correct readiness check must not return
+// until it has proxied a real request; a dial-only check returns as soon as
+// the TCP handshake completes, which happens during the reset window.
+func TestWaitForTunnelSurvivesInitialResets(t *testing.T) {
+	const resetWindow = 1 * time.Second
+	addr := startFlakyListener(t, resetWindow)
+
+	start := time.Now()
+	waitForTunnel(t, addr, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if elapsed < resetWindow {
+		t.Fatalf("waitForTunnel returned after %v, before the reset window (%v) elapsed — "+
+			"it accepted a dead tunnel as ready", elapsed, resetWindow)
+	}
+}


### PR DESCRIPTION
## What was broken (CAI-173)

Two compounding defects made the first HTTP request through every
`helpers.PortForward` tunnel an unguarded race:

1. `kubectl port-forward` binds and listens on the local port
   immediately, independent of and before establishing the actual
   tunnel to the pod. `PortForward`'s readiness check was a bare
   `net.DialTimeout`, which succeeds as soon as kubectl has bound the
   socket — proving kubectl is running, not that the tunnel proxies
   anything. `PortForward` could hand back a port whose tunnel wasn't
   actually up yet.
2. `LoginAsAdmin` then fired a single `client.Do` for `POST
   /api/auth/setup` and `t.Fatalf`'d on any transport error, with no
   retry — so a connection reset on that first request killed the test
   in ~0.01s, exactly what CI observed on `TestGitProviderAdminAPICRUD`.

## The fix

- `test/helpers/portforward.go`: `PortForward` now waits for a full
  HTTP round trip through the tunnel (`waitForTunnel` /
  `probeTunnel`) instead of a TCP dial. A connection reset is treated
  as not-ready and retried within a bounded 30s window; the failure
  message is explicit if that window expires. The readiness logic is
  extracted into a small function testable without spawning kubectl.
- `test/helpers/mortise_api.go`: `LoginAsAdmin`'s HTTP calls now go
  through a small `doWithRetry` helper that retries transport errors
  (connection reset, EOF, etc.) a bounded number of times, rebuilding
  the request each attempt. This is centralized in the helper so all 5
  files calling `LoginAsAdmin` benefit without touching call sites.
- `test/helpers/portforward_test.go` (new): reproduces the race with a
  local listener that mimics kubectl's actual behavior — it accepts
  TCP connections immediately but RSTs them for a fixed window before
  it starts serving real HTTP. No Kubernetes cluster needed.

## Fail-before / pass-after evidence

Ran the new test (`TestWaitForTunnelSurvivesInitialResets`) against
the old dial-only readiness check (temporarily restored), then against
the fix.

**Before (old `net.DialTimeout` check):**
```
=== RUN   TestWaitForTunnelSurvivesInitialResets
    portforward_test.go:64: waitForTunnel returned after 105.387µs, before the reset window (1s) elapsed — it accepted a dead tunnel as ready
--- FAIL: TestWaitForTunnelSurvivesInitialResets (0.00s)
FAIL
```

**After (new HTTP-round-trip check):**
```
=== RUN   TestWaitForTunnelSurvivesInitialResets
--- PASS: TestWaitForTunnelSurvivesInitialResets (1.00s)
PASS
```

## Verification

- `make test` — full pass (unit + envtest + staticcheck + go vet + UI check).
- `go vet ./...` — clean.
- Existing `mortise_api_test.go` `LoginAsAdmin` unit tests still pass unchanged.

## Left out of scope

- The external-dependency-at-setup-time flakes (Traefik chart fetched
  from `traefik.github.io`, registry image pulls during test setup)
  are not addressed here. Vendoring the Traefik chart and/or
  pre-pulling images touches the chart layout and k3d setup path in
  ways that would meaningfully broaden this diff, and I have no
  cluster available in this environment to validate an image-pull
  change. Leaving this for a separate, focused change.
- The 312s-then-fail `TestFromBindingProjectsNamedKey` signature is a
  separate, undiagnosed flake and is not touched or speculated about
  here.
- CAI-165 (promoting Integration to a required check) is out of scope.
