### PR TITLE
fix(controller): write the env Secret before the build, not after (CAI-245)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -320,6 +320,14 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if err != nil {
 			return r.envResourceError(ctx, &app, envNs, env.Name, "reconcile credentials secret", err)
 		}
+		// Before the build, deliberately. Config and credentials do not depend
+		// on the image, and the build paths below `continue` out of this loop
+		// while a build is in flight — so writing the env Secret after them
+		// made propagation wait for the build to finish, bounded by build
+		// duration rather than by the requeue interval (CAI-245).
+		if err := r.reconcileEnvSecret(ctx, &app, env, envNs); err != nil {
+			return r.envResourceError(ctx, &app, envNs, env.Name, "reconcile env secret", err)
+		}
 
 		autoRedeploy := project != nil && project.Spec.AutoRedeploy
 
@@ -1654,13 +1662,9 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		replicas = *env.Replicas
 	}
 
-	// Reconcile the {app}-env Secret — merges bindings, shared vars, and
-	// user-set env vars into a single Secret mounted via envFrom. This
-	// replaces the old pattern of baking env var literals onto the
-	// Deployment container spec.
-	if err := r.reconcileEnvSecret(ctx, app, env, envNs); err != nil {
-		return fmt.Errorf("reconcile env secret: %w", err)
-	}
+	// The {app}-env Secret — bindings, shared vars, and user-set env vars
+	// merged into a single Secret mounted via envFrom — is written by the
+	// caller before the build, so it is already current here.
 	envHash := r.hashEnvSecretData(ctx, app.Name, envNs)
 
 	// PORT is injected directly (not via Secret) because it's a Mortise
@@ -1942,10 +1946,7 @@ func deploymentSelectorMismatch(existing, desired *appsv1.Deployment) bool {
 func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, image, credentialsHash string, autoRedeploy bool) error {
 	name := cronJobName(app.Name)
 
-	// Reconcile env Secret — same as Deployment path.
-	if err := r.reconcileEnvSecret(ctx, app, env, envNs); err != nil {
-		return fmt.Errorf("reconcile env secret: %w", err)
-	}
+	// Env Secret written by the caller before the build — same as Deployment path.
 	envHash := r.hashEnvSecretData(ctx, app.Name, envNs)
 
 	containers := []corev1.Container{

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -5396,6 +5396,80 @@ var _ = Describe("App Controller — git source", func() {
 		})
 	})
 
