### PR TITLE
fix(controller): reconcile Apps when their GitProvider's webhook Secret changes (CAI-262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A changed webhook Secret now re-registers every hook that used it**
+  (CAI-262): the GitProvider's HMAC Secret was watched by nothing, so
+  recreating it left every registered GitHub hook delivering with the old
+  value and every delivery failing signature verification, silently, until
+  someone read GitHub's delivery log (CAI-261: a month of dead
+  push-to-deploy). Apps sourced from the provider now reconcile on that
+  Secret's change, and the registration input hash does the rest.
+
 - **Picker-added variables now render immediately** (mo-baq): a variable
   added via the bindings/secret picker was written to the App spec but
   frequently did not appear in the variables table until the drawer was

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -4667,6 +4667,19 @@ const referencedCredentialSecretIndex = "spec.credentials.valueFrom.secretRef"
 // indexed, because the env namespace can't be derived without a client lookup.
 // fetchParentProject's label-based fallback covers those on the reconcile path;
 // they fall back to the cache resync here.
+// providerRefIndex indexes git-source Apps by spec.source.providerRef, so a
+// change to a GitProvider's webhook Secret can find every App whose hook was
+// registered with the old value.
+const providerRefIndex = "spec.source.providerRef"
+
+func indexAppProviderRef(obj client.Object) []string {
+	app, ok := obj.(*mortisev1alpha1.App)
+	if !ok || app.Spec.Source.ProviderRef == "" {
+		return nil
+	}
+	return []string{app.Spec.Source.ProviderRef}
+}
+
 func indexAppReferencedSecrets(obj client.Object) []string {
 	app, ok := obj.(*mortisev1alpha1.App)
 	if !ok {
@@ -4770,7 +4783,42 @@ func (r *AppReconciler) appRequestsForReferencedSecret(ctx context.Context, obj 
 // test, only the resolution logic it feeds.
 func (r *AppReconciler) appRequestsForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
 	reqs := appRequestsForManagedResource(ctx, obj)
-	return append(reqs, r.appRequestsForReferencedSecret(ctx, obj)...)
+	reqs = append(reqs, r.appRequestsForReferencedSecret(ctx, obj)...)
+	return append(reqs, r.appRequestsForWebhookSecret(ctx, obj)...)
+}
+
+// appRequestsForWebhookSecret maps a GitProvider's webhook HMAC Secret to
+// every App sourced from that provider. ensureWebhook folds the secret into
+// its registration input hash, so once the App reconciles the hook is
+// re-registered with the new value. Without this mapping nothing triggered
+// that reconcile: a recreated Secret left every registered hook delivering
+// with the old value, and every delivery failed signature verification for a
+// month before anyone looked at GitHub's side (CAI-261, CAI-262).
+func (r *AppReconciler) appRequestsForWebhookSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	var providers mortisev1alpha1.GitProviderList
+	if err := r.List(ctx, &providers); err != nil {
+		logf.FromContext(ctx).Error(err, "listing GitProviders for webhook secret", "secret", obj.GetNamespace()+"/"+obj.GetName())
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range providers.Items {
+		ref := providers.Items[i].Spec.WebhookSecretRef
+		if ref == nil || ref.Name != obj.GetName() || ref.Namespace != obj.GetNamespace() {
+			continue
+		}
+		var apps mortisev1alpha1.AppList
+		if err := r.List(ctx, &apps, client.MatchingFields{providerRefIndex: providers.Items[i].Name}); err != nil {
+			logf.FromContext(ctx).Error(err, "listing Apps for GitProvider", "provider", providers.Items[i].Name)
+			continue
+		}
+		for j := range apps.Items {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      apps.Items[j].Name,
+				Namespace: apps.Items[j].Namespace,
+			}})
+		}
+	}
+	return reqs
 }
 
 // appRequestsForManagedResource maps a resource the reconciler created back to
