### PR TITLE
fix(controller): guard the app-global build failure write on preview envs (CAI-229)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -298,6 +298,10 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	for _, env := range resolvedEnvs {
 		projectionEnvOrder = append(projectionEnvOrder, env.Name)
 	}
+	// Same selection updateStatus aggregates on. Computed once here so the env
+	// loop can refuse to write an app-global build failure it would only have
+	// to repair a moment later (CAI-229).
+	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
 
 	for i := range resolvedEnvs {
 		env := &resolvedEnvs[i]
@@ -326,7 +330,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		var image string
 		if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && r.BuildClient != nil {
 			buildIdentity := resolveEnvBuildIdentity(&app, *env, previewBuildIdentities)
-			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, env.Name, buildIdentity.branch, buildIdentity.revision)
+			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, buildAggregationEnvNames, env.Name, buildIdentity.branch, buildIdentity.revision)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile buildrun for env %s: %w", env.Name, err)
 			}
@@ -991,8 +995,17 @@ func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Envir
 // shouldClearNoCache is true when this env consumed a pending rebuild request;
 // the caller clears the rebuild markers once after the env loop, so a mid-loop
 // error return leaves them in place and the rebuild stays pending.
-func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
+// buildAggregationEnvNames is the set of envs allowed to write the app-global
+// BuildSucceeded condition; envs outside it still get their per-env BuildRun
+// status projected, they just don't speak for the whole App.
+func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, buildAggregationEnvNames map[string]struct{}, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
+
+	// A preview env's build failure must never reach the app-global condition.
+	// updateStatus repairs such a write later in the same pass, so writing it
+	// here only makes the App oscillate False -> True on every reconcile, and
+	// every reader in between sees the preview's raw build error (CAI-229).
+	_, aggregatesBuildFailure := buildAggregationEnvNames[envName]
 
 	branch = firstNonEmpty(branch, app.Spec.Source.Branch)
 	revision = firstNonEmpty(revision, app.Annotations["mortise.dev/revision"])
@@ -1034,8 +1047,10 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
 					return current.Status.Image, false, true, false, nil
 				case mortisev1alpha1.BuildRunPhaseFailed:
-					if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
-						return "", false, false, false, err
+					if aggregatesBuildFailure {
+						if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
+							return "", false, false, false, err
+						}
 					}
 					return "", false, true, false, nil
 				default:
@@ -1074,8 +1089,10 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
 		return run.Status.Image, false, true, consumedRebuild, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
-		if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
-			return "", false, false, false, err
+		if aggregatesBuildFailure {
+			if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
+				return "", false, false, false, err
+			}
 		}
 		return "", false, true, consumedRebuild, nil
 	default:

