### PR TITLE
fix(controller): report a pending redeploy; frozen env-hash no longer survives an image roll (CAI-153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   revision is absent, not empty, when there is no built commit (image-source
   Apps). **Upgrading rolls every workload once**: the pod template gains the
   new variables. A user-set `MORTISE_REVISION` build arg is kept.
+- **A pending redeploy is now a condition** (CAI-153): with
+  `Project.spec.autoRedeploy` off (the default) an applied env change
+  updates the derived Secret but deliberately does not roll pods; only the
+  UI banner said so, and `kubectl apply` reported success while a rotated
+  credential's old value stayed live. The App now carries
+  `EnvRolledOut=False / RedeployPending`, naming the environments whose
+  running pods lag the spec and the two ways to close the gap (redeploy, or
+  `autoRedeploy: true`). Cleared automatically when pods carry the current
+  env.
 
 - **PlatformConfig misconfiguration conditions** (#449): the PlatformConfig
   status now surfaces two problems that previously lived only in operator

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1832,16 +1832,6 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		desiredPodAnnotations := mergeAnnotations(nil, desired.Spec.Template.Annotations)
 		desiredPodAnnotations = carryRestartMarkers(
 			desiredPodAnnotations, existing.Spec.Template.Annotations)
-		// When autoRedeploy is off, freeze the deployed env-hash so the new
-		// hash doesn't trigger a rolling update. Users redeploy manually.
-		if !autoRedeploy {
-			if v, ok := existing.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
-				desiredPodAnnotations = mergeAnnotations(desiredPodAnnotations, map[string]string{
-					"mortise.dev/env-hash": v,
-				})
-			}
-		}
-
 		// Only update if the fields we manage actually changed. Comparing the
 		// full spec/template doesn't work because k8s adds dozens of default
 		// fields (securityContext, serviceAccount, terminationMessagePolicy, etc.)
@@ -1885,6 +1875,20 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		}
 		if existing.Spec.Replicas == nil || *existing.Spec.Replicas != *desired.Spec.Replicas {
 			needsUpdate = true
+		}
+		// When autoRedeploy is off, freeze the deployed env-hash so an env
+		// change alone doesn't trigger a rolling update; users redeploy
+		// manually. Only while the image stays put: an image change rolls
+		// the pods regardless, and the new pods read the current Secret, so
+		// carrying the old hash through that roll would leave
+		// deployedEnvHash claiming pods are stale when they are not (CAI-153,
+		// seen on postlab-api: 32/32 keys in sync, hashes disagreeing).
+		if !autoRedeploy && existingContainer.Image == desiredContainer.Image {
+			if v, ok := existing.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
+				desiredPodAnnotations = mergeAnnotations(desiredPodAnnotations, map[string]string{
+					"mortise.dev/env-hash": v,
+				})
+			}
 		}
 		if !annotationsEqual(existing.Spec.Template.ObjectMeta.Annotations, desiredPodAnnotations) {
 			needsUpdate = true
@@ -2063,14 +2067,6 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 		desiredPodAnnotations := mergeAnnotations(nil, desired.Spec.JobTemplate.Spec.Template.Annotations)
 		desiredPodAnnotations = carryRestartMarkers(
 			desiredPodAnnotations, existing.Spec.JobTemplate.Spec.Template.Annotations)
-		if !autoRedeploy {
-			if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
-				desiredPodAnnotations = mergeAnnotations(desiredPodAnnotations, map[string]string{
-					"mortise.dev/env-hash": v,
-				})
-			}
-		}
-
 		desiredPodSpec := desired.Spec.JobTemplate.Spec.Template.Spec
 		if len(desiredPodSpec.Containers) == 0 {
 			return false, fmt.Errorf("desired CronJob %s/%s has no containers", envNs, name)
@@ -2082,6 +2078,16 @@ func (r *AppReconciler) reconcileCronJob(ctx context.Context, app *mortisev1alph
 			return false, fmt.Errorf("existing CronJob %s/%s has no containers", envNs, name)
 		}
 		existingContainer := existingPodSpec.Containers[0]
+
+		// Same freeze rule as the Deployment path: only while the image is
+		// unchanged, so a code deploy does not carry a stale env-hash.
+		if !autoRedeploy && existingContainer.Image == desiredContainer.Image {
+			if v, ok := existing.Spec.JobTemplate.Spec.Template.Annotations["mortise.dev/env-hash"]; ok {
+				desiredPodAnnotations = mergeAnnotations(desiredPodAnnotations, map[string]string{
+					"mortise.dev/env-hash": v,
+				})
+			}
+		}
 
 		needsUpdate := false
 		if existingContainer.Image != desiredContainer.Image {
@@ -3820,6 +3826,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		} else {
 			meta.RemoveStatusCondition(&fresh.Status.Conditions, "PodHealthy")
 		}
+		setEnvRolledOutCondition(&fresh.Status.Conditions, envStatuses, app.Generation)
 		if buildFailed {
 			if anyServing && !anyCrash {
 				reason := buildFailureCond.Reason
@@ -4864,4 +4871,36 @@ func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&mortisev1alpha1.PreviewEnvironment{}, enqueueAppsFromPreviewEnvironment).
 		Named("app").
 		Complete(r)
+}
+
+// envRolledOutCondition is the App condition that says whether every
+// environment's running pods carry the env the spec currently resolves to.
+const envRolledOutCondition = "EnvRolledOut"
+
+// setEnvRolledOutCondition reports a pending redeploy as a condition. With
+// Project.spec.autoRedeploy off (the default) the controller freezes the
+// pod-template env-hash, so an applied env change updates the derived Secret
+// and nothing else: the process keeps the values it booted with. The UI reads
+// pendingEnvHash != deployedEnvHash and shows a banner; kubectl and the CLI
+// showed nothing, which is how a credential rotation reported success while
+// the revoked key was still live (CAI-153). Envs with no Deployment yet, or
+// no derived Secret, are not "pending"; nothing has diverged there.
+func setEnvRolledOutCondition(conds *[]metav1.Condition, envStatuses []mortisev1alpha1.EnvironmentStatus, generation int64) {
+	var pending []string
+	for _, es := range envStatuses {
+		if es.PendingEnvHash != "" && es.DeployedEnvHash != "" && es.PendingEnvHash != es.DeployedEnvHash {
+			pending = append(pending, es.Name)
+		}
+	}
+	if len(pending) == 0 {
+		meta.RemoveStatusCondition(conds, envRolledOutCondition)
+		return
+	}
+	meta.SetStatusCondition(conds, metav1.Condition{
+		Type:               envRolledOutCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             "RedeployPending",
+		Message:            fmt.Sprintf("pods may still be running the previous env in: %s (the env changed after the operator's last rollout; a pod restarted since then already has the current values). Redeploy the app (UI, or POST /api/projects/{project}/apps/{app}/redeploy) or set Project spec.autoRedeploy: true", strings.Join(pending, ", ")),
+		ObservedGeneration: generation,
+	})
 }

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -6942,6 +6942,69 @@ var _ = Describe("App Controller — git source", func() {
 			Expect(envData).NotTo(BeNil())
 			Expect(envData).To(HaveKeyWithValue("PORT", "3000"))
 		})
+
+		It("reports a pending redeploy as a condition when autoRedeploy is off (CAI-153)", func() {
+			appName := "redeploy-pending"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+					Network: mortisev1alpha1.NetworkConfig{Public: true},
+					Environments: []mortisev1alpha1.Environment{{
+						Name: "production",
+						Env:  []mortisev1alpha1.EnvVar{{Name: "API_KEY", Value: "old"}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace}}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			Expect(meta.FindStatusCondition(fresh.Status.Conditions, "EnvRolledOut")).To(BeNil(), "nothing has diverged yet")
+
+			// Rotate the value. No Project exists, so autoRedeploy is off and
+			// the pod template's env-hash is frozen: the Secret changes, the
+			// pods do not.
+			fresh.Spec.Environments[0].Env[0].Value = "new"
+			Expect(k8sClient.Update(ctx, &fresh)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			cond := meta.FindStatusCondition(fresh.Status.Conditions, "EnvRolledOut")
+			Expect(cond).NotTo(BeNil(), "an applied env change that did not roll pods must be reported")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("RedeployPending"))
+			Expect(cond.Message).To(ContainSubstring("production"))
+			es := fresh.Status.Environments[0]
+			Expect(es.PendingEnvHash).NotTo(Equal(es.DeployedEnvHash))
+
+			// An image change rolls the pods anyway, and the new pods read
+			// the current Secret. The frozen hash must not survive that roll,
+			// or status would report stale pods that are in fact current.
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			fresh.Spec.Source.Image = testImageNginx + "-rolled"
+			Expect(k8sClient.Update(ctx, &fresh)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			es = fresh.Status.Environments[0]
+			Expect(es.DeployedEnvHash).To(Equal(es.PendingEnvHash), "an image roll adopts the current env")
+			Expect(meta.FindStatusCondition(fresh.Status.Conditions, "EnvRolledOut")).To(BeNil())
+		})
 	})
 
 	Context("cron app (kind=cron, §5.8a)", func() {

--- a/internal/controller/app_envrolledout_test.go
+++ b/internal/controller/app_envrolledout_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestSetEnvRolledOutCondition(t *testing.T) {
+	envs := func(pairs ...string) []mortisev1alpha1.EnvironmentStatus {
+		var out []mortisev1alpha1.EnvironmentStatus
+		for i := 0; i+2 < len(pairs); i += 3 {
+			out = append(out, mortisev1alpha1.EnvironmentStatus{Name: pairs[i], PendingEnvHash: pairs[i+1], DeployedEnvHash: pairs[i+2]})
+		}
+		return out
+	}
+
+	t.Run("diverged env sets RedeployPending naming the env", func(t *testing.T) {
+		var conds []metav1.Condition
+		setEnvRolledOutCondition(&conds, envs("production", "new", "old", "staging", "same", "same"), 3)
+		c := meta.FindStatusCondition(conds, "EnvRolledOut")
+		if c == nil || c.Status != metav1.ConditionFalse || c.Reason != "RedeployPending" || c.ObservedGeneration != 3 {
+			t.Fatalf("got %+v", c)
+		}
+		if got := c.Message; !contains(got, "production") || contains(got, "staging") {
+			t.Fatalf("message should name only the diverged env: %q", got)
+		}
+	})
+
+	t.Run("no deployment yet or no secret is not pending", func(t *testing.T) {
+		conds := []metav1.Condition{{Type: "EnvRolledOut", Status: metav1.ConditionFalse}}
+		setEnvRolledOutCondition(&conds, envs("production", "new", "", "staging", "", "old"), 1)
+		if meta.FindStatusCondition(conds, "EnvRolledOut") != nil {
+			t.Fatal("condition should be cleared when nothing has diverged")
+		}
+	})
+
+	t.Run("converged clears a stale condition", func(t *testing.T) {
+		conds := []metav1.Condition{{Type: "EnvRolledOut", Status: metav1.ConditionFalse}}
+		setEnvRolledOutCondition(&conds, envs("production", "h", "h"), 1)
+		if meta.FindStatusCondition(conds, "EnvRolledOut") != nil {
+			t.Fatal("condition should be cleared once deployed == pending")
+		}
+	})
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Fixes CAI-153.

## Why silence was the defect

`Project.spec.autoRedeploy` is off by default, so an applied env change updates the derived Secret and, by design, does not roll pods. Only the UI banner (`pendingEnvHash != deployedEnvHash`) said so. `kubectl apply` reported success while a rotated credential's old value stayed live.

## Change 1: the condition

`EnvRolledOut=False / RedeployPending` on the App, naming the environments whose pods may still run the previous env and the two ways to close it (redeploy, or `autoRedeploy: true`). Cleared when hashes converge. Wording states the uncertainty, not the inequality: a kubelet-restarted pod already has the current values and the annotation cannot know it.

## Change 2: the freeze was lying after image rolls

Found by postlab-mgr while I was building change 1: `postlab-api` showed diverged hashes with 32/32 env keys byte-identical in the container. Cause: the frozen env-hash was carried onto the pod template unconditionally, including when the image changed; the image roll restarted pods that read the current Secret, and the annotation kept the old hash. The condition on top of that would have been a false "redeploy production" signal.

Now the freeze applies only while the image is unchanged (Deployment and CronJob paths); an image roll stamps the current hash.

## Tests

- envtest: image App, autoRedeploy off — env change → condition False/RedeployPending naming `production`, hashes diverge; then image change → hashes converge, condition gone.
- unit: `setEnvRolledOutCondition` — names only diverged envs; no-deployment/no-secret not pending; clears a stale condition.
- `make test` green.

postlab-mgr will re-run their digest sweep against the real environment once this is released.
