### PR TITLE
feat(cli): mortise admin reset-password / create-user, cluster-side (CAI-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`mortise admin reset-password` and `mortise admin create-user`**
+  (CAI-55): cluster-side user administration that needs no API login, for
+  the case where nobody can log in. Tokens carry the user's password
+  generation, so a hand-minted token is `invalid token` regardless of the
+  signing key; the reset bumps the generation and invalidates every prior
+  token for that user. Recipe: `docs/recipes/recover-admin-access.md`.
+
 - **The operator reports its own build** (CAI-185): every binary is stamped
   at link time with its release version (or `<branch>-<sha>` for an untagged
   build) and git commit. The operator writes them to

--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/mortise-org/mortise/internal/auth"
+)
+
+// The admin commands talk to Kubernetes directly, like `mortise diff`, and
+// not to the API: they exist for the case where nobody can log in. A lost
+// admin password, or an API whose every saved token has expired, has no
+// API-side recovery by construction. Cluster access to mortise-system is
+// the credential here, which is the same bar as reading the user Secrets.
+func newAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Cluster-side user administration (no login required)",
+		Long: `Manage Mortise users directly in the cluster, without an API login.
+
+These commands need a kubeconfig that can read and write Secrets in
+mortise-system. They are the recovery path when no one can log in; for
+day-to-day user management use the UI or the /api/admin/users endpoints.`,
+	}
+	cmd.AddCommand(newAdminResetPasswordCmd())
+	cmd.AddCommand(newAdminCreateUserCmd())
+	return cmd
+}
+
+func newAdminResetPasswordCmd() *cobra.Command {
+	var kubeconfig, kubecontext string
+	var stdin bool
+	cmd := &cobra.Command{
+		Use:   "reset-password <email>",
+		Short: "Set a user's password and invalidate their existing tokens",
+		Long: `Set a new password for an existing user. Every token issued before the
+reset stops validating: tokens carry the user's password generation and it
+is bumped here. Read the password from the terminal, or from stdin with
+--password-stdin for scripts (the first line is used).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pw, err := readPassword(cmd.InOrStdin(), cmd.ErrOrStderr(), stdin, "New password: ")
+			if err != nil {
+				return err
+			}
+			c, err := newKubeClient(kubeconfig, kubecontext)
+			if err != nil {
+				return err
+			}
+			return adminResetPassword(cmd.Context(), c, cmd.OutOrStdout(), args[0], pw)
+		},
+	}
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (default: KUBECONFIG, then ~/.kube/config)")
+	cmd.Flags().StringVar(&kubecontext, "context", "", "Kubeconfig context to use")
+	cmd.Flags().BoolVar(&stdin, "password-stdin", false, "Read the password from stdin instead of the terminal")
+	return cmd
+}
+
+func newAdminCreateUserCmd() *cobra.Command {
+	var kubeconfig, kubecontext, role string
+	var stdin bool
+	cmd := &cobra.Command{
+		Use:   "create-user <email>",
+		Short: "Create a user directly in the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := auth.Role(role)
+			if r != auth.RoleAdmin && r != auth.RoleMember {
+				return fmt.Errorf("--role must be %q or %q", auth.RoleAdmin, auth.RoleMember)
+			}
+			pw, err := readPassword(cmd.InOrStdin(), cmd.ErrOrStderr(), stdin, "Password: ")
+			if err != nil {
+				return err
+			}
+			c, err := newKubeClient(kubeconfig, kubecontext)
+			if err != nil {
+				return err
+			}
+			return adminCreateUser(cmd.Context(), c, cmd.OutOrStdout(), args[0], pw, r)
+		},
+	}
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (default: KUBECONFIG, then ~/.kube/config)")
+	cmd.Flags().StringVar(&kubecontext, "context", "", "Kubeconfig context to use")
+	cmd.Flags().StringVar(&role, "role", string(auth.RoleMember), "Role: admin or member")
+	cmd.Flags().BoolVar(&stdin, "password-stdin", false, "Read the password from stdin instead of the terminal")
+	return cmd
+}
+
+func adminResetPassword(ctx context.Context, c client.Client, out io.Writer, email, password string) error {
+	if err := auth.NewNativeAuthProvider(c).UpdatePassword(ctx, email, password); err != nil {
+		return fmt.Errorf("reset password for %s: %w", email, err)
+	}
+	fmt.Fprintf(out, "Password updated for %s; previously issued tokens are no longer valid.\n", email)
+	return nil
+}
+
+func adminCreateUser(ctx context.Context, c client.Client, out io.Writer, email, password string, role auth.Role) error {
+	if err := auth.NewNativeAuthProvider(c).CreateUser(ctx, email, password, role); err != nil {
+		return fmt.Errorf("create user %s: %w", email, err)
+	}
+	fmt.Fprintf(out, "Created %s user %s.\n", role, email)
+	return nil
+}
+
+// readPassword takes the password from stdin when asked, else prompts on the
+// terminal without echo. A password never appears in argv, where it would
+// land in shell history and `ps`.
+func readPassword(in io.Reader, errOut io.Writer, fromStdin bool, prompt string) (string, error) {
+	if fromStdin {
+		line, err := bufio.NewReader(in).ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", fmt.Errorf("reading password from stdin: %w", err)
+		}
+		pw := strings.TrimRight(line, "\r\n")
+		if pw == "" {
+			return "", fmt.Errorf("empty password on stdin")
+		}
+		return pw, nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", fmt.Errorf("stdin is not a terminal; use --password-stdin")
+	}
+	fmt.Fprint(errOut, prompt)
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(errOut)
+	if err != nil {
+		return "", fmt.Errorf("reading password: %w", err)
+	}
+	return string(b), nil
+}

--- a/cmd/cli/admin_test.go
+++ b/cmd/cli/admin_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/mortise-org/mortise/internal/auth"
+)
+
+func TestAdminCreateUserAndResetPassword(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	var out bytes.Buffer
+
+	if err := adminCreateUser(ctx, c, &out, "ops@example.com", "correct horse", auth.RoleAdmin); err != nil {
+		t.Fatal(err)
+	}
+	p := auth.NewNativeAuthProvider(c)
+	if _, err := p.Authenticate(ctx, auth.Credentials{Email: "ops@example.com", Password: "correct horse"}); err != nil {
+		t.Fatalf("login with the created password: %v", err)
+	}
+
+	// A token minted before the reset carries the old password generation.
+	before, err := p.Authenticate(ctx, auth.Credentials{Email: "ops@example.com", Password: "correct horse"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := adminResetPassword(ctx, c, &out, "ops@example.com", "battery staple"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Authenticate(ctx, auth.Credentials{Email: "ops@example.com", Password: "correct horse"}); err == nil {
+		t.Fatal("old password still authenticates")
+	}
+	after, err := p.Authenticate(ctx, auth.Credentials{Email: "ops@example.com", Password: "battery staple"})
+	if err != nil {
+		t.Fatalf("login with the new password: %v", err)
+	}
+	if after.PasswordGen <= before.PasswordGen {
+		t.Fatalf("password generation must advance so old tokens stop validating: before=%d after=%d", before.PasswordGen, after.PasswordGen)
+	}
+	if !strings.Contains(out.String(), "previously issued tokens are no longer valid") {
+		t.Fatalf("output: %q", out.String())
+	}
+}
+
+func TestAdminResetPasswordUnknownUser(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	var out bytes.Buffer
+	if err := adminResetPassword(context.Background(), c, &out, "nobody@example.com", "long enough"); err == nil {
+		t.Fatal("expected an error for an unknown user")
+	}
+}
+
+func TestReadPasswordFromStdin(t *testing.T) {
+	pw, err := readPassword(strings.NewReader("s3cret-line\nsecond line\n"), &bytes.Buffer{}, true, "")
+	if err != nil || pw != "s3cret-line" {
+		t.Fatalf("got %q, %v", pw, err)
+	}
+	if _, err := readPassword(strings.NewReader("\n"), &bytes.Buffer{}, true, ""); err == nil {
+		t.Fatal("empty stdin password must be rejected")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -47,6 +47,7 @@ Quickstart:
 
 	// Lifecycle commands (cluster management)
 	cmd.AddCommand(newInstallCmd())
+	cmd.AddCommand(newAdminCmd())
 	cmd.AddCommand(newUpCmd())
 	cmd.AddCommand(newDownCmd())
 	cmd.AddCommand(newDestroyCmd())

--- a/docs/recipes/recover-admin-access.md
+++ b/docs/recipes/recover-admin-access.md
@@ -1,0 +1,46 @@
+# Recover admin access
+
+When nobody can log in — a lost admin password, or every saved CLI token has
+expired — there is no API-side recovery by construction. The recovery
+credential is cluster access to `mortise-system`.
+
+## Why a hand-minted token does not work
+
+Tokens are signed with `mortise-system/mortise-jwt-key` **and** carry the
+user's password generation (`pwd_gen`). The API checks that claim against the
+`password_gen` field of the user's Secret on every request, so a token minted
+outside the API without the current generation reads as `invalid token` even
+with the right key. Do not mint tokens by hand; reset the password instead.
+
+## Reset a password
+
+```bash
+mortise admin reset-password you@example.com
+# or, from a script (first line of stdin is the password):
+printf '%s\n' "$NEW_PASSWORD" | mortise admin reset-password you@example.com --password-stdin
+```
+
+This writes a new bcrypt hash and bumps the password generation, which
+invalidates every previously issued token for that user. Then:
+
+```bash
+mortise login https://mortise.example.com
+```
+
+`--kubeconfig` and `--context` select the cluster, as for `mortise diff`.
+
+## Create a user without logging in
+
+```bash
+mortise admin create-user ops@example.com --role admin
+```
+
+Roles are `admin` or `member`. For day-to-day user management use the UI or
+`/api/admin/users`; the cluster-side verbs exist for recovery and for
+bootstrapping automation accounts.
+
+## Long-lived tokens for automation
+
+Once logged in, `mortise token create` issues a deploy token that does not
+depend on the interactive session. Rotating that user's password invalidates
+those tokens too, by design.


### PR DESCRIPTION
For CAI-55.

## Diagnosis

The signing key (`mortise-jwt-key`) has not changed since 2026-04-25. Tokens carry `pwd_gen` and the API checks it against the user Secret's `password_gen`; a hand-minted token without the current generation is `invalid token` with the right key. With no recorded admin password there was no recovery path.

## Change

- `mortise admin reset-password <email>` and `mortise admin create-user <email> --role admin|member`: cluster-direct (kubeconfig, like `mortise diff`), via `auth.NativeAuthProvider`. Reset bumps the generation → prior tokens invalid. Password from terminal (no echo) or `--password-stdin`; never argv.
- `docs/recipes/recover-admin-access.md`.

## Tests

`cmd/cli/admin_test.go` with the fake client: create → authenticate; reset → old password rejected, new accepted, `PasswordGen` advanced; unknown user errors; stdin password parsing.

## Not in this PR

Running the reset on jazure (Chase's account, or new accounts for the PM agents) is a production write and an access decision; on the issue for Chase.