--- a/internal/controller/app_preview_build_failure_test.go
+++ b/internal/controller/app_preview_build_failure_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// The preview exclusion in updateStatus is a repair, not a guard: it can only
+// ever undo an app-global BuildSucceeded=False that the env loop already
+// persisted. Asserting on the App after Reconcile therefore proves nothing —
+// the repair has run by then. This spec records every status write that
+// reaches the API server during a single Reconcile, so the transient False
+// that readers (API, UI) can observe mid-pass is visible to the test.
+var _ = Describe("App Controller — preview build failure isolation", func() {
+	const namespace = "pj-default-project"
+	const previewEnv = "pr-6"
+	const revision = "same-sha"
+
+	AfterEach(func() {
+		purgeAllAppsIn(context.Background(), namespace)
+	})
+
+	It("never writes an app-global BuildSucceeded=False when only a preview env's build failed", func() {
+		ctx := context.Background()
+
+		var proj mortisev1alpha1.Project
+		Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{Name: "default-project"}, &proj)).To(Succeed())
+		originalEnvs := proj.Spec.Environments
+		proj.Spec.Environments = append(append([]mortisev1alpha1.ProjectEnvironment{}, originalEnvs...),
+			mortisev1alpha1.ProjectEnvironment{Name: previewEnv, DisplayOrder: 9, Preview: true})
+		Expect(k8sClient.Update(ctx, &proj)).To(Succeed())
+		ensureNamespace(ctx, namespace+"-"+previewEnv)
+		defer func() {
+			var restore mortisev1alpha1.Project
+			Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{Name: "default-project"}, &restore)).To(Succeed())
+			restore.Spec.Environments = originalEnvs
+			Expect(k8sClient.Update(ctx, &restore)).To(Succeed())
+		}()
+
+		app := makeGitSourceApp("preview-build-fail", namespace, "gh-preview")
+		app.Annotations["mortise.dev/revision"] = revision
+		Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		key := types.NamespacedName{Name: app.Name, Namespace: namespace}
+
+		rb := &fakeRegistryBackend{}
+		prodTarget, err := rb.PushTarget(app.Name, envImageTag(revision, "production"))
+		Expect(err).NotTo(HaveOccurred())
+		previewTarget, err := rb.PushTarget(app.Name, envImageTag(revision, previewEnv))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Both BuildRuns are seeded terminal so the env loop takes its
+		// already-built short-circuit and no build is actually launched.
+		prodRun := &mortisev1alpha1.BuildRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "preview-build-fail-production-run", Namespace: namespace},
+			Spec:       appBuildRunSpec(app, "production", "main", revision, prodTarget.Full, prodTarget.Full),
+		}
+		Expect(k8sClient.Create(ctx, prodRun)).To(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, prodRun)).To(Succeed()) }()
+		prodRun.Status = mortisev1alpha1.BuildRunStatus{
+			Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+			Image: prodTarget.Full,
+		}
+		Expect(k8sClient.Status().Update(ctx, prodRun)).To(Succeed())
+
+		previewRun := &mortisev1alpha1.BuildRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "preview-build-fail-preview-run", Namespace: namespace},
+			Spec:       appBuildRunSpec(app, previewEnv, "main", revision, previewTarget.Full, previewTarget.Full),
+		}
+		Expect(k8sClient.Create(ctx, previewRun)).To(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, previewRun)).To(Succeed()) }()
+		previewRun.Status = mortisev1alpha1.BuildRunStatus{
+			Phase:          mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason:  "BuildFailed",
+			FailureMessage: "invalid reference format",
+		}
+		Expect(k8sClient.Status().Update(ctx, previewRun)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+		app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{
+			{
+				Name:           "production",
+				LastBuiltSHA:   revision,
+				LastBuiltImage: prodTarget.Full,
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  prodRun.Name,
+					Phase: mortisev1alpha1.BuildRunPhaseSucceeded,
+				},
+			},
+			{
+				Name: previewEnv,
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  previewRun.Name,
+					Phase: mortisev1alpha1.BuildRunPhaseFailed,
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+		var written []metav1.Condition
+		base, err := ctrlclient.NewWithWatch(cfg, ctrlclient.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+		recording := interceptor.NewClient(base, interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c ctrlclient.Client, subResourceName string, obj ctrlclient.Object, opts ...ctrlclient.SubResourceUpdateOption) error {
+				if a, ok := obj.(*mortisev1alpha1.App); ok {
+					if cond := meta.FindStatusCondition(a.Status.Conditions, "BuildSucceeded"); cond != nil {
+						written = append(written, *cond)
+					}
+				}
+				return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		})
+
+		// GitClient nil makes prepareGitSource a no-op, so the spec exercises
+		// the env loop without standing up a GitProvider and token secret.
+		r := &AppReconciler{
+			Client:          recording,
+			Scheme:          scheme.Scheme,
+			BuildClient:     &fakeBuildClient{},
+			RegistryBackend: rb,
+			Builds:          &BuildTrackerStore{},
+		}
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, cond := range written {
+			Expect(cond.Status).NotTo(Equal(metav1.ConditionFalse),
+				"env loop persisted a preview-only build failure to the app-global condition: reason=%s message=%s",
+				cond.Reason, cond.Message)
+		}
+
+		// The per-env result must still be recorded — the guard suppresses the
+		// app-global write, not the projection.
+		Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+		es := envStatusFor(app, previewEnv)
+		Expect(es).NotTo(BeNil())
+		Expect(es.CurrentBuildRunRef).NotTo(BeNil())
+		Expect(es.CurrentBuildRunRef.Phase).To(Equal(mortisev1alpha1.BuildRunPhaseFailed))
+	})
+})

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -18,6 +18,18 @@ import (
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 )
 
+// envAggregationSet builds the build-failure aggregation set these tests pass
+// to reconcileEnvBuild. Every env named here may write the app-global
+// BuildSucceeded condition — the shape buildFailureAggregationEnvNames returns
+// for an app with no preview envs, and for a preview-only app.
+func envAggregationSet(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
 // ensureAppBuildRun must NOT clear the rebuild markers itself: the env loop
 // shares one *App, so a mid-loop clear starves envs after the first (GH #436).
 // Markers are cleared once by the app controller after the env loop.
@@ -552,7 +564,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, envAggregationSet("production"), "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -645,7 +657,7 @@ func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, envAggregationSet("production"), "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -734,7 +746,7 @@ func TestReconcileEnvBuildRebuildRequestReachesEveryEnv(t *testing.T) {
 	}
 
 	for _, env := range envs {
-		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, env, "main", "same-sha")
+		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, envAggregationSet(envs...), env, "main", "same-sha")
 		if err != nil {
 			t.Fatalf("reconcileEnvBuild %s: %v", env, err)
 		}
