### PR TITLE
fix(controller): keep preview build failures off the parent App (CAI-229)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -246,6 +246,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		resolvedEnvs = resolveEnvs(project, &app)
 		previewEnvNames = resolvedPreviewEnvNames(project, resolvedEnvs)
 	}
+	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
 	if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && len(previewEnvNames) > 0 {
 		previewBuildIdentities, err = r.previewBuildIdentitiesByEnv(ctx, &app, previewEnvNames)
 		if err != nil {
@@ -326,7 +327,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		var image string
 		if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && r.BuildClient != nil {
 			buildIdentity := resolveEnvBuildIdentity(&app, *env, previewBuildIdentities)
-			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, env.Name, buildIdentity.branch, buildIdentity.revision)
+			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, buildAggregationEnvNames, env.Name, buildIdentity.branch, buildIdentity.revision)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile buildrun for env %s: %w", env.Name, err)
 			}
@@ -984,6 +985,16 @@ func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Envir
 	return identity
 }
 
+// envCountsTowardAppBuildFailure reports whether envName's build failure may be
+// written to the App's top-level BuildSucceeded condition.
+func envCountsTowardAppBuildFailure(buildAggregationEnvNames map[string]struct{}, envName string) bool {
+	if len(buildAggregationEnvNames) == 0 {
+		return true
+	}
+	_, ok := buildAggregationEnvNames[envName]
+	return ok
+}
+
 // reconcileEnvBuild handles per-environment builds for git-source apps. Returns
 // the image to use for this env's deployment, or "" if a build is still in
 // flight (caller should skip deployment and requeue). statusDirty is true when
@@ -991,7 +1002,13 @@ func resolveEnvBuildIdentity(app *mortisev1alpha1.App, env mortisev1alpha1.Envir
 // shouldClearNoCache is true when this env consumed a pending rebuild request;
 // the caller clears the rebuild markers once after the env loop, so a mid-loop
 // error return leaves them in place and the rebuild stays pending.
-func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
+//
+// buildAggregationEnvNames is the set of envs whose build failures may reach the
+// App's top-level BuildSucceeded condition. An env outside it (a preview) records
+// its failure in env status only: writing it app-wide would both misattribute the
+// failure to production and trip the terminal-failure short-circuit that halts
+// every subsequent build until a manual rebuild. A nil set means every env counts.
+func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, buildAggregationEnvNames map[string]struct{}, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
 
 	branch = firstNonEmpty(branch, app.Spec.Source.Branch)
@@ -1034,8 +1051,10 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
 					return current.Status.Image, false, true, false, nil
 				case mortisev1alpha1.BuildRunPhaseFailed:
-					if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
-						return "", false, false, false, err
+					if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
+						if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(current.Status.FailureReason, "BuildFailed"), current.Status.FailureMessage); err != nil {
+							return "", false, false, false, err
+						}
 					}
 					return "", false, true, false, nil
 				default:
@@ -1074,8 +1093,10 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
 		return run.Status.Image, false, true, consumedRebuild, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
-		if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
-			return "", false, false, false, err
+		if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
+			if err := r.setBuildFailureCondition(ctx, app, firstNonEmpty(run.Status.FailureReason, "BuildFailed"), run.Status.FailureMessage); err != nil {
+				return "", false, false, false, err
+			}
 		}
 		return "", false, true, consumedRebuild, nil
 	default:

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -552,7 +552,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -645,7 +645,7 @@ func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -734,7 +734,7 @@ func TestReconcileEnvBuildRebuildRequestReachesEveryEnv(t *testing.T) {
 	}
 
 	for _, env := range envs {
-		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, env, "main", "same-sha")
+		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, nil, env, "main", "same-sha")
 		if err != nil {
 			t.Fatalf("reconcileEnvBuild %s: %v", env, err)
 		}