@@ -4854,6 +4902,11 @@ func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		context.Background(), &mortisev1alpha1.App{}, referencedCredentialSecretIndex, indexAppCredentialSecrets,
 	); err != nil {
 		return fmt.Errorf("index apps by referenced credential secret: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mortisev1alpha1.App{}, providerRefIndex, indexAppProviderRef,
+	); err != nil {
+		return fmt.Errorf("index apps by git provider: %w", err)
 	}
 
 	enqueueAppFromSecret := handler.EnqueueRequestsFromMapFunc(r.appRequestsForSecret)

--- a/internal/controller/app_secret_watch_test.go
+++ b/internal/controller/app_secret_watch_test.go
@@ -346,3 +346,62 @@ func TestAppRequestsForSecret_CredentialRefs(t *testing.T) {
 		}
 	})
 }
+
+// A GitProvider's webhook HMAC Secret is referenced by nothing an App owns
+// or reads, so neither of the other mappings finds the Apps whose hooks were
+// registered with it. Every App on that provider must reconcile so the hook
+// input hash sees the new value and re-registers (CAI-262).
+func TestAppRequestsForSecret_WebhookSecret(t *testing.T) {
+	scheme := gcTestScheme(t)
+
+	gp := &mortisev1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "github"},
+		Spec: mortisev1alpha1.GitProviderSpec{
+			Type: mortisev1alpha1.GitProviderTypeGitHub,
+			WebhookSecretRef: &mortisev1alpha1.SecretRef{
+				Namespace: "mortise-system", Name: "gitprovider-webhook-github", Key: "webhookSecret",
+			},
+		},
+	}
+	onProvider := func(name, project string) *mortisev1alpha1.App {
+		return &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: constants.ControlNamespace(project)},
+			Spec: mortisev1alpha1.AppSpec{Source: mortisev1alpha1.AppSource{
+				Type: mortisev1alpha1.SourceTypeGit, Repo: "https://github.com/org/" + name + ".git", ProviderRef: "github",
+			}},
+		}
+	}
+	other := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "gitea-app", Namespace: constants.ControlNamespace("demo")},
+		Spec:       mortisev1alpha1.AppSpec{Source: mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeGit, ProviderRef: "gitea"}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&mortisev1alpha1.App{}, referencedSecretIndex, indexAppReferencedSecrets).
+		WithIndex(&mortisev1alpha1.App{}, referencedCredentialSecretIndex, indexAppCredentialSecrets).
+		WithIndex(&mortisev1alpha1.App{}, providerRefIndex, indexAppProviderRef).
+		WithObjects(gp, onProvider("site", "portfolio"), onProvider("api", "postlab"), other).
+		Build()
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gitprovider-webhook-github", Namespace: "mortise-system"}}
+	reqs := r.appRequestsForSecret(context.Background(), secret)
+
+	got := map[string]bool{}
+	for _, req := range reqs {
+		got[req.Namespace+"/"+req.Name] = true
+	}
+	for _, want := range []string{"pj-portfolio/site", "pj-postlab/api"} {
+		if !got[want] {
+			t.Errorf("App %s on the provider was not enqueued; got %v", want, reqs)
+		}
+	}
+	if got["pj-demo/gitea-app"] {
+		t.Errorf("an App on another provider was enqueued: %v", reqs)
+	}
+
+	unrelated := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "something-else", Namespace: "mortise-system"}}
+	if reqs := r.appRequestsForSecret(context.Background(), unrelated); len(reqs) != 0 {
+		t.Errorf("unrelated Secret enqueued Apps: %v", reqs)
+	}
+}


### PR DESCRIPTION
For CAI-262 (reconcile half). Motivated by CAI-261.

## The gap

`ensureWebhook` re-registers a hook when its input hash (URL, events, secret) changes — on reconcile. Nothing watched the GitProvider's webhook Secret, so a recreated Secret orphaned every registered hook until an unrelated reconcile happened to run. In production that took a month and a PM reading GitHub's delivery log.

## Change

- Index Apps by `spec.source.providerRef`.
- `appRequestsForWebhookSecret`: Secret → GitProviders whose `webhookSecretRef` names it → every App on those providers. Composed into the existing Secret watch mapping.

## Test

`TestAppRequestsForSecret_WebhookSecret`: two Apps on `github` enqueued, an App on `gitea` not, an unrelated Secret enqueues nothing. `make test` green.

## Not in this PR

The detect half: `signature mismatch` on an inbound delivery surfacing as an App condition. Stays on CAI-262.
