### PR TITLE
feat(controller): inject MORTISE_REVISION and MORTISE_IMAGE (CAI-180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`--client` skips the operator call). Production ran an untagged build
   153 commits behind `main` for weeks and nothing said so; this is the
   read that would have.
+- **Every container knows what it is running** (CAI-180): git-source builds
+  receive `MORTISE_REVISION` (the commit being built) as a build arg, and
+  every container gets `MORTISE_IMAGE` (the resolved image reference, digest
+  included) plus, for git-source Apps, `MORTISE_REVISION` as environment
+  variables next to `PORT`. A `/version` endpoint can now report its commit
+  without the team wiring an `ARG` through their own CI, and the process
+  answers "what am I" independently of the operator's bookkeeping. The
+  revision is absent, not empty, when there is no built commit (image-source
+  Apps). **Upgrading rolls every workload once**: the pod template gains the
+  new variables. A user-set `MORTISE_REVISION` build arg is kept.
 
 - **PlatformConfig misconfiguration conditions** (#449): the PlatformConfig
   status now surfaces two problems that previously lived only in operator

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1669,10 +1669,18 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 
 	// PORT is injected directly (not via Secret) because it's a Mortise
 	// convention that must always be present and match the container port.
-	portEnv := []corev1.EnvVar{{
-		Name:  "PORT",
-		Value: strconv.Itoa(int(appPort(app))),
-	}}
+	// MORTISE_IMAGE and MORTISE_REVISION ride the same way: they let the
+	// process report what it is running, independently of the operator's
+	// own bookkeeping (CAI-180). MORTISE_REVISION is absent, not empty, when
+	// there is no built revision (image-source Apps), so an empty value can
+	// never be mistaken for a build that failed to record one.
+	portEnv := []corev1.EnvVar{
+		{Name: "PORT", Value: strconv.Itoa(int(appPort(app)))},
+		{Name: imageEnvName, Value: image},
+	}
+	if es := envStatusFor(app, env.Name); es != nil && es.LastBuiltSHA != "" {
+		portEnv = append(portEnv, corev1.EnvVar{Name: revisionEnvName, Value: es.LastBuiltSHA})
+	}
 
 	containers := []corev1.Container{
 		{

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -6926,10 +6926,16 @@ var _ = Describe("App Controller — git source", func() {
 				Name: appName, Namespace: envNsProduction,
 			}, &dep)).To(Succeed())
 
-			// Deployment only carries the PORT literal injected by the controller.
+			// Deployment only carries the literals injected by the controller:
+			// PORT and MORTISE_IMAGE. An image-source App has no built
+			// revision, so MORTISE_REVISION is absent rather than empty.
 			envVars := dep.Spec.Template.Spec.Containers[0].Env
-			Expect(envVars).To(HaveLen(1))
+			Expect(envVars).To(HaveLen(2))
 			Expect(envVars[0].Name).To(Equal("PORT"))
+			Expect(envVars[1]).To(Equal(corev1.EnvVar{Name: "MORTISE_IMAGE", Value: testImageNginx}))
+			for _, ev := range envVars {
+				Expect(ev.Name).NotTo(Equal("MORTISE_REVISION"))
+			}
 
 			// User-defined env vars are in the app-env Secret.
 			envData := readAppEnvSecret(ctx, appName, envNsProduction)
@@ -8489,6 +8495,60 @@ var _ = Describe("App Controller — git source", func() {
 	})
 
 	Context("per-environment build args", func() {
+		It("injects MORTISE_REVISION into the build and the container (CAI-180)", func() {
+			ctx := context.Background()
+
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-revision"},
+				Spec: mortisev1alpha1.GitProviderSpec{
+					Type:     mortisev1alpha1.GitProviderTypeGitHub,
+					Host:     "https://github.com",
+					ClientID: "test-client-id",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-gh-revision-token-74657374406578616d706c652e636f6d",
+					Namespace: "mortise-system",
+				},
+				Data: map[string][]byte{"token": []byte("tok")},
+			}
+			Expect(k8sClient.Create(ctx, tokenSecret)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, tokenSecret)).To(Succeed()) }()
+
+			bc := &fakeBuildClient{digest: "sha256:revision"}
+			r := gitSourceReconciler(bc, &fakeGitClient{}, &fakeRegistryBackend{})
+
+			app := makeGitSourceApp("revision-app", namespace, "gh-revision")
+			app.Annotations["mortise.dev/revision"] = "abc123"
+			app.Spec.Environments = []mortisev1alpha1.Environment{{
+				Name:      "production",
+				Replicas:  ptr.To[int32](1),
+				BuildArgs: map[string]string{"FOO": "bar"},
+			}}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(app)}
+			_, err := reconcileUntilBuildDone(r, ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			bc.mu.Lock()
+			Expect(bc.requests).To(HaveLen(1))
+			Expect(bc.requests[0].BuildArgs).To(HaveKeyWithValue("MORTISE_REVISION", "abc123"))
+			Expect(bc.requests[0].BuildArgs).To(HaveKeyWithValue("FOO", "bar"), "user build args are kept")
+			bc.mu.Unlock()
+
+			var dep appsv1.Deployment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "revision-app", Namespace: envNsProduction}, &dep)).To(Succeed())
+			envVars := dep.Spec.Template.Spec.Containers[0].Env
+			Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "MORTISE_REVISION", Value: "abc123"}))
+			Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "MORTISE_IMAGE", Value: dep.Spec.Template.Spec.Containers[0].Image}))
+		})
+
 		It("passes per-environment build args to the build client", func() {
 			ctx := context.Background()
 			withStagingEnv(ctx)
@@ -8563,8 +8623,9 @@ var _ = Describe("App Controller — git source", func() {
 				}
 			}
 
-			Expect(prodArgs).To(Equal(map[string]string{"ENV": "prod", "DEBUG": "false"}))
-			Expect(stagingArgs).To(Equal(map[string]string{"ENV": "staging", "DEBUG": "true"}))
+			// MORTISE_REVISION is injected beside the user's args (CAI-180).
+			Expect(prodArgs).To(Equal(map[string]string{"ENV": "prod", "DEBUG": "false", "MORTISE_REVISION": "abc123"}))
+			Expect(stagingArgs).To(Equal(map[string]string{"ENV": "staging", "DEBUG": "true", "MORTISE_REVISION": "abc123"}))
 		})
 	})
 

