### PR TITLE
feat(controller): report credential-shaped env literals (CAI-155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The App now carries `EnvKeysReserved=False / PlatformValueWins` naming
   the declarations by environment or `sharedVars`. Behaviour is unchanged;
   the silence is gone.
+- **Credential-shaped literals are reported** (CAI-155): `value:` is the
+  obvious shape and every example used it, so credentials landed in the
+  CRD as plaintext by default and were copied into every annotation and
+  dump. An App now carries `PlaintextCredentials=False /
+  LiteralLooksLikeCredential` naming env vars (per environment and
+  `sharedVars`) whose name matches KEY/SECRET/TOKEN/PASSWORD/WEBHOOK but
+  whose value is a literal; PUBLIC/PUBLISHABLE names are exempt, values
+  are never inspected. The way out is `valueFrom.secretRef`.
 
 - **`mortise admin reset-password` and `mortise admin create-user`**
   (CAI-55): cluster-side user administration that needs no API login, for

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -3828,6 +3828,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			meta.RemoveStatusCondition(&fresh.Status.Conditions, "PodHealthy")
 		}
 		setReservedEnvKeysCondition(&fresh.Status.Conditions, app, resolvedEnvs, app.Generation)
+		setPlaintextCredentialsCondition(&fresh.Status.Conditions, app, resolvedEnvs, app.Generation)
 		setEnvRolledOutCondition(&fresh.Status.Conditions, envStatuses, app.Generation)
 		setEnvironmentJoinedCondition(&fresh.Status.Conditions, envStatuses, r.clock().Now(), app.Generation)
 		if buildFailed {

--- a/internal/controller/app_plaintext_credentials.go
+++ b/internal/controller/app_plaintext_credentials.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// plaintextCredentialsCondition reports env vars whose NAME looks like a
+// credential but whose value is a literal in the CRD.
+const plaintextCredentialsCondition = "PlaintextCredentials"
+
+// credentialNamePattern is the name heuristic from CAI-155. Names only;
+// a value heuristic misses every custom format and the name is what the
+// author chose. PUBLIC/PUBLISHABLE names are the deliberate exception:
+// a publishable key is meant to be public and a warning on it trains
+// people to ignore the condition.
+var credentialNamePattern = regexp.MustCompile(`(?i)(^|_)(KEY|SECRET|TOKEN|PASSWORD|PASSWD|WEBHOOK)(_|$)`)
+var publicNamePattern = regexp.MustCompile(`(?i)(^|_)(PUBLIC|PUBLISHABLE)(_|$)`)
+
+func looksLikeCredentialName(name string) bool {
+	return credentialNamePattern.MatchString(name) && !publicNamePattern.MatchString(name)
+}
+
+// setPlaintextCredentialsCondition names credential-shaped env vars carried
+// as literals. `value:` is the obvious shape and every example uses it, so
+// credentials land in the CRD as plaintext by default and are then copied
+// into every annotation and dump of the object. The condition steers the
+// author to valueFrom.secretRef at the moment it is cheap to change.
+func setPlaintextCredentialsCondition(conds *[]metav1.Condition, app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment, generation int64) {
+	var parts []string
+	var shared []string
+	for _, sv := range app.Spec.SharedVars {
+		if sv.ValueFrom == nil && sv.Value != "" && looksLikeCredentialName(sv.Name) {
+			shared = append(shared, sv.Name)
+		}
+	}
+	if len(shared) > 0 {
+		parts = append(parts, "sharedVars: "+strings.Join(shared, ", "))
+	}
+	for _, env := range envs {
+		var names []string
+		for _, ev := range env.Env {
+			if ev.ValueFrom == nil && ev.Value != "" && looksLikeCredentialName(ev.Name) {
+				names = append(names, ev.Name)
+			}
+		}
+		if len(names) > 0 {
+			parts = append(parts, env.Name+": "+strings.Join(names, ", "))
+		}
+	}
+	if len(parts) == 0 {
+		meta.RemoveStatusCondition(conds, plaintextCredentialsCondition)
+		return
+	}
+	meta.SetStatusCondition(conds, metav1.Condition{
+		Type:               plaintextCredentialsCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             "LiteralLooksLikeCredential",
+		Message:            fmt.Sprintf("these variables are named like credentials but carried as literals in the App spec (%s); move each into a Secret and reference it with valueFrom.secretRef. Names only; values are not inspected", strings.Join(parts, "; ")),
+		ObservedGeneration: generation,
+	})
+}

--- a/internal/controller/app_plaintextcreds_test.go
+++ b/internal/controller/app_plaintextcreds_test.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+func TestLooksLikeCredentialName(t *testing.T) {
+	yes := []string{"STRIPE_SECRET_KEY", "SUPABASE_SERVICE_KEY", "ENCRYPTION_KEY", "LINKEDIN_CLIENT_SECRET", "GITHUB_TOKEN", "DB_PASSWORD", "SLACK_WEBHOOK_URL", "API_KEY", "secret"}
+	no := []string{"PORT", "NODE_ENV", "LOG_LEVEL", "FRONTEND_URL", "STRIPE_PUBLISHABLE_KEY", "VAPID_PUBLIC_KEY", "KEYBOARD_LAYOUT", "MONKEY", "TOKENIZER_MODEL"}
+	for _, n := range yes {
+		if !looksLikeCredentialName(n) {
+			t.Errorf("%s should look like a credential", n)
+		}
+	}
+	for _, n := range no {
+		if looksLikeCredentialName(n) {
+			t.Errorf("%s should not look like a credential", n)
+		}
+	}
+}
+
+func TestSetPlaintextCredentialsCondition(t *testing.T) {
+	app := &mortisev1alpha1.App{Spec: mortisev1alpha1.AppSpec{
+		SharedVars: []mortisev1alpha1.EnvVar{{Name: "SENTRY_TOKEN", Value: "x"}, {Name: "LOG_LEVEL", Value: "info"}},
+	}}
+	envs := []mortisev1alpha1.Environment{{
+		Name: "production",
+		Env: []mortisev1alpha1.EnvVar{
+			{Name: "STRIPE_SECRET_KEY", Value: "sk_live_1"},
+			{Name: "PORT", Value: "3000"},
+			{Name: "DB_PASSWORD", ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "db-creds"}},
+			{Name: "STRIPE_PUBLISHABLE_KEY", Value: "pk_live_1"},
+		},
+	}}
+	var conds []metav1.Condition
+	setPlaintextCredentialsCondition(&conds, app, envs, 7)
+	c := meta.FindStatusCondition(conds, "PlaintextCredentials")
+	if c == nil || c.Status != metav1.ConditionFalse || c.Reason != "LiteralLooksLikeCredential" || c.ObservedGeneration != 7 {
+		t.Fatalf("got %+v", c)
+	}
+	for _, want := range []string{"sharedVars: SENTRY_TOKEN", "production: STRIPE_SECRET_KEY"} {
+		if !strings.Contains(c.Message, want) {
+			t.Errorf("message lacks %q: %s", want, c.Message)
+		}
+	}
+	for _, not := range []string{"PORT", "DB_PASSWORD", "PUBLISHABLE", "sk_live", "LOG_LEVEL"} {
+		if strings.Contains(c.Message, not) {
+			t.Errorf("message must not contain %q: %s", not, c.Message)
+		}
+	}
+	clean := []mortisev1alpha1.Environment{{Name: "production", Env: []mortisev1alpha1.EnvVar{{Name: "PORT", Value: "3000"}, {Name: "API_KEY", ValueFrom: &mortisev1alpha1.EnvVarSource{SecretRef: "creds"}}}}}
+	setPlaintextCredentialsCondition(&conds, &mortisev1alpha1.App{}, clean, 8)
+	if meta.FindStatusCondition(conds, "PlaintextCredentials") != nil {
+		t.Fatal("condition must clear once every credential-shaped var is a secretRef")
+	}
+}


### PR DESCRIPTION
Fixes CAI-155 (option 2, status; option 1 needs admission, which is gone). `PlaintextCredentials=False / LiteralLooksLikeCredential` names literal-valued vars whose name matches KEY/SECRET/TOKEN/PASSWORD/WEBHOOK, per env and sharedVars. PUBLIC/PUBLISHABLE exempt; values never inspected; `PORT`/`NODE_ENV`/`FRONTEND_URL` do not warn (tested both directions). Cleared when each is a secretRef. `make test` green.