@@ -818,7 +830,7 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, "pr-6", "feature/preview-fail", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, envAggregationSet("pr-6"), "pr-6", "feature/preview-fail", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -895,7 +907,7 @@ func TestReconcileEnvBuildDoesNotReuseAnotherEnvsCurrentRun(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, "staging", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, envAggregationSet("production", "staging"), "staging", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -977,7 +989,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, envAggregationSet("production"), "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}


### PR DESCRIPTION
Fixes CAI-229.

## The defect

The preview-environment exclusion for build failures was implemented as an **after-the-fact repair, not a guard on the write**.

Per reconcile pass, for an App with a non-preview env plus a failed preview env `pr-N`:

1. The env loop reaches `pr-N`, finds its BuildRun in phase `Failed`, and calls `setBuildFailureCondition` — an **app-global** condition write with no preview awareness (two call sites in `reconcileEnvBuild`; `envName` was in scope at both and simply not consulted).
2. That persists `BuildSucceeded=False / BuildFailed / <raw BuildKit error>` to the API server.
3. `updateStatus` later runs the preview-exclusion logic and **repairs** it back to `True`, keyed off `buildFailureAggregationEnvNames`.

So the App's top-level `BuildSucceeded` oscillated False → True on every reconcile while a failed preview BuildRun existed, and in the window between (2) and (3) the object genuinely carried the preview's failure — visible to the API, the UI, or any test that read it.

## The fix

`buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)` — the same selection `updateStatus` already aggregates on — is computed once in `Reconcile` before the env loop and threaded into `reconcileEnvBuild`. Both `BuildRunPhaseFailed` branches call `setBuildFailureCondition` only when the current env is in that set.

Deliberately unchanged:

- `projectAppBuildRunStatus` still runs for the env either way, so `es.CurrentBuildRunRef` still records the per-env result and nothing downstream loses information. The new spec asserts this.
- **The repair branch in `updateStatus` is kept.** It heals Apps that already carry a latched condition from before this change; it is not dead code.
- Preview-only Apps still latch the failure — `buildFailureAggregationEnvNames` falls back to all envs when no non-preview env exists, and the existing test covering that case passes unmodified.

## Behavioural consequence, accepted deliberately

`prepareGitSource`'s "don't retry the same failed build" latch keys on the app-global condition. With this fix, a preview-only build failure no longer suppresses the parent App's git preflight. That is the correct semantic — a preview PR's broken Dockerfile should not stop the parent App from resolving credentials — and it does not cause a rebuild storm:

- `reconcileEnvBuild`'s already-built short-circuit returns the existing `Failed` BuildRun by `CurrentBuildRunRef` name before `ensureAppBuildRun` is ever reached.
- `ensureAppBuildRun` itself derives a deterministic name from `(app, env, revision, inputHash, requestID)` and `Get`s it before creating, so an unchanged revision resolves to the same failed BuildRun rather than a new one.
- `prepareGitSource` does not clone. It resolves the git token and calls `ensureWebhook`, which short-circuits on a registration input hash stored in the `WebhookConfigured` condition — no git API traffic in steady state.

## Tests

Every existing preview unit test calls `r.updateStatus(...)` directly, so they exercise only the repair, never the write that precedes it — none of them could catch this.

`internal/controller/app_preview_build_failure_test.go` adds an envtest spec that drives a full `Reconcile` for an App with `production` (build succeeded) plus a preview env `pr-6` (BuildRun `Failed`), through a client that records every status write reaching the API server, and asserts that none of them sets `BuildSucceeded=False`.

Against the unfixed code:

```
[FAILED] env loop persisted a preview-only build failure to the app-global condition: reason=BuildFailed message=invalid reference format
Expected
    <v1.ConditionStatus>: False
not to equal
    <v1.ConditionStatus>: False
```

After the fix: `Ran 1 of 222 Specs` / `SUCCESS! -- 1 Passed | 0 Failed`.

No existing assertion was weakened or edited. The five existing `reconcileEnvBuild` call sites in `buildrun_support_test.go` gained the new argument (setup only, via a small `envAggregationSet` helper) — every env each of those tests exercises remains in the aggregation set, which is what `buildFailureAggregationEnvNames` returns for an app with no preview envs and for a preview-only app.

`make test` and `go vet ./...` are green; controller package coverage 76.8% → 77.1%.

## Out of scope

The integration test's TOCTOU in `preview_webhook_test.go`, and the suspected self-sustaining reconcile loop (no `GenerationChangedPredicate` on `For(&App{})`) — both left untouched.
