### PR TITLE
fix(controller): merge per-env build fields on flush instead of the whole slice (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,11 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `RegistryTargetValid=False / RegistryTargetInvalid` naming the env and
   the error, and the reconcile requeues; the condition clears when a
   target resolves again.
+- **The build-status flush no longer overwrites concurrent status writes**
+  (#444): after the environment loop the controller assigned its whole
+  in-memory `status.environments` over a freshly read status, so hashes,
+  replica counts and anything a concurrent writer had just set could be
+  stomped. It now merges only the build fields per environment.
 
 - **A changed webhook Secret now re-registers every hook that used it**
   (CAI-262): the GitProvider's HMAC Secret was watched by nothing, so

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -408,7 +408,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			status.LastBuiltSHA = app.Status.LastBuiltSHA
 			status.LastBuiltImage = app.Status.LastBuiltImage
 			status.DetectedPort = app.Status.DetectedPort
-			status.Environments = app.Status.Environments
+			mergeEnvBuildFields(&status.Environments, app.Status.Environments)
 			status.CurrentBuildRunName, status.LastBuildRunName = aggregateAppBuildRunNames(status.Environments)
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("flush build status after env loop: %w", err)
@@ -5003,4 +5003,31 @@ func setEnvironmentJoinedCondition(conds *[]metav1.Condition, envStatuses []mort
 		Message:            fmt.Sprintf("this App started participating in: %s; workloads are created in the environment's namespace. If this followed deleting a spec.environments[] block, that block held enabled: false -- restore it to opt out", strings.Join(recent, ", ")),
 		ObservedGeneration: generation,
 	})
+}
+
+// mergeEnvBuildFields copies the per-environment fields the build path
+// mutates in memory onto a freshly read status. The flush used to assign
+// the whole in-memory Environments slice, which stomped anything a
+// concurrent status writer (a BuildRun projection, a redeploy) had changed
+// on the other fields between the read and the flush (#444). Environments
+// the fresh status does not know yet are appended.
+func mergeEnvBuildFields(dst *[]mortisev1alpha1.EnvironmentStatus, src []mortisev1alpha1.EnvironmentStatus) {
+	byName := make(map[string]int, len(*dst))
+	for i := range *dst {
+		byName[(*dst)[i].Name] = i
+	}
+	for _, se := range src {
+		i, ok := byName[se.Name]
+		if !ok {
+			*dst = append(*dst, se)
+			continue
+		}
+		de := &(*dst)[i]
+		de.Phase = se.Phase
+		de.Message = se.Message
+		de.LastBuiltSHA = se.LastBuiltSHA
+		de.LastBuiltImage = se.LastBuiltImage
+		de.CurrentBuildRunRef = se.CurrentBuildRunRef
+		de.LastSuccessfulBuildRunRef = se.LastSuccessfulBuildRunRef
+	}
 }

--- a/internal/controller/app_flush_merge_test.go
+++ b/internal/controller/app_flush_merge_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"testing"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// The flush after the env loop must carry the build fields without
+// discarding what a concurrent status writer changed elsewhere (#444).
+func TestMergeEnvBuildFields(t *testing.T) {
+	fresh := []mortisev1alpha1.EnvironmentStatus{{
+		Name: "production", Phase: mortisev1alpha1.AppPhaseReady, ReadyReplicas: 2,
+		PendingEnvHash: "p1", DeployedEnvHash: "d1", // written concurrently
+		LastBuiltSHA: "old",
+	}}
+	inMemory := []mortisev1alpha1.EnvironmentStatus{
+		{Name: "production", Phase: mortisev1alpha1.AppPhaseBuilding, Message: "building revision new", LastBuiltSHA: "new", LastBuiltImage: "img:new",
+			LastSuccessfulBuildRunRef: &mortisev1alpha1.BuildRunReference{Name: "br-new"}},
+		{Name: "staging", Phase: mortisev1alpha1.AppPhaseBuilding, LastBuiltSHA: "new"},
+	}
+	mergeEnvBuildFields(&fresh, inMemory)
+
+	if len(fresh) != 2 {
+		t.Fatalf("expected the unknown env appended, got %d envs", len(fresh))
+	}
+	prod := fresh[0]
+	if prod.LastBuiltSHA != "new" || prod.LastBuiltImage != "img:new" || prod.Phase != mortisev1alpha1.AppPhaseBuilding || prod.LastSuccessfulBuildRunRef == nil || prod.LastSuccessfulBuildRunRef.Name != "br-new" {
+		t.Fatalf("build fields not carried: %+v", prod)
+	}
+	if prod.PendingEnvHash != "p1" || prod.DeployedEnvHash != "d1" || prod.ReadyReplicas != 2 {
+		t.Fatalf("concurrently written fields were stomped: %+v", prod)
+	}
+	if fresh[1].Name != "staging" || fresh[1].LastBuiltSHA != "new" {
+		t.Fatalf("appended env wrong: %+v", fresh[1])
+	}
+}


### PR DESCRIPTION
Last open controller item on #444. `mergeEnvBuildFields` replaces the whole-slice assignment in the post-env-loop flush: build fields (phase, message, lastBuiltSHA/Image, BuildRun refs) are copied per env by name; unknown envs appended; everything else on the fresh status (hashes, replicas, joinedAt…) survives. Unit test covers both. `make test` green.