### PR TITLE
ci: dispatchable N-run integration repeat to measure the flake rate (CAI-173)

### DIFF
--- a/.github/workflows/integration-repeat.yml
+++ b/.github/workflows/integration-repeat.yml
@@ -1,0 +1,116 @@
+name: Integration repeat
+
+# Measures the integration suite's flake rate on one tree (CAI-173). N
+# independent runs of the same job that CI runs, each on its own runner and
+# k3d cluster; a summary tallies pass/fail and names the failing tests. Run
+# it before promoting Integration to a required check (CAI-165), and after
+# any fix that claims to remove a flake class.
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Number of independent runs
+        default: "10"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - id: m
+        run: |
+          n="${{ inputs.runs }}"
+          echo "matrix=$(seq -s, 1 "$n" | sed 's/^/[/;s/$/]/')" >> "$GITHUB_OUTPUT"
+
+  run:
+    needs: plan
+    name: Run ${{ matrix.run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /usr/local/bin/k3d "https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64"
+          echo "dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e  /usr/local/bin/k3d" | sha256sum --check
+          chmod +x /usr/local/bin/k3d
+
+      - name: Run integration tests
+        id: t
+        run: |
+          mkdir -p result
+          set +e
+          make test-integration 2>&1 | tee result/output.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "$rc" > result/rc
+          grep -E '^--- FAIL: ' result/output.log | sed 's/^--- FAIL: //' | cut -d' ' -f1 | sort -u > result/failed-tests.txt || true
+          exit "$rc"
+
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > result/operator.log || true
+          kubectl get events -A --sort-by=.lastTimestamp > result/events.txt || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: run-${{ matrix.run }}
+          path: result/
+          if-no-files-found: ignore
+
+      - name: Tear down integration cluster
+        if: always()
+        run: k3d cluster delete mortise-int || true
+
+  summary:
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: results
+
+      - name: Tally
+        run: |
+          total=0; failed=0
+          {
+            echo "## Integration repeat: ${{ github.sha }}"
+            echo
+            echo "| run | result | failing tests |"
+            echo "|---|---|---|"
+            for d in $(ls -d results/run-* | sort -t- -k2 -n); do
+              total=$((total+1))
+              rc=$(cat "$d/rc" 2>/dev/null || echo "?")
+              tests=$(tr '\n' ' ' < "$d/failed-tests.txt" 2>/dev/null)
+              if [ "$rc" = "0" ]; then r="pass"; else r="FAIL"; failed=$((failed+1)); fi
+              echo "| ${d#results/run-} | $r | $tests |"
+            done
+            echo
+            echo "**$failed of $total runs failed.**"
+            echo
+            echo "### By test"
+            cat results/run-*/failed-tests.txt 2>/dev/null | sort | uniq -c | sort -rn | sed 's/^ *\([0-9]*\) \(.*\)/- \2: \1/'
+          } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
For CAI-173 / CAI-165 A.2. `gh workflow run integration-repeat.yml -f runs=10` runs the integration job N times on one tree in parallel, uploads each run's output and (on failure) the full operator log, and writes a summary with the failure count and failing test names. First measurement dispatched from this branch (tree = main + this file).