+	Context("in-flight build and env propagation (CAI-245)", func() {
+		// A build in flight must not block config propagation. The derived
+		// <app>-env Secret is written by reconcileEnvSecret, which is only
+		// reachable from reconcileDeployment/reconcileCronJob -- both of which
+		// sit AFTER the env loop's build `continue`s. So while a build is
+		// running, a changed env value (or a rotated credential) never reaches
+		// the derived Secret, and the delay is bounded by build duration rather
+		// than by the 15s poll interval. A hung build blocks it indefinitely
+		// while the App, the spec and the referenced Secret all read correct.
+		It("refreshes the derived env Secret while a build is still in flight", func() {
+			ctx := context.Background()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-inflight"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type:     mortisev1alpha1.GitProviderTypeGitHub,
+					Host:     "https://github.com",
+					ClientID: "test-client-id",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mortise-system"}})
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-gh-inflight-token-74657374406578616d706c652e636f6d", Namespace: "mortise-system"},
+				Data:       map[string][]byte{"token": []byte("tok")},
+			}
+			Expect(k8sClient.Create(ctx, tokenSecret)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, tokenSecret)).To(Succeed()) }()
+
+			app := makeGitSourceApp("git-inflight", namespace, "gh-inflight")
+			app.Annotations["mortise.dev/revision"] = "revinflight"
+			app.Spec.Environments[0].Env = []mortisev1alpha1.EnvVar{
+				{Name: "STRIPE_PRICE_ID", Value: "price_new_19"},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			// The build never completes for the duration of this test.
+			release := make(chan struct{})
+			defer close(release)
+			bc := &gatedBuildClient{digest: "sha256:inflightdigest", release: release}
+
+			r := gitSourceReconciler(bc, &fakeGitClient{}, &fakeRegistryBackend{})
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: app.Name, Namespace: namespace}}
+
+			// Two reconciles, both with the build still running.
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Control read first: the build really is still in flight, so this
+			// test is asserting about the state it claims to be asserting about.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: namespace}, app)).To(Succeed())
+			Expect(app.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseBuilding))
+			var dep appsv1.Deployment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "git-inflight", Namespace: envNsProduction,
+			}, &dep)).To(MatchError(ContainSubstring("not found")))
+
+			// The config change must have landed anyway. It does not depend on
+			// the image.
+			var envSecret corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      envstore.AppEnvSecretName("git-inflight"),
+				Namespace: envNsProduction,
+			}, &envSecret)).To(Succeed(), "derived env Secret should exist while the build is in flight")
+			Expect(string(envSecret.Data["STRIPE_PRICE_ID"])).To(Equal("price_new_19"),
+				"a build in flight must not block config/credential propagation")
+		})
+	})
+
 	Context("async build", func() {
 		It("should return Building + requeue on first reconcile and finish on subsequent reconciles", func() {
 			ctx := context.Background()


### PR DESCRIPTION
## The defect

`reconcileEnvSecret` is the only writer of the derived `{app}-env` Secret. It was reachable from exactly three places, and all three are behind a build:

| Call site | Reached when |
| -- | -- |
| `reconcileResolvedEnvSecrets` | git preflight, and **only** when `prepareGitSource` returns `!proceed \|\| err` |
| `reconcileDeployment` | env loop, **after** the build `continue`s |
| `reconcileCronJob` | env loop, **after** the build `continue`s |

```go
if requeue {          // build in flight for this env
    needsRequeue = true
    continue          // skips reconcileDeployment -> reconcileEnvSecret
}
if envImage == "" {
    continue          // same
}
```

A normal in-flight build returns `proceed == true`, so the preflight path does not compensate. Nothing refreshed the Secret on that reconcile and the reconciler requeued after `buildPollInterval` (15s).

**A config change or credential rotation therefore did not propagate until the build finished.** The delay was bounded by *build duration*, not the poll interval, and a hung build blocked it indefinitely — while the App, the spec, and any referenced Secret all read as correct.

## How it was found

Tracing why three PostLab production rotations refreshed in ~10s, <15s and ~40s:

| Change | Observed |
| -- | -- |
| `DEEPSEEK_API_KEY`, no code deploy | ~10s |
| Coupon repoint, no code deploy | <15s |
| Reprice — **code deployed first**, then config | four stale polls, **~40s** |

The slow one is the only one with a build running. ~40s is two to three 15s poll intervals.

## The fix

Config and credentials do not depend on the image. Write the env Secret in the env loop alongside the other pre-build env resources (PVCs, ConfigMaps, ServiceAccount, credentials Secret), and drop it from the two workload paths.

One write site, ahead of anything that can skip it — removing the class rather than compensating for it. `reconcileDeployment`'s `hashEnvSecretData` still reads a current Secret, since it is written earlier in the same reconcile.

Errors route through `envResourceError` like the other env writes, rather than feeding the workqueue's rate limiter.

## Test

`refreshes the derived env Secret while a build is still in flight` — drives two reconciles against a `gatedBuildClient` whose build never completes, does a **control read first** (phase is `Building`, no Deployment exists) so the test is asserting about the state it claims to be, then asserts the derived Secret carries the new value.

Fails before:

```
secrets "git-inflight-env" not found
```

The Secret did not merely hold a stale value — it did not exist at all while the build ran. Passes after. Full `make test` (unit + envtest) green; `gofmt`/`go vet` clean.

## Scope note

This is **not** fixed by the pending v1.1.0 release (CAI-164) — the defect is live on `main` as well as on the deployed operator, so it should not be counted among that release's wins.

Closes CAI-245.