@@ -818,7 +818,7 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, "pr-6", "feature/preview-fail", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, nil, "pr-6", "feature/preview-fail", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestReconcileEnvBuildDoesNotReuseAnotherEnvsCurrentRun(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, "staging", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, nil, "staging", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -1136,5 +1136,97 @@ func TestPersistBuildRunLogKeepsLegacyAppConfigMap(t *testing.T) {
 	}
 	if legacy.OwnerReferences[0].Kind != "App" || legacy.OwnerReferences[0].Name != app.Name {
 		t.Fatalf("expected legacy log owner App/%s, got %+v", app.Name, legacy.OwnerReferences)
+	}
+}
+
+// TestReconcileEnvBuildKeepsPreviewFailureOffTopLevelApp is the CAI-229
+// reproduction: a preview env's build failure must stay in that env's status and
+// never reach the App's top-level BuildSucceeded condition. Before the fix the
+// condition was written for every env and only compensated for later in
+// updateStatus, so an interleaving where the clear had not yet run left the
+// parent App reporting a failure for a branch it does not deploy — and tripped
+// the terminal-failure short-circuit that halts all subsequent builds.
+func TestReconcileEnvBuildKeepsPreviewFailureOffTopLevelApp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mortisev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	app := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "pj-default-project",
+			Annotations: map[string]string{
+				"mortise.dev/revision": "same-sha",
+			},
+		},
+		Spec: mortisev1alpha1.AppSpec{
+			Source: mortisev1alpha1.AppSource{
+				Type:   mortisev1alpha1.SourceTypeGit,
+				Branch: "main",
+			},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Environments: []mortisev1alpha1.EnvironmentStatus{{
+				Name: "pr-6",
+				CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{
+					Name:  "preview-run",
+					Phase: mortisev1alpha1.BuildRunPhaseFailed,
+				},
+			}},
+			CurrentBuildRunName: "preview-run",
+		},
+	}
+	run := &mortisev1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-run",
+			Namespace: app.Namespace,
+		},
+		Spec: appBuildRunSpec(app, "pr-6", "feature/preview-fail", "same-sha", "registry.example.com/mortise/demo:same-sh-pr-6", "registry.example.com/mortise/demo:same-sh-pr-6"),
+		Status: mortisev1alpha1.BuildRunStatus{
+			Phase:          mortisev1alpha1.BuildRunPhaseFailed,
+			FailureReason:  "BuildFailed",
+			FailureMessage: `failed to solve: failed to parse stage name "invalid@@image": invalid reference format`,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app, run).WithStatusSubresource(app).Build()
+	r := &AppReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		RegistryBackend: &fakeRegistryBackend{},
+	}
+
+	// production is the only env that may speak for the App; pr-6 is a preview.
+	aggregation := map[string]struct{}{"production": {}}
+
+	image, _, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "pr-6"}, aggregation, "pr-6", "feature/preview-fail", "same-sha")
+	if err != nil {
+		t.Fatalf("reconcileEnvBuild: %v", err)
+	}
+	if image != "" {
+		t.Fatalf("expected no image on failed preview build, got %q", image)
+	}
+	if !statusDirty {
+		t.Fatal("expected failed preview buildrun projection to dirty status")
+	}
+
+	// The preview's own status must still record the failure.
+	es := envStatusFor(app, "pr-6")
+	if es == nil || es.CurrentBuildRunRef == nil || es.CurrentBuildRunRef.Phase != mortisev1alpha1.BuildRunPhaseFailed {
+		t.Fatalf("expected preview env status to record the failed buildrun, got %+v", es)
+	}
+
+	// The App must not.
+	if cond := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded"); cond != nil && cond.Status == metav1.ConditionFalse {
+		t.Fatalf("preview build failure reached the top-level App condition: reason=%q message=%q", cond.Reason, cond.Message)
+	}
+
+	var persisted mortisev1alpha1.App
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: app.Namespace, Name: app.Name}, &persisted); err != nil {
+		t.Fatalf("get persisted app: %v", err)
+	}
+	if cond := meta.FindStatusCondition(persisted.Status.Conditions, "BuildSucceeded"); cond != nil && cond.Status == metav1.ConditionFalse {
+		t.Fatalf("preview build failure persisted onto the App: reason=%q message=%q", cond.Reason, cond.Message)
 	}
 }


### PR DESCRIPTION
## The defect

A preview environment's BuildRun failure was written straight onto the App's **top-level** `BuildSucceeded` condition. `reconcileEnvBuild` knew which env it was building, but `setBuildFailureCondition` wrote app-wide regardless.

The preview exclusion did exist — but only as a *compensating clear* later in `updateStatus` (`buildFailureOutsideAggregation`). That clear depends on the preview's failure already being recorded in env status. Any interleaving where it had not yet run left the parent App reporting:

```
BuildSucceeded=False  Reason=BuildFailed
Message: failed to solve: failed to parse stage name "invalid@@image": invalid reference format
```

A production app showing a build failure for a Dockerfile nobody wrote, on a branch that is not deployed. That is CAI-150's defect class inverted: the platform reporting a failure that is not the user's.

## It is not only cosmetic

`prepareGitSource` short-circuits on a terminal `BuildSucceeded=False` (`app_controller.go:846`):

```go
if !hasPendingRebuildRequest(app) && isTerminalBuildFailureCondition(...) {
    return ctrl.Result{}, true, nil
}
```

So a preview failure landing app-wide **halts every subsequent build for that App** until someone requests a manual rebuild. That consequence was not in the original report; it surfaced while tracing the write path.

## The fix

Pass the build-failure aggregation env set (the existing `buildFailureAggregationEnvNames`, already computed for `updateStatus`) into `reconcileEnvBuild`, and write the app-wide condition only for an env inside it.

This removes the failure class rather than compensating for it: the wrong write never happens, so there is no race for the clear to lose. The preview's own env status still records the failure via `projectAppBuildRunStatus` — nothing is lost, the failure just stops speaking for the whole App.

A nil set means every env counts, preserving behaviour for callers with no project-derived preview information.

## Test

`TestReconcileEnvBuildKeepsPreviewFailureOffTopLevelApp` — asserts the preview env status still records the failure, and that neither the in-memory nor the persisted App carries it.

Verified fails-before by landing the guard inert first:

```
--- FAIL: TestReconcileEnvBuildKeepsPreviewFailureOffTopLevelApp
    preview build failure reached the top-level App condition:
    reason="BuildFailed" message="failed to solve: failed to parse stage name \"invalid@@image\": invalid reference format"
```

Passes after. Full `make test` (unit + envtest) green; `gofmt`/`go vet` clean.

## What this does not claim

The integration test `TestPreviewBuildFailureViaWebhookDoesNotDegradeTopLevelApp` is intermittent (CAI-173), so a single green run of it would not be evidence either way. I have not run it. The unit test is the durable proof that the controller no longer makes the wrong write; CAI-229's acceptance asked whether the cause was controller or test sequencing, and the answer is **controller**.

Closes CAI-229.