### PR TITLE
feat: stamp the build identity into every binary and report it (CAI-185)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
           target: operator
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
@@ -122,7 +125,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Cross-compile CLI
-        run: make build-cli-all
+        run: make build-cli-all VERSION="${GITHUB_REF_NAME#v}" COMMIT="${GITHUB_SHA}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The operator reports its own build** (CAI-185): every binary is stamped
+  at link time with its release version (or `<branch>-<sha>` for an untagged
+  build) and git commit. The operator writes them to
+  `PlatformConfig.status.operatorVersion` / `operatorCommit` on each
+  reconcile (`kubectl get platformconfig` shows an `Operator` column),
+  `GET /api/platform` returns an `operator` block from the running binary,
+  and `mortise version` prints the CLI and operator versions side by side
+  (`--client` skips the operator call). Production ran an untagged build
+  153 commits behind `main` for weeks and nothing said so; this is the
+  read that would have.
+
 - **PlatformConfig misconfiguration conditions** (#449): the PlatformConfig
   status now surfaces two problems that previously lived only in operator
   logs. `RegistryPullConfig=False/PullURLMissing` flags a cluster-internal

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN npm run build
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=0.0.0-dev
+ARG COMMIT=unknown
 
 WORKDIR /workspace
 COPY go.mod go.sum ./
@@ -20,7 +22,7 @@ COPY . .
 RUN rm -rf internal/ui/build
 COPY --from=ui-builder /ui/build ./internal/ui/build
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "-X github.com/mortise-org/mortise/internal/version.Version=${VERSION} -X github.com/mortise-org/mortise/internal/version.Commit=${COMMIT}" -o manager cmd/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o observer ./cmd/observer
 
 # Final image — debian-slim instead of distroless/alpine because Railpack

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,12 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 ##@ Build
 
+# Build identity stamped into every binary (internal/version). See
+# hack/version.sh for the VERSION rule; release.yml overrides both.
+COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+VERSION ?= $(shell hack/version.sh)
+LDFLAGS = -ldflags "-X github.com/mortise-org/mortise/internal/version.Version=$(VERSION) -X github.com/mortise-org/mortise/internal/version.Commit=$(COMMIT)"
+
 .PHONY: build-ui
 build-ui: ## Build the SvelteKit UI and copy into internal/ui/build for embedding.
 	cd ui && npm install && npm run build
@@ -101,7 +107,7 @@ build-ui: ## Build the SvelteKit UI and copy into internal/ui/build for embeddin
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build $(LDFLAGS) -o bin/manager cmd/main.go
 
 .PHONY: build-observer
 build-observer: fmt vet ## Build observer binary.
@@ -109,7 +115,7 @@ build-observer: fmt vet ## Build observer binary.
 
 .PHONY: build-cli
 build-cli: fmt vet ## Build CLI binary.
-	go build -o bin/mortise ./cmd/cli
+	go build $(LDFLAGS) -o bin/mortise ./cmd/cli
 
 CLI_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
@@ -118,7 +124,7 @@ build-cli-all: fmt vet ## Cross-compile CLI binary for all release platforms.
 	@for platform in $(CLI_PLATFORMS); do \
 		os=$${platform%/*}; arch=$${platform#*/}; \
 		echo "Building mortise-$${os}-$${arch}..."; \
-		GOOS=$${os} GOARCH=$${arch} go build -o bin/mortise-$${os}-$${arch} ./cmd/cli; \
+		GOOS=$${os} GOARCH=$${arch} go build $(LDFLAGS) -o bin/mortise-$${os}-$${arch} ./cmd/cli; \
 	done
 
 .PHONY: run
@@ -538,7 +544,7 @@ dev-reload: build-ui ## Rebuild image, re-apply CRDs + chart, restart Mortise in
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --target operator -t ${IMG} .
+	$(CONTAINER_TOOL) build --target operator --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t ${IMG} .
 
 .PHONY: docker-build-observer
 docker-build-observer: ## Build docker image with the observer.

--- a/api/v1alpha1/platformconfig_types.go
+++ b/api/v1alpha1/platformconfig_types.go
@@ -218,6 +218,17 @@ type PlatformConfigStatus struct {
 	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// OperatorVersion is the build identity of the operator that last
+	// reconciled this resource: the release tag without "v", or a
+	// "<branch>-<sha>" marker for an untagged build. It answers "which
+	// operator is production actually running" without a cluster spelunk.
+	// +optional
+	OperatorVersion string `json:"operatorVersion,omitempty"`
+
+	// OperatorCommit is the git SHA the running operator was built from.
+	// +optional
+	OperatorCommit string `json:"operatorCommit,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -225,6 +236,7 @@ type PlatformConfigStatus struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Domain",type=string,JSONPath=`.spec.domain`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Operator",type=string,JSONPath=`.status.operatorVersion`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PlatformConfig is the Schema for the platformconfigs API. It is cluster-scoped

--- a/charts/mortise-core/crds/mortise.mortise.dev_platformconfigs.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_platformconfigs.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.operatorVersion
+      name: Operator
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -365,6 +368,17 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              operatorCommit:
+                description: OperatorCommit is the git SHA the running operator was
+                  built from.
+                type: string
+              operatorVersion:
+                description: |-
+                  OperatorVersion is the build identity of the operator that last
+                  reconciled this resource: the release tag without "v", or a
+                  "<branch>-<sha>" marker for an untagged build. It answers "which
+                  operator is production actually running" without a cluster spelunk.
+                type: string
               phase:
                 description: Phase is the current lifecycle phase.
                 enum:

--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -495,6 +495,10 @@ func (c *Client) DeleteGitProvider(name string) error {
 // ---------- Platform ----------
 
 type PlatformResponse struct {
+	Operator struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	} `json:"operator"`
 	Domain   string `json:"domain"`
 	Registry struct {
 		URL string `json:"url"`

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -25,6 +25,7 @@ Quickstart:
 `,
 		SilenceUsage: true,
 	}
+	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newProjectCmd())
 	cmd.AddCommand(newAppCmd())

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mortise-org/mortise/internal/version"
+)
+
+func newVersionCmd() *cobra.Command {
+	var clientOnly bool
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the CLI and operator build versions",
+		Long: `Print the CLI build version and, unless --client is given, the version of
+the operator the CLI is logged in to. The operator's version comes from the
+running binary, so it names what production is actually running, not what
+was last merged or tagged.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Client:   %s\n", version.String())
+			if clientOnly {
+				return nil
+			}
+			c, err := newClientFromConfig()
+			if err != nil {
+				return err
+			}
+			return printOperatorVersion(out, c)
+		},
+	}
+	cmd.Flags().BoolVar(&clientOnly, "client", false, "Print only the CLI version; do not contact the operator")
+	return cmd
+}
+
+func printOperatorVersion(out io.Writer, c *Client) error {
+	p, err := c.GetPlatform()
+	if err != nil {
+		return err
+	}
+	op := p.Operator
+	if op.Version == "" {
+		// An operator built before this field existed answers with nothing;
+		// say so rather than printing an empty line that looks like a bug.
+		fmt.Fprintln(out, "Operator: unknown (operator predates version reporting)")
+		return nil
+	}
+	fmt.Fprintf(out, "Operator: %s (%s)\n", op.Version, op.Commit)
+	return nil
+}

--- a/cmd/cli/version_test.go
+++ b/cmd/cli/version_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestVersion_PrintsOperatorIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/platform"; got != want {
+			t.Errorf("unexpected path: got %q, want %q", got, want)
+		}
+		var resp PlatformResponse
+		resp.Operator.Version = "1.1.0"
+		resp.Operator.Commit = "5e3011e0aa30f00"
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	if err := printOperatorVersion(&buf, newTestClient(srv)); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "Operator: 1.1.0 (5e3011e0aa30f00)\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestVersion_OldOperatorReportsUnknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PlatformResponse{Domain: "example.com"})
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	if err := printOperatorVersion(&buf, newTestClient(srv)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Operator: unknown") {
+		t.Errorf("expected unknown marker, got %q", buf.String())
+	}
+}
+
+func TestVersion_ClientOnlyDoesNotNeedLogin(t *testing.T) {
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"version", "--client"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(buf.String(), "Client:   0.0.0-dev (unknown)") {
+		t.Errorf("unexpected output %q", buf.String())
+	}
+}

--- a/config/crd/bases/mortise.mortise.dev_platformconfigs.yaml
+++ b/config/crd/bases/mortise.mortise.dev_platformconfigs.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.operatorVersion
+      name: Operator
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -365,6 +368,17 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              operatorCommit:
+                description: OperatorCommit is the git SHA the running operator was
+                  built from.
+                type: string
+              operatorVersion:
+                description: |-
+                  OperatorVersion is the build identity of the operator that last
+                  reconciled this resource: the release tag without "v", or a
+                  "<branch>-<sha>" marker for an untagged build. It answers "which
+                  operator is production actually running" without a cluster spelunk.
+                type: string
               phase:
                 description: Phase is the current lifecycle phase.
                 enum:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -606,6 +606,13 @@ definitions:
       trafficAdapterEndpoint:
         type: string
     type: object
+  api.platformOperatorResponse:
+    properties:
+      commit:
+        type: string
+      version:
+        type: string
+    type: object
   api.platformRegistryResponse:
     properties:
       namespace:
@@ -629,6 +636,8 @@ definitions:
         $ref: '#/definitions/api.platformGitHubResponse'
       observability:
         $ref: '#/definitions/api.platformObservabilityResponse'
+      operator:
+        $ref: '#/definitions/api.platformOperatorResponse'
       phase:
         $ref: '#/definitions/v1alpha1.PlatformConfigPhase'
       registry:

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Prints the build identity for internal/version. At an exact release tag this
+# is the tag without its leading "v" (matching the chart/image version); on
+# any other commit it is "<branch>-<12-char sha>", so an untagged build names
+# itself as one. release.yml passes VERSION explicitly and does not use this.
+set -eu
+tag=$(git describe --tags --exact-match 2>/dev/null || true)
+if [ -n "$tag" ]; then
+  echo "${tag#v}"
+  exit 0
+fi
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo dev)
+branch=$(printf "%s" "$branch" | tr "/" "-")
+sha=$(git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
+echo "${branch}-${sha}"

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -606,6 +606,13 @@ definitions:
       trafficAdapterEndpoint:
         type: string
     type: object
+  api.platformOperatorResponse:
+    properties:
+      commit:
+        type: string
+      version:
+        type: string
+    type: object
   api.platformRegistryResponse:
     properties:
       namespace:
@@ -629,6 +636,8 @@ definitions:
         $ref: '#/definitions/api.platformGitHubResponse'
       observability:
         $ref: '#/definitions/api.platformObservabilityResponse'
+      operator:
+        $ref: '#/definitions/api.platformOperatorResponse'
       phase:
         $ref: '#/definitions/v1alpha1.PlatformConfigPhase'
       registry:

--- a/internal/api/platform.go
+++ b/internal/api/platform.go
@@ -14,6 +14,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/authz"
+	"github.com/mortise-org/mortise/internal/version"
 )
 
 // platformConfigName is the well-known singleton name.
@@ -103,8 +104,17 @@ type platformDefaultsResponse struct {
 	Memory string `json:"memory,omitempty"`
 }
 
+// platformOperatorResponse identifies the operator binary serving this
+// request. It comes from the binary itself, not from PlatformConfig status,
+// so it is present even before a PlatformConfig exists.
+type platformOperatorResponse struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
 // platformResponse is the JSON shape returned from GET and PATCH.
 type platformResponse struct {
+	Operator       platformOperatorResponse            `json:"operator"`
 	Domain         string                              `json:"domain"`
 	ExternalDomain string                              `json:"externalDomain,omitempty"`
 	DomainTemplate string                              `json:"domainTemplate,omitempty"`
@@ -137,7 +147,7 @@ func (s *Server) GetPlatform(w http.ResponseWriter, r *http.Request) {
 	var pc mortisev1alpha1.PlatformConfig
 	err := s.client.Get(r.Context(), types.NamespacedName{Name: platformConfigName}, &pc)
 	if errors.IsNotFound(err) {
-		writeJSON(w, http.StatusOK, platformResponse{})
+		writeJSON(w, http.StatusOK, platformResponse{Operator: operatorIdentity()})
 		return
 	}
 	if err != nil {
@@ -319,6 +329,7 @@ func adapterTokenSecretRef(key string) *mortisev1alpha1.SecretRef {
 
 func newPlatformResponse(pc *mortisev1alpha1.PlatformConfig) platformResponse {
 	resp := platformResponse{
+		Operator:       operatorIdentity(),
 		Domain:         pc.Spec.Domain,
 		ExternalDomain: pc.Spec.ExternalDomain,
 		DomainTemplate: pc.Spec.DomainTemplate,
@@ -436,4 +447,8 @@ func buildPlatformSpec(base mortisev1alpha1.PlatformConfigSpec, req *patchPlatfo
 		base.GitHub.ClientID = req.GitHub.ClientID
 	}
 	return base
+}
+
+func operatorIdentity() platformOperatorResponse {
+	return platformOperatorResponse{Version: version.Version, Commit: version.Commit}
 }

--- a/internal/api/platform_test.go
+++ b/internal/api/platform_test.go
@@ -12,6 +12,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/auth"
+	"github.com/mortise-org/mortise/internal/version"
 )
 
 func TestPatchPlatformCreates(t *testing.T) {
@@ -109,6 +110,12 @@ func TestGetPlatformEmpty(t *testing.T) {
 	_ = json.NewDecoder(w.Body).Decode(&resp)
 	if resp["domain"] != "" {
 		t.Errorf("domain: expected empty, got %v", resp["domain"])
+	}
+	// The operator identity comes from the binary, so it is reported even
+	// with no PlatformConfig to read it from.
+	op, _ := resp["operator"].(map[string]any)
+	if op["version"] != version.Version || op["commit"] != version.Commit {
+		t.Errorf("operator: expected %s/%s, got %v", version.Version, version.Commit, resp["operator"])
 	}
 }
 

--- a/internal/controller/platformconfig_controller.go
+++ b/internal/controller/platformconfig_controller.go
@@ -31,6 +31,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/platformconfig"
+	"github.com/mortise-org/mortise/internal/version"
 )
 
 // singletonName is the required metadata.name for the singleton PlatformConfig.
@@ -76,6 +77,11 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		return ctrl.Result{}, err
 	}
+
+	// Stamp the running operator's identity on every status write, so
+	// `kubectl get platformconfig` names the build production is on.
+	pc.Status.OperatorVersion = version.Version
+	pc.Status.OperatorCommit = version.Commit
 
 	// Enforce singleton: only the instance named "platform" is valid.
 	if pc.Name != singletonName {

--- a/internal/controller/platformconfig_controller_test.go
+++ b/internal/controller/platformconfig_controller_test.go
@@ -30,6 +30,7 @@ import (
 
 	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
 	"github.com/mortise-org/mortise/internal/platformconfig"
+	"github.com/mortise-org/mortise/internal/version"
 )
 
 var _ = Describe("PlatformConfig Controller", func() {
@@ -98,6 +99,19 @@ var _ = Describe("PlatformConfig Controller", func() {
 			Expect(availableCond).NotTo(BeNil())
 			Expect(availableCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(availableCond.Reason).To(Equal("Reconciled"))
+		})
+
+		It("stamps the running operator's build identity into status", func() {
+			origV, origC := version.Version, version.Commit
+			version.Version, version.Commit = "9.9.9-test", "abc123def456"
+			DeferCleanup(func() { version.Version, version.Commit = origV, origC })
+
+			Expect(doReconcile(pcName)).To(Succeed())
+
+			var updated mortisev1alpha1.PlatformConfig
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, &updated)).To(Succeed())
+			Expect(updated.Status.OperatorVersion).To(Equal("9.9.9-test"))
+			Expect(updated.Status.OperatorCommit).To(Equal("abc123def456"))
 		})
 	})
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,19 @@
+// Package version carries the build identity of this binary. The values are
+// stamped at link time (see the Dockerfile and Makefile LDFLAGS); the
+// defaults are what an unstamped `go build` produces, and they are
+// deliberately recognisable as such so a dev build can never be mistaken for
+// a release.
+package version
+
+var (
+	// Version is the release tag without the leading "v" (e.g. "1.1.0"), or a
+	// non-release marker such as "main-5e3011e0aa30" for untagged builds.
+	Version = "0.0.0-dev"
+	// Commit is the full git SHA the binary was built from.
+	Commit = "unknown"
+)
+
+// String renders the identity the way the CLI and logs print it.
+func String() string {
+	return Version + " (" + Commit + ")"
+}


### PR DESCRIPTION
Fixes CAI-185. Track A (visibility) on CAI-246.

## The defect

The operator could not say which build it was. Production ran an untagged image 153 commits behind `main` for weeks; discovering that took a pod image tag and a git ancestry walk by hand.

## The change

- `internal/version`: `Version` and `Commit`, stamped via ldflags. Defaults `0.0.0-dev` / `unknown` are deliberately recognisable as unstamped.
- Dockerfile build args; `release.yml` passes the tag version and sha to the image build and the CLI cross-compile; Makefile derives them from git via `hack/version.sh` for local builds.
- `PlatformConfig.status.operatorVersion` / `operatorCommit`, written on every reconcile, plus an `Operator` printcolumn on `kubectl get platformconfig`.
- `GET /api/platform` returns `operator: {version, commit}` from the running binary, present even with no PlatformConfig.
- `mortise version` prints CLI and operator identities; `--client` skips the operator call; an old operator reports `unknown` rather than an empty line.

## Verification

- envtest: reconcile stamps the status fields (`platformconfig_controller_test.go`).
- API: `TestGetPlatformEmpty` asserts the operator block on the no-PlatformConfig path.
- CLI: three tests in `cmd/cli/version_test.go`.
- End to end on this tree: `make`-style ldflags build of the CLI prints `Client: feat-mo-cai185-operator-version-<sha> (<full sha>)`.
- `make test` green.

## Not in scope

No comparison against the newest release tag. That needs a source of truth for "newest release" that the operator should not fetch from GitHub on its own; it belongs with the cadence half of Track A (CAI-177).
