### PR TITLE
fix(rbac): bind only Secrets and ConfigMaps to the operator in its own namespace (#444, #441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,13 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The operator's grant in its own namespace is narrowed to Secrets and
+  ConfigMaps** (#444, the narrowing half of #441): the release-namespace
+  RoleBinding bound the full workload ClusterRole (Deployments, Services,
+  PVCs, Ingresses, CronJobs, pods/exec) that the operator only needs in
+  `pj-*` namespaces. It now binds a namespaced Role with the two kinds it
+  actually writes there. No behaviour change; a smaller blast radius.
+
 - **Stateful Apps no longer get a default liveness probe** (CAI-159). An
   App that declares `storage[]` and no explicit `livenessProbe` now runs
   without one, matching what Kubernetes does unless asked. The injected

--- a/charts/mortise-core/templates/rbac.yaml
+++ b/charts/mortise-core/templates/rbac.yaml
@@ -197,8 +197,23 @@ subjects:
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 ---
-# Static RoleBinding in the operator namespace so it can manage its own
-# secrets (GitHub OAuth client secret, etc.).
+# In its own namespace the operator writes only Secrets (users, tokens, the
+# JWT key, git-provider webhook secrets, registry credentials) and
+# ConfigMaps (activity store). It used to bind the full mortise-controller-ns
+# ClusterRole here -- Deployments, Services, PVCs, Ingresses, CronJobs,
+# pods/exec -- none of which it manages in the release namespace (#444,
+# #441's narrowing half). Workload namespaces still get the ClusterRole via
+# the per-project RoleBinding the Project controller creates.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mortise-operator-ns
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["create", "update", "patch", "delete"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -206,8 +221,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: mortise-controller-ns
+  kind: Role
+  name: mortise-operator-ns
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}


### PR DESCRIPTION
CAI-9 lane b2.5, re-anchored. Of its four items, three are already on main (finalizers drift fixed, self-grant caveat documented in rbac.yaml, tgz generated from source); this is the fourth: the release-namespace RoleBinding bound the full workload ClusterRole. Now a namespaced Role with secrets+configmaps CRUD. Checked: pods/exec targets pj-* pods only; the chart does not enable leader election. `make test-charts` passes; the Integration job installs this chart and runs the operator against it, which is the runtime check.