### PR TITLE
fix(controller): report a registry target failure instead of skipping the env (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A registry target failure is reported** (#444): when the registry
+  backend could not produce a push or pull image reference, the
+  environment was skipped with a log line and the App stayed `Ready` on
+  its previous image indefinitely. The App now carries
+  `RegistryTargetValid=False / RegistryTargetInvalid` naming the env and
+  the error, and the reconcile requeues; the condition clears when a
+  target resolves again.
+
 - **A changed webhook Secret now re-registers every hook that used it**
   (CAI-262): the GitProvider's HMAC Secret was watched by nothing, so
   recreating it left every registered GitHub hook delivering with the old

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1031,14 +1031,13 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 
 	imageRef, err := r.RegistryBackend.PushTarget(app.Name, envImageTag(revision, envName))
 	if err != nil {
-		log.Error(err, "push target failed", "env", envName)
-		return "", false, false, false, nil
+		return "", false, false, false, r.setRegistryTargetCondition(ctx, app, envName, "push", err)
 	}
 	pullRef, err := r.RegistryBackend.PullTarget(app.Name, envImageTag(revision, envName))
 	if err != nil {
-		log.Error(err, "pull target failed", "env", envName)
-		return "", false, false, false, nil
+		return "", false, false, false, r.setRegistryTargetCondition(ctx, app, envName, "pull", err)
 	}
+	r.clearRegistryTargetCondition(ctx, app)
 	desiredRunSpec := appBuildRunSpec(app, envName, branch, revision, imageRef.Full, pullRef.Full)
 
 	// Short-circuit: skip rebuild if we already built this revision for this env

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -4611,6 +4611,7 @@ func TestIsTerminalBuildFailureCondition(t *testing.T) {
 
 // fakeRegistryBackend implements registry.RegistryBackend for tests.
 type fakeRegistryBackend struct {
+	targetErr      error // when set, PushTarget/PullTarget fail with it
 	imageRef       registry.ImageRef
 	pullSecretName string
 	resolveDigest  string
@@ -4619,6 +4620,9 @@ type fakeRegistryBackend struct {
 }
 
 func (f *fakeRegistryBackend) PushTarget(app, tag string) (registry.ImageRef, error) {
+	if f.targetErr != nil {
+		return registry.ImageRef{}, f.targetErr
+	}
 	if f.imageRef.Full != "" {
 		return f.imageRef, nil
 	}
@@ -8701,6 +8705,45 @@ var _ = Describe("App Controller — git source", func() {
 			envVars := dep.Spec.Template.Spec.Containers[0].Env
 			Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "MORTISE_REVISION", Value: "abc123"}))
 			Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "MORTISE_IMAGE", Value: dep.Spec.Template.Spec.Containers[0].Image}))
+		})
+
+		It("reports a registry target failure instead of silently skipping the env (#444)", func() {
+			ctx := context.Background()
+			gp := &mortisev1alpha1.GitProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "gh-regtarget"},
+				Spec:       mortisev1alpha1.GitProviderSpec{Type: mortisev1alpha1.GitProviderTypeGitHub, Host: "https://github.com", ClientID: "test-client-id"},
+			}
+			Expect(k8sClient.Create(ctx, gp)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, gp)).To(Succeed()) }()
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-gh-regtarget-token-74657374406578616d706c652e636f6d", Namespace: "mortise-system"},
+				Data:       map[string][]byte{"token": []byte("tok")},
+			}
+			Expect(k8sClient.Create(ctx, tokenSecret)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, tokenSecret)).To(Succeed()) }()
+
+			bc := &fakeBuildClient{digest: "sha256:never"}
+			r := gitSourceReconciler(bc, &fakeGitClient{}, &fakeRegistryBackend{targetErr: fmt.Errorf("registry URL not configured")})
+
+			app := makeGitSourceApp("regtarget-app", namespace, "gh-regtarget")
+			app.Annotations["mortise.dev/revision"] = "abc123"
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(app)}
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).To(HaveOccurred(), "a registry misconfiguration must requeue, not vanish")
+			Expect(err.Error()).To(ContainSubstring("registry push target"))
+
+			var fresh mortisev1alpha1.App
+			Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+			cond := meta.FindStatusCondition(fresh.Status.Conditions, "RegistryTargetValid")
+			Expect(cond).NotTo(BeNil(), "the failure must be on the App, not only in the log")
+			Expect(cond.Reason).To(Equal("RegistryTargetInvalid"))
+			Expect(cond.Message).To(ContainSubstring("production"))
+			bc.mu.Lock()
+			Expect(bc.requests).To(BeEmpty(), "no build can be submitted without a target")
+			bc.mu.Unlock()
 		})
 
 		It("passes per-environment build args to the build client", func() {

--- a/internal/controller/app_registry_target.go
+++ b/internal/controller/app_registry_target.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// registryTargetCondition reports that the registry backend could not
+// produce a push or pull image reference for a build. The env used to be
+// skipped with only a log line, so a persistent registry misconfiguration
+// left the App Ready on its last image indefinitely (#444). Its own
+// condition type, not BuildSucceeded: that one short-circuits future builds
+// until a manual rebuild, and a registry fix should resume them on its own.
+const registryTargetCondition = "RegistryTargetValid"
+
+func (r *AppReconciler) setRegistryTargetCondition(ctx context.Context, app *mortisev1alpha1.App, envName, which string, cause error) error {
+	msg := fmt.Sprintf("registry %s target for env %s: %v; check PlatformConfig spec.registry", which, envName, cause)
+	if err := r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:               registryTargetCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "RegistryTargetInvalid",
+			Message:            msg,
+			ObservedGeneration: app.Generation,
+		})
+	}); err != nil {
+		return fmt.Errorf("record registry target failure: %w (cause: %v)", err, cause)
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func (r *AppReconciler) clearRegistryTargetCondition(ctx context.Context, app *mortisev1alpha1.App) {
+	if meta.FindStatusCondition(app.Status.Conditions, registryTargetCondition) == nil {
+		return
+	}
+	_ = r.updateAppStatus(ctx, app, func(status *mortisev1alpha1.AppStatus) {
+		meta.RemoveStatusCondition(&status.Conditions, registryTargetCondition)
+	})
+}

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -699,14 +699,14 @@ func (r *ProjectReconciler) ensureProjectCreateActivity(ctx context.Context, pro
 		return nil
 	}
 
-	if err := r.appendProjectCreateActivityIfMissing(ctx, projectCreateActivityEvent(project)); err != nil {
+	if err := r.appendProjectCreateActivityIfMissing(ctx, projectCreateActivityEvent(project, r.clock().Now())); err != nil {
 		return fmt.Errorf("append project activity: %w", err)
 	}
 	return r.markProjectCreateActivityRecorded(ctx, project.Name)
 }
 
-func projectCreateActivityEvent(project *mortisev1alpha1.Project) activity.Event {
-	ts := time.Now().UTC()
+func projectCreateActivityEvent(project *mortisev1alpha1.Project, now time.Time) activity.Event {
+	ts := now.UTC()
 	if !project.CreationTimestamp.IsZero() {
 		ts = project.CreationTimestamp.UTC()
 	}


### PR DESCRIPTION
Two #444 controller items. (1) `RegistryTargetValid=False / RegistryTargetInvalid` on the App when PushTarget/PullTarget fail, with requeue; clears on success; own condition type so a fixed registry resumes builds without a manual rebuild. envtest: failing fake registry → reconcile error, condition set, no build submitted. (2) Project controller's bare `time.Now()` takes the injected clock. Left open on #444: the whole-slice build-status flush.