--- a/internal/controller/build_runner.go
+++ b/internal/controller/build_runner.go
@@ -115,7 +115,7 @@ func runBuild(
 		SourceDir:     cloneDir,
 		DockerfileDir: dockerfileDir,
 		Dockerfile:    p.dockerfile,
-		BuildArgs:     p.buildArgs,
+		BuildArgs:     withRevisionBuildArg(p.buildArgs, p.branch, p.revision),
 		ContextMode:   toContextMode(p.buildContext),
 		NoCache:       p.noCache,
 		PushTarget:    p.imageRef.Full,
@@ -151,4 +151,36 @@ func runBuild(
 		pullImage = p.pullImageRef.Registry + "/" + p.pullImageRef.Path + "@" + digest
 	}
 	t.setSucceeded(pullImage, digest, detectedPort)
+}
+
+// revisionEnvName is the build arg and container env var that carries the git
+// revision an image was built from. Mortise is the component that always
+// knows it, so it supplies it rather than every team wiring an ARG through
+// their own CI (CAI-180).
+const revisionEnvName = "MORTISE_REVISION"
+
+// imageEnvName is the container env var that carries the resolved image
+// reference the pod is running, digest included.
+const imageEnvName = "MORTISE_IMAGE"
+
+// withRevisionBuildArg adds MORTISE_REVISION to the user's build args. It is
+// added here, at submission, rather than into BuildRunSpec.BuildArgs: the
+// BuildRun input hash already covers the revision, and adding a derived arg
+// to the spec would change every existing App's hash and force a rebuild
+// on upgrade for no new information. A user-set value wins. When the
+// revision is only the branch fallback there is no commit to report, so the
+// arg is left absent rather than set to a branch name.
+func withRevisionBuildArg(args map[string]string, branch, revision string) map[string]string {
+	if revision == "" || revision == branch {
+		return args
+	}
+	if _, set := args[revisionEnvName]; set {
+		return args
+	}
+	out := make(map[string]string, len(args)+1)
+	for k, v := range args {
+		out[k] = v
+	}
+	out[revisionEnvName] = revision
+	return out
 }

--- a/internal/controller/build_runner_test.go
+++ b/internal/controller/build_runner_test.go
@@ -117,3 +117,33 @@ func createBuildRunnerCommit(t *testing.T, wt *gogit.Worktree, repoDir, path, co
 	}
 	return hash.String()
 }
+
+func TestWithRevisionBuildArg(t *testing.T) {
+	t.Run("adds the revision beside user args", func(t *testing.T) {
+		got := withRevisionBuildArg(map[string]string{"FOO": "bar"}, "main", "abc123")
+		if got["MORTISE_REVISION"] != "abc123" || got["FOO"] != "bar" {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("does not mutate the caller's map", func(t *testing.T) {
+		in := map[string]string{"FOO": "bar"}
+		_ = withRevisionBuildArg(in, "main", "abc123")
+		if _, ok := in["MORTISE_REVISION"]; ok {
+			t.Fatal("input map was mutated")
+		}
+	})
+	t.Run("user value wins", func(t *testing.T) {
+		got := withRevisionBuildArg(map[string]string{"MORTISE_REVISION": "mine"}, "main", "abc123")
+		if got["MORTISE_REVISION"] != "mine" {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("absent when the revision is only the branch fallback", func(t *testing.T) {
+		if got := withRevisionBuildArg(nil, "main", "main"); got != nil {
+			t.Fatalf("got %v", got)
+		}
+		if got := withRevisionBuildArg(nil, "main", ""); got != nil {
+			t.Fatalf("got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes CAI-180. Motivating case: CAI-261 — the first Mortise deploy of mchaseallen.com in a month could only be proven by pod image digest; `/version` said `unknown`.

## Change

- Build: `MORTISE_REVISION=<commit>` added to build args at submission (`withRevisionBuildArg`). Not in `BuildRunSpec.BuildArgs`, so no input-hash churn or rebuild-on-upgrade. User value wins; absent when the revision is only the branch fallback.
- Runtime: `MORTISE_IMAGE` on every container; `MORTISE_REVISION` on git-source containers from `status.environments[].lastBuiltSHA`. Absent, not empty, for image-source Apps.

## Rollout consequence

Pod template gains variables → every workload rolls once on upgrade. In the CHANGELOG.

## Tests

- envtest: git-source App → build request carries `MORTISE_REVISION` beside user args; Deployment carries both env vars.
- envtest (updated): image-source App has `PORT` + `MORTISE_IMAGE` and no `MORTISE_REVISION`.
- unit: `withRevisionBuildArg` (user wins, no mutation, branch-fallback absent).
- `make test` green.
