### PR TITLE
feat(controller): report reserved env keys a user declares (CAI-220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Declaring a reserved variable is reported** (CAI-220): `PORT`,
+  `MORTISE_IMAGE` and `MORTISE_REVISION` are set on the container itself
+  and beat every `envFrom` source, so a user-declared `PORT` landed in the
+  derived Secret, visibly, while the process ran the platform's value.
+  The App now carries `EnvKeysReserved=False / PlatformValueWins` naming
+  the declarations by environment or `sharedVars`. Behaviour is unchanged;
+  the silence is gone.
+
 - **`mortise admin reset-password` and `mortise admin create-user`**
   (CAI-55): cluster-side user administration that needs no API login, for
   the case where nobody can log in. Tokens carry the user's password

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -163,6 +163,9 @@ type ConfigFile struct {
 	Content string `json:"content"`
 }
 
+// PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+// container itself and win over anything declared as an EnvVar; declaring
+// them raises the EnvKeysReserved condition instead of taking effect.
 // EnvVar is one environment variable for an App environment. Set exactly one
 // of Value or ValueFrom.
 type EnvVar struct {

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -199,6 +199,9 @@ spec:
                     env:
                       items:
                         description: |-
+                          PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                          container itself and win over anything declared as an EnvVar; declaring
+                          them raises the EnvKeysReserved condition instead of taking effect.
                           EnvVar is one environment variable for an App environment. Set exactly one
                           of Value or ValueFrom.
                         properties:
@@ -611,6 +614,9 @@ spec:
                   flags that should not be repeated per environment.
                 items:
                   description: |-
+                    PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                    container itself and win over anything declared as an EnvVar; declaring
+                    them raises the EnvKeysReserved condition instead of taking effect.
                     EnvVar is one environment variable for an App environment. Set exactly one
                     of Value or ValueFrom.
                   properties:

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -199,6 +199,9 @@ spec:
                     env:
                       items:
                         description: |-
+                          PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                          container itself and win over anything declared as an EnvVar; declaring
+                          them raises the EnvKeysReserved condition instead of taking effect.
                           EnvVar is one environment variable for an App environment. Set exactly one
                           of Value or ValueFrom.
                         properties:
@@ -611,6 +614,9 @@ spec:
                   flags that should not be repeated per environment.
                 items:
                   description: |-
+                    PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                    container itself and win over anything declared as an EnvVar; declaring
+                    them raises the EnvKeysReserved condition instead of taking effect.
                     EnvVar is one environment variable for an App environment. Set exactly one
                     of Value or ValueFrom.
                   properties:

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -3828,6 +3828,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 		} else {
 			meta.RemoveStatusCondition(&fresh.Status.Conditions, "PodHealthy")
 		}
+		setReservedEnvKeysCondition(&fresh.Status.Conditions, app, resolvedEnvs, app.Generation)
 		setEnvRolledOutCondition(&fresh.Status.Conditions, envStatuses, app.Generation)
 		setEnvironmentJoinedCondition(&fresh.Status.Conditions, envStatuses, r.clock().Now(), app.Generation)
 		if buildFailed {

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -6946,6 +6946,39 @@ var _ = Describe("App Controller — git source", func() {
 			}
 		})
 
+		It("reports a user-declared PORT as reserved instead of silently ignoring it (CAI-220)", func() {
+			appName := "declares-port"
+			app := &mortisev1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+				Spec: mortisev1alpha1.AppSpec{
+					Source:  mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+					Network: mortisev1alpha1.NetworkConfig{Public: true, Port: 3000},
+					Environments: []mortisev1alpha1.Environment{{
+						Name: "production",
+						Env:  []mortisev1alpha1.EnvVar{{Name: "PORT", Value: "8080"}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace}}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var dep appsv1.Deployment
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName, Namespace: envNsProduction}, &dep)).To(Succeed())
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "PORT", Value: "3000"}), "platform value still wins")
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			cond := meta.FindStatusCondition(fresh.Status.Conditions, "EnvKeysReserved")
+			Expect(cond).NotTo(BeNil(), "the ignored declaration must be reported")
+			Expect(cond.Reason).To(Equal("PlatformValueWins"))
+			Expect(cond.Message).To(ContainSubstring("production: PORT"))
+		})
+
 		It("should not change behavior when sharedVars is empty", func() {
 			appName := "shared-vars-empty"
 			app := &mortisev1alpha1.App{

--- a/internal/controller/app_reserved_env.go
+++ b/internal/controller/app_reserved_env.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// reservedEnvKeysCondition reports env var names the platform injects
+// directly on the container, where they beat anything in the derived Secret.
+const reservedEnvKeysCondition = "EnvKeysReserved"
+
+// reservedEnvKeys are set on container.env, which Kubernetes resolves ahead
+// of every envFrom source. A user declaring one of them in spec.env or
+// spec.sharedVars gets it written into the derived Secret, visibly, and
+// the container runs the platform's value anyway -- with nothing saying so
+// (CAI-220). Rejecting at admission is not available (CAI-161), so the
+// controller reports it on the App instead.
+var reservedEnvKeys = map[string]struct{}{"PORT": {}, imageEnvName: {}, revisionEnvName: {}}
+
+func setReservedEnvKeysCondition(conds *[]metav1.Condition, app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment, generation int64) {
+	var parts []string
+	for _, sv := range app.Spec.SharedVars {
+		if _, reserved := reservedEnvKeys[sv.Name]; reserved {
+			parts = append(parts, "sharedVars: "+sv.Name)
+		}
+	}
+	for _, env := range envs {
+		var names []string
+		for _, ev := range env.Env {
+			if _, reserved := reservedEnvKeys[ev.Name]; reserved {
+				names = append(names, ev.Name)
+			}
+		}
+		if len(names) > 0 {
+			parts = append(parts, env.Name+": "+strings.Join(names, ", "))
+		}
+	}
+	if len(parts) == 0 {
+		meta.RemoveStatusCondition(conds, reservedEnvKeysCondition)
+		return
+	}
+	meta.SetStatusCondition(conds, metav1.Condition{
+		Type:               reservedEnvKeysCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             "PlatformValueWins",
+		Message:            fmt.Sprintf("these declared variables are set by Mortise on the container and the declared value is not what the process sees (%s); PORT follows spec.network.port, MORTISE_IMAGE and MORTISE_REVISION are the running build. Remove them from the spec", strings.Join(parts, "; ")),
+		ObservedGeneration: generation,
+	})
+}

--- a/internal/controller/app_reservedenv_test.go
+++ b/internal/controller/app_reservedenv_test.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestSetReservedEnvKeysCondition(t *testing.T) {
+	app := &mortisev1alpha1.App{Spec: mortisev1alpha1.AppSpec{
+		SharedVars: []mortisev1alpha1.EnvVar{{Name: "MORTISE_IMAGE", Value: "x"}, {Name: "LOG_LEVEL", Value: "info"}},
+	}}
+	envs := []mortisev1alpha1.Environment{
+		{Name: "production", Env: []mortisev1alpha1.EnvVar{{Name: "PORT", Value: "8080"}, {Name: "DB", Value: "x"}}},
+		{Name: "staging", Env: []mortisev1alpha1.EnvVar{{Name: "DB", Value: "y"}}},
+	}
+	t.Run("names every reserved declaration by source", func(t *testing.T) {
+		var conds []metav1.Condition
+		setReservedEnvKeysCondition(&conds, app, envs, 4)
+		c := meta.FindStatusCondition(conds, "EnvKeysReserved")
+		if c == nil || c.Status != metav1.ConditionFalse || c.Reason != "PlatformValueWins" || c.ObservedGeneration != 4 {
+			t.Fatalf("got %+v", c)
+		}
+		for _, want := range []string{"sharedVars: MORTISE_IMAGE", "production: PORT"} {
+			if !strings.Contains(c.Message, want) {
+				t.Errorf("message lacks %q: %s", want, c.Message)
+			}
+		}
+		if strings.Contains(c.Message, "staging") || strings.Contains(c.Message, "DB") || strings.Contains(c.Message, "8080") {
+			t.Errorf("message names a non-reserved key, env, or a value: %s", c.Message)
+		}
+	})
+	t.Run("clears when nothing reserved is declared", func(t *testing.T) {
+		conds := []metav1.Condition{{Type: "EnvKeysReserved", Status: metav1.ConditionFalse}}
+		setReservedEnvKeysCondition(&conds, &mortisev1alpha1.App{}, []mortisev1alpha1.Environment{{Name: "production", Env: []mortisev1alpha1.EnvVar{{Name: "DB", Value: "x"}}}}, 1)
+		if meta.FindStatusCondition(conds, "EnvKeysReserved") != nil {
+			t.Fatal("expected cleared")
+		}
+	})
+}


### PR DESCRIPTION
Fixes CAI-220 (option 1, controller-side since admission is gone). `EnvKeysReserved=False / PlatformValueWins` names `PORT` / `MORTISE_IMAGE` / `MORTISE_REVISION` declarations per environment or `sharedVars`; the container's behaviour is unchanged. EnvVar type doc says so. envtest: declared PORT=8080 with network.port 3000 → container has 3000 and the App reports the declaration. Unit test for the condition. `make test` green. CronJob Apps: no PORT injection there today; documented difference stands, out of scope here.