### PR TITLE
fix(envstore): hash env in the order the container resolves it (CAI-178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,15 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   someone read GitHub's delivery log (CAI-261: a month of dead
   push-to-deploy). Apps sourced from the provider now reconcile on that
   Secret's change, and the registration input hash does the rest.
+- **The env hash now tracks the value the container runs** (CAI-178): the
+  pod-template `mortise.dev/env-hash` merged `{app}-env` then `shared-env`,
+  while the container's `envFrom` lists them the other way round and
+  Kubernetes lets the later source win. For a key present in both, changing
+  the value the process actually used never moved the hash, so no rollout
+  fired even with `autoRedeploy: true`. Both now derive from one ordering.
+  **Upgrade consequence:** every App with a colliding key gets a new hash
+  on its next reconcile: with `autoRedeploy: true` it rolls once; otherwise
+  it shows a pending redeploy. Those pods were running the wrong value.
 
 - **Picker-added variables now render immediately** (mo-baq): a variable
   added via the bindings/secret picker was written to the App spec but

--- a/internal/envstore/envstore.go
+++ b/internal/envstore/envstore.go
@@ -83,16 +83,26 @@ func AppEnvSecretName(appName string) string {
 // EnvFromSources returns the envFrom entries for a Deployment container.
 // Order: shared-env (lowest priority) then {app}-env (wins on conflict).
 func EnvFromSources(appName string) []corev1.EnvFromSource {
-	return []corev1.EnvFromSource{
-		{SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: SharedEnvName},
+	names := envSourceNames(appName)
+	sources := make([]corev1.EnvFromSource, 0, len(names))
+	for _, name := range names {
+		sources = append(sources, corev1.EnvFromSource{SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: name},
 			Optional:             boolPtr(true),
-		}},
-		{SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: AppEnvSecretName(appName)},
-			Optional:             boolPtr(true),
-		}},
+		}})
 	}
+	return sources
+}
+
+// envSourceNames is the one ordering of the Secrets a container's env is
+// built from. Kubernetes resolves envFrom collisions in favour of the LATER
+// entry, so {app}-env beats shared-env in the process. EnvFromSources and
+// EnvHash both derive from this list: the hash used to merge in the
+// opposite order, so for a key present in both Secrets the pod-template hash
+// tracked a value the container was not running, and changing the value the
+// container did run never rolled it (CAI-178).
+func envSourceNames(appName string) []string {
+	return []string{SharedEnvName, AppEnvSecretName(appName)}
 }
 
 // Store is the read/write interface for env var Secrets.
@@ -619,20 +629,16 @@ func HashData(data map[string][]byte) string {
 // namespace. Missing Secrets contribute nothing. Read-only.
 func EnvHash(ctx context.Context, reader client.Reader, appName, envNs string) string {
 	combined := make(map[string][]byte)
-
-	var appSecret corev1.Secret
-	if err := reader.Get(ctx, types.NamespacedName{Name: AppEnvSecretName(appName), Namespace: envNs}, &appSecret); err == nil {
-		for k, v := range appSecret.Data {
+	// Same order as the container's envFrom: a later Secret overwrites an
+	// earlier one here exactly as it does in the process.
+	for _, name := range envSourceNames(appName) {
+		var sec corev1.Secret
+		if err := reader.Get(ctx, types.NamespacedName{Name: name, Namespace: envNs}, &sec); err != nil {
+			continue
+		}
+		for k, v := range sec.Data {
 			combined[k] = v
 		}
 	}
-
-	var sharedSecret corev1.Secret
-	if err := reader.Get(ctx, types.NamespacedName{Name: SharedEnvName, Namespace: envNs}, &sharedSecret); err == nil {
-		for k, v := range sharedSecret.Data {
-			combined[k] = v
-		}
-	}
-
 	return HashData(combined)
 }

--- a/internal/envstore/envstore_test.go
+++ b/internal/envstore/envstore_test.go
@@ -504,3 +504,37 @@ func TestEnvHash(t *testing.T) {
 		}
 	})
 }
+
+// A key present in both Secrets must hash to the value envFrom delivers:
+// the later source wins in the container, so it must win in the hash, or a
+// change to the value the process actually runs never rolls it (CAI-178).
+func TestEnvHash_CollidingKeyTracksTheContainerValue(t *testing.T) {
+	ctx := context.Background()
+	shared := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: SharedEnvName, Namespace: "pj-demo-production"},
+		Data:       map[string][]byte{"LOG_LEVEL": []byte("info"), "ONLY_SHARED": []byte("s")},
+	}
+	app := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: AppEnvSecretName("web"), Namespace: "pj-demo-production"},
+		Data:       map[string][]byte{"LOG_LEVEL": []byte("debug"), "ONLY_APP": []byte("a")},
+	}
+	c := fake.NewClientBuilder().WithObjects(shared, app).Build()
+
+	got := EnvHash(ctx, c, "web", "pj-demo-production")
+	want := HashData(map[string][]byte{"LOG_LEVEL": []byte("debug"), "ONLY_SHARED": []byte("s"), "ONLY_APP": []byte("a")})
+	if got != want {
+		t.Fatalf("hash tracks the shared value for a colliding key; container runs the app value")
+	}
+
+	// And the two orderings are one ordering.
+	sources := EnvFromSources("web")
+	names := envSourceNames("web")
+	if len(sources) != len(names) {
+		t.Fatalf("EnvFromSources has %d entries, envSourceNames %d", len(sources), len(names))
+	}
+	for i := range names {
+		if sources[i].SecretRef.Name != names[i] {
+			t.Fatalf("source %d is %q, ordering says %q", i, sources[i].SecretRef.Name, names[i])
+		}
+	}
+}


### PR DESCRIPTION
Fixes CAI-178. `EnvHash` and `EnvFromSources` now derive from one ordering (`envSourceNames`: shared-env, then {app}-env; later wins in both). `TestEnvHash_CollidingKeyTracksTheContainerValue` fails with the old merge order (checked by swapping the order back with the helper in place) and passes with the fix; it also asserts the two orderings are one. **Upgrade consequence** in CHANGELOG: Apps with a colliding key get a new hash on next reconcile (roll with autoRedeploy, pending redeploy otherwise) — they were running the wrong value. `make test` green.