### PR TITLE
feat(platformconfig): externalScheme decides the webhook URL scheme (CAI-264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   generation, so a hand-minted token is `invalid token` regardless of the
   signing key; the reset bumps the generation and invalidates every prior
   token for that user. Recipe: `docs/recipes/recover-admin-access.md`.
+- **`PlatformConfig.spec.externalScheme`** (CAI-264): the scheme git hosts
+  use to reach the API for webhook deliveries. Unset keeps the old
+  inference (https only when `spec.tls.certManagerClusterIssuer` is set),
+  which registers plain-http hooks wherever TLS terminates ahead of the
+  cluster; a host that then redirects http→https breaks deliveries
+  silently, since git hosts do not follow redirects. Set `https` there.
+  Changing it re-registers every hook.
 
 - **The operator reports its own build** (CAI-185): every binary is stamped
   at link time with its release version (or `<branch>-<sha>` for an untagged

--- a/api/v1alpha1/platformconfig_types.go
+++ b/api/v1alpha1/platformconfig_types.go
@@ -123,6 +123,18 @@ type PlatformConfigSpec struct {
 	// +optional
 	ExternalDomain string `json:"externalDomain,omitempty"`
 
+	// ExternalScheme is the URL scheme git hosts use to reach the API at
+	// ExternalDomain, for webhook registration. When unset, https is used
+	// if spec.tls.certManagerClusterIssuer is configured and http otherwise
+	// -- which is wrong wherever TLS terminates ahead of the cluster (an
+	// edge proxy, a tunnel): the hook is then registered over plain http,
+	// and a host that redirects http to https breaks deliveries silently,
+	// since git hosts do not follow redirects. Set it explicitly in that
+	// case. Changing it re-registers every hook.
+	// +kubebuilder:validation:Enum=http;https
+	// +optional
+	ExternalScheme string `json:"externalScheme,omitempty"`
+
 	// DomainTemplate is a Go text/template that controls how auto-generated
 	// hostnames are constructed. Available variables: {{.App}}, {{.Project}},
 	// {{.Env}}, {{.Domain}}. The {{.Env}} component is omitted for the

--- a/charts/mortise-core/crds/mortise.mortise.dev_platformconfigs.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_platformconfigs.yaml
@@ -142,6 +142,20 @@ spec:
                   reachable. Used for git webhook callbacks. Falls back to Domain
                   when unset.
                 type: string
+              externalScheme:
+                description: |-
+                  ExternalScheme is the URL scheme git hosts use to reach the API at
+                  ExternalDomain, for webhook registration. When unset, https is used
+                  if spec.tls.certManagerClusterIssuer is configured and http otherwise
+                  -- which is wrong wherever TLS terminates ahead of the cluster (an
+                  edge proxy, a tunnel): the hook is then registered over plain http,
+                  and a host that redirects http to https breaks deliveries silently,
+                  since git hosts do not follow redirects. Set it explicitly in that
+                  case. Changing it re-registers every hook.
+                enum:
+                - http
+                - https
+                type: string
               github:
                 description: |-
                   GitHub holds optional overrides for the project-maintained GitHub App.

--- a/config/crd/bases/mortise.mortise.dev_platformconfigs.yaml
+++ b/config/crd/bases/mortise.mortise.dev_platformconfigs.yaml
@@ -142,6 +142,20 @@ spec:
                   reachable. Used for git webhook callbacks. Falls back to Domain
                   when unset.
                 type: string
+              externalScheme:
+                description: |-
+                  ExternalScheme is the URL scheme git hosts use to reach the API at
+                  ExternalDomain, for webhook registration. When unset, https is used
+                  if spec.tls.certManagerClusterIssuer is configured and http otherwise
+                  -- which is wrong wherever TLS terminates ahead of the cluster (an
+                  edge proxy, a tunnel): the hook is then registered over plain http,
+                  and a host that redirects http to https breaks deliveries silently,
+                  since git hosts do not follow redirects. Set it explicitly in that
+                  case. Changing it re-registers every hook.
+                enum:
+                - http
+                - https
+                type: string
               github:
                 description: |-
                   GitHub holds optional overrides for the project-maintained GitHub App.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,16 @@ PlatformConfig CRD:
 spec:
   domain: apps.example.com          # used for app subdomains
   externalDomain: mortise.example.com  # where Mortise API is reachable
+  externalScheme: https             # optional; see below
 ```
+
+**`externalScheme`:** the scheme in the registered webhook URL. Unset,
+Mortise uses `https` only when `spec.tls.certManagerClusterIssuer` is
+configured and `http` otherwise. If TLS terminates ahead of the cluster
+(an edge proxy or tunnel) that inference registers plain-`http` hooks;
+set `externalScheme: https` explicitly. Git hosts do not follow
+redirects, so an `http` hook against a host that redirects to `https`
+fails every delivery. Changing the value re-registers every hook.
 
 ### Webhook reachability
 

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -3310,11 +3310,7 @@ func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.
 		return nil
 	}
 
-	scheme := "https"
-	if pc.Spec.TLS.CertManagerClusterIssuer == "" {
-		scheme = "http"
-	}
-	webhookURL := fmt.Sprintf("%s://%s/api/webhooks/%s", scheme, host, gp.Name)
+	webhookURL := fmt.Sprintf("%s://%s/api/webhooks/%s", webhookScheme(&pc), host, gp.Name)
 
 	// Resolve webhook secret. The webhook handler rejects every delivery for
 	// a provider without a usable secret, so registering a secretless hook
@@ -4956,4 +4952,18 @@ func setEnvRolledOutCondition(conds *[]metav1.Condition, envStatuses []mortisev1
 		Message:            fmt.Sprintf("pods may still be running the previous env in: %s (the env changed after the operator's last rollout; a pod restarted since then already has the current values). Redeploy the app (UI, or POST /api/projects/{project}/apps/{app}/redeploy) or set Project spec.autoRedeploy: true", strings.Join(pending, ", ")),
 		ObservedGeneration: generation,
 	})
+}
+
+// webhookScheme picks the scheme for the registered webhook URL. An explicit
+// spec.externalScheme wins; otherwise the historical inference from
+// cert-manager config stands, so installs that never set the field keep the
+// hooks they have (CAI-264).
+func webhookScheme(pc *mortisev1alpha1.PlatformConfig) string {
+	if pc.Spec.ExternalScheme != "" {
+		return pc.Spec.ExternalScheme
+	}
+	if pc.Spec.TLS.CertManagerClusterIssuer == "" {
+		return "http"
+	}
+	return "https"
 }

--- a/internal/controller/app_webhook_scheme_test.go
+++ b/internal/controller/app_webhook_scheme_test.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"testing"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestWebhookScheme(t *testing.T) {
+	cases := []struct {
+		name   string
+		spec   mortisev1alpha1.PlatformConfigSpec
+		expect string
+	}{
+		{"unset without cert-manager infers http", mortisev1alpha1.PlatformConfigSpec{}, "http"},
+		{"unset with cert-manager infers https", mortisev1alpha1.PlatformConfigSpec{TLS: mortisev1alpha1.TLSConfig{CertManagerClusterIssuer: "letsencrypt"}}, "https"},
+		{"explicit https wins without cert-manager (edge TLS)", mortisev1alpha1.PlatformConfigSpec{ExternalScheme: "https"}, "https"},
+		{"explicit http wins with cert-manager", mortisev1alpha1.PlatformConfigSpec{ExternalScheme: "http", TLS: mortisev1alpha1.TLSConfig{CertManagerClusterIssuer: "x"}}, "http"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := webhookScheme(&mortisev1alpha1.PlatformConfig{Spec: c.spec}); got != c.expect {
+				t.Fatalf("got %q, want %q", got, c.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes CAI-264. `spec.externalScheme` (enum http|https, optional) wins when set; unset keeps today's cert-manager inference so no existing install's hooks move. Unit test on the selection; CRDs regenerated; docs/configuration.md documents it. Setting it on jazure (→ https) is a PlatformConfig edit that re-registers hooks; that's a cluster change for after the release.