### PR TITLE
test(e2e): exact: true on every literal-named button/link role selector (#442)

### DIFF
--- a/ui/tests/e2e/apps.spec.ts
+++ b/ui/tests/e2e/apps.spec.ts
@@ -61,7 +61,7 @@ test.describe('new app modal structure', () => {
 
 		// App name input and Create button.
 		await expect(page.getByText('App name')).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Create app' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Create app', exact: true })).toBeVisible();
 	});
 
 	test('selecting Database shows preset grid', async ({ page }) => {
@@ -86,7 +86,7 @@ test.describe('new app modal structure', () => {
 		await page.getByText('Docker Image', { exact: true }).click();
 
 		// Configure pane is shown.
-		await expect(page.getByRole('button', { name: 'Create app' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Create app', exact: true })).toBeVisible();
 
 		// Click "← Back" to return to type picker.
 		await page.getByRole('button', { name: /Back/ }).click();
@@ -103,7 +103,7 @@ test.describe('new app modal structure', () => {
 		await expect(page.getByText('Docker Image', { exact: true })).toBeVisible({ timeout: 10_000 });
 		await page.getByText('Docker Image', { exact: true }).click();
 
-		await page.getByRole('button', { name: 'Cancel' }).click();
+		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/projects/${project}(\\?|$)`), { timeout: 10_000 });
 	});
@@ -135,7 +135,7 @@ test.describe('deploy docker image', () => {
 		await page.getByText('Docker Image', { exact: true }).click();
 
 		// Create button should be disabled when no app name is provided.
-		const createBtn = page.getByRole('button', { name: 'Create app' });
+		const createBtn = page.getByRole('button', { name: 'Create app', exact: true });
 		await expect(createBtn).toBeDisabled();
 	});
 
@@ -151,7 +151,7 @@ test.describe('deploy docker image', () => {
 		await page.getByPlaceholder('nginx:1.27 or ghcr.io/org/app:latest').fill('nginx:1.27');
 		await page.getByPlaceholder('my-app').fill(appName);
 
-		const createBtn = page.getByRole('button', { name: 'Create app' });
+		const createBtn = page.getByRole('button', { name: 'Create app', exact: true });
 		await expect(createBtn).toBeEnabled();
 		await createBtn.click();
 
@@ -193,7 +193,7 @@ test.describe('deploy database preset', () => {
 		await expect(appNameInput).toHaveValue('postgres');
 
 		// Create button should be enabled.
-		await expect(page.getByRole('button', { name: 'Create app' })).toBeEnabled();
+		await expect(page.getByRole('button', { name: 'Create app', exact: true })).toBeEnabled();
 	});
 
 	test('select Redis preset, prefills app name', async ({ page }) => {
@@ -309,11 +309,11 @@ test.describe('app drawer', () => {
 		await expect(page.getByRole('heading', { name: appName })).toBeVisible({ timeout: 10_000 });
 
 		// All five tab buttons.
-		await expect(page.getByRole('button', { name: 'Deployments' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Variables' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Deploy Logs' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Metrics' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Deployments', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Variables', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Deploy Logs', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Metrics', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible();
 	});
 
 	test('close button navigates back to project canvas', async ({ page }) => {
@@ -323,7 +323,7 @@ test.describe('app drawer', () => {
 		await expect(page.getByRole('heading', { name: appName })).toBeVisible({ timeout: 10_000 });
 
 		// Close button (X icon, aria-label="Close drawer").
-		await page.getByRole('button', { name: 'Close drawer' }).click();
+		await page.getByRole('button', { name: 'Close drawer', exact: true }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/projects/${project}(\\?|$)`), { timeout: 5_000 });
 	});
@@ -334,7 +334,7 @@ test.describe('app drawer', () => {
 
 		await expect(page.getByRole('heading', { name: appName })).toBeVisible({ timeout: 10_000 });
 
-		await page.getByRole('button', { name: 'Variables' }).click();
+		await page.getByRole('button', { name: 'Variables', exact: true }).click();
 
 		// Variables tab content should appear — "Runtime - <env>" section heading is visible.
 		await expect(page.getByText(/Runtime -/)).toBeVisible({ timeout: 5_000 });

--- a/ui/tests/e2e/auth.spec.ts
+++ b/ui/tests/e2e/auth.spec.ts
@@ -54,7 +54,7 @@ test.describe('login page', () => {
 		await expect(page.getByText('Sign in to your platform')).toBeVisible();
 		await expect(page.getByLabel('Username')).toBeVisible();
 		await expect(page.getByLabel('Password')).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible();
 	});
 
 	test('successful login redirects to / and stores mortise_token', async ({ page }) => {
@@ -65,7 +65,7 @@ test.describe('login page', () => {
 
 		await Promise.all([
 			page.waitForURL((url) => url.pathname === '/'),
-			page.getByRole('button', { name: 'Sign in' }).click()
+			page.getByRole('button', { name: 'Sign in', exact: true }).click()
 		]);
 
 		const token = await page.evaluate(() => localStorage.getItem('mortise_token'));
@@ -80,7 +80,7 @@ test.describe('login page', () => {
 
 		await Promise.all([
 			page.waitForURL((url) => url.pathname === '/'),
-			page.getByRole('button', { name: 'Sign in' }).click()
+			page.getByRole('button', { name: 'Sign in', exact: true }).click()
 		]);
 
 		// After login, the Settings link should be visible for admin.
@@ -108,7 +108,7 @@ test.describe('login page', () => {
 
 		await page.getByLabel('Username').fill('wrong@example.com');
 		await page.getByLabel('Password').fill('wrongpassword');
-		await page.getByRole('button', { name: 'Sign in' }).click();
+		await page.getByRole('button', { name: 'Sign in', exact: true }).click();
 
 		// The server returns an error; the page renders it as a text-danger paragraph.
 		await expect(page.locator('p.text-danger')).toBeVisible({ timeout: 5_000 });
@@ -172,6 +172,6 @@ test.describe('getting started page', () => {
 		await expect(page.getByText('HTTPS, storage, registry')).toBeVisible();
 
 		await expect(page.getByRole('button', { name: /Go to Dashboard/, exact: false })).toBeVisible();
-		await expect(page.getByRole('link', { name: 'Settings' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Settings', exact: true })).toBeVisible();
 	});
 });

--- a/ui/tests/e2e/build-and-deploy.spec.ts
+++ b/ui/tests/e2e/build-and-deploy.spec.ts
@@ -50,7 +50,7 @@ test.describe('build and deploy', () => {
 		await page.getByPlaceholder('my-app').fill(appName);
 
 		// Create the app
-		const createBtn = page.getByRole('button', { name: 'Create app' });
+		const createBtn = page.getByRole('button', { name: 'Create app', exact: true });
 		await expect(createBtn).toBeEnabled();
 		await createBtn.click();
 
@@ -92,7 +92,7 @@ test.describe('build and deploy', () => {
 		await page.getByPlaceholder('nginx:1.27 or ghcr.io/org/app:latest').fill('nginx:1.27');
 		await page.getByPlaceholder('my-app').fill(appName);
 
-		await page.getByRole('button', { name: 'Create app' }).click();
+		await page.getByRole('button', { name: 'Create app', exact: true }).click();
 
 		// Drawer opens showing the new app
 		await expect(page.getByRole('heading', { name: appName })).toBeVisible({

--- a/ui/tests/e2e/deploy-tokens.spec.ts
+++ b/ui/tests/e2e/deploy-tokens.spec.ts
@@ -66,7 +66,7 @@ test.describe('deploy tokens', () => {
 		await expect(page.locator('text=/mrt_[0-9a-f]+/')).toBeVisible({ timeout: 3_000 });
 
 		// Copy button should be present.
-		await expect(page.getByRole('button', { name: 'Copy token' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Copy token', exact: true })).toBeVisible();
 
 		// Verify the token was persisted via API.
 		const tokens = await listTokensViaAPI(request, adminToken, projectName, appName);

--- a/ui/tests/e2e/domains.spec.ts
+++ b/ui/tests/e2e/domains.spec.ts
@@ -98,7 +98,7 @@ test.describe('domains', () => {
 
 		// Click "Remove" next to the domain.
 		const domainRow = page.locator('.rounded-md').filter({ hasText: existingDomain });
-		await domainRow.getByRole('button', { name: 'Remove' }).click();
+		await domainRow.getByRole('button', { name: 'Remove', exact: true }).click();
 
 		// Domain should disappear from the UI.
 		await expect(page.getByText(existingDomain)).not.toBeVisible({ timeout: 5_000 });

--- a/ui/tests/e2e/environments.spec.ts
+++ b/ui/tests/e2e/environments.spec.ts
@@ -221,12 +221,12 @@ test.describe('project settings environments tab (real backend)', () => {
 
     // Navigate to Environments tab.
     await page.getByRole('button', { name: 'Environments', exact: true }).click();
-    await expect(page.getByRole('button', { name: 'New environment' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'New environment', exact: true })).toBeVisible({
       timeout: 10_000
     });
 
     // --- Invalid DNS label is rejected client-side.
-    await page.getByRole('button', { name: 'New environment' }).click();
+    await page.getByRole('button', { name: 'New environment', exact: true }).click();
     const nameInput = page.locator('input#new-env');
     await expect(nameInput).toBeVisible();
     await nameInput.fill('Bad_Name');
@@ -248,7 +248,7 @@ test.describe('project settings environments tab (real backend)', () => {
     await expect(main.getByText('staging', { exact: true })).toBeVisible();
 
     // --- Reorder: move staging up so it's before production.
-    const upOnStaging = main.getByRole('button', { name: 'Move up' }).last();
+    const upOnStaging = main.getByRole('button', { name: 'Move up', exact: true }).last();
     await upOnStaging.click();
     // Reload so the navbar re-queries the persisted order (the navbar seeds
     // `projectEnvs` once in $effect on mount).
@@ -266,7 +266,7 @@ test.describe('project settings environments tab (real backend)', () => {
     await page.keyboard.press('Escape');
     await page.goto(`/projects/${project}/settings`);
     await page.getByRole('button', { name: 'Environments', exact: true }).click();
-    await expect(page.getByRole('button', { name: 'New environment' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'New environment', exact: true })).toBeVisible({
       timeout: 10_000
     });
 
@@ -336,7 +336,7 @@ test.describe('app drawer env interpolation', () => {
     await waitForAppCurrentImage(request, token, project, appName);
     await injectToken(page, token);
     await page.goto(`/projects/${project}/apps/${appName}`);
-    await expect(page.getByRole('button', { name: 'Close drawer' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'Close drawer', exact: true })).toBeVisible({
       timeout: 15_000
     });
 
@@ -482,7 +482,7 @@ test.describe('app drawer respects ?env= on open', () => {
       { project }
     );
     await page.goto(`/projects/${project}/apps/${appName}?env=staging`);
-    await expect(page.getByRole('button', { name: 'Close drawer' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'Close drawer', exact: true })).toBeVisible({
       timeout: 15_000
     });
 
@@ -524,7 +524,7 @@ test.describe('variables tab has no project-level section', () => {
   test('variables tab shows project-scoped variables section', async ({ page }) => {
     await injectToken(page, token);
     await page.goto(`/projects/${project}/apps/${appName}`);
-    await expect(page.getByRole('button', { name: 'Close drawer' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'Close drawer', exact: true })).toBeVisible({
       timeout: 15_000
     });
 
@@ -579,7 +579,7 @@ test.describe('drawer tabs show env selector with multi-env', () => {
   }) => {
     await injectToken(page, token);
     await page.goto(`/projects/${project}/apps/${appName}`);
-    await expect(page.getByRole('button', { name: 'Close drawer' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'Close drawer', exact: true })).toBeVisible({
       timeout: 15_000
     });
 
@@ -596,7 +596,7 @@ test.describe('drawer tabs show env selector with multi-env', () => {
   test('logs tab renders env pills that scope the log stream URL', async ({ page }) => {
     await injectToken(page, token);
     await page.goto(`/projects/${project}/apps/${appName}`);
-    await expect(page.getByRole('button', { name: 'Close drawer' })).toBeVisible({
+    await expect(page.getByRole('button', { name: 'Close drawer', exact: true })).toBeVisible({
       timeout: 15_000
     });
 

--- a/ui/tests/e2e/journey.spec.ts
+++ b/ui/tests/e2e/journey.spec.ts
@@ -52,14 +52,14 @@ test.describe('full user journey', () => {
 
 		// ── Step 2: Create a project via the UI ──────────────────────
 		// "New Project" link is admin-only in the dashboard header.
-		await page.getByRole('link', { name: 'New Project' }).click();
+		await page.getByRole('link', { name: 'New Project', exact: true }).click();
 		await expect(page).toHaveURL('/projects/new');
 		await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible();
 
 		await page.getByLabel('Project name').fill(projectName);
 		await page.getByLabel('Description').fill('Journey test project');
 
-		await page.getByRole('button', { name: 'Create project' }).click();
+		await page.getByRole('button', { name: 'Create project', exact: true }).click();
 
 		// Should redirect to the project canvas page.
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}(\\?|$)`), { timeout: 10_000 });
@@ -90,7 +90,7 @@ test.describe('full user journey', () => {
 		await page.getByPlaceholder('nginx:1.27 or ghcr.io/org/app:latest').fill('nginx:1.27');
 		await page.getByPlaceholder('my-app').fill(appName);
 
-		await page.getByRole('button', { name: 'Create app' }).click();
+		await page.getByRole('button', { name: 'Create app', exact: true }).click();
 
 		// After creation, navigates to the app drawer URL.
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}/apps/${appName}(\\?|$)`), { timeout: 15_000 });
@@ -105,7 +105,7 @@ test.describe('full user journey', () => {
 		await expect(phaseBadge.first()).toBeVisible({ timeout: 15_000 });
 
 		// ── Step 5: Check Variables tab ───────────────────────────────
-		await page.getByRole('button', { name: 'Variables' }).click();
+		await page.getByRole('button', { name: 'Variables', exact: true }).click();
 		// Actual empty state text in VariablesTab.
 		await expect(page.getByText(/No variables set/).first()).toBeVisible({ timeout: 5_000 });
 
@@ -142,7 +142,7 @@ test.describe('full user journey', () => {
 		await page.getByPlaceholder('Filter settings…').clear();
 
 		// ── Step 7: Close drawer, return to canvas ────────────────────
-		await page.getByRole('button', { name: 'Close drawer' }).click();
+		await page.getByRole('button', { name: 'Close drawer', exact: true }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}(\\?|$)`), { timeout: 5_000 });
 
@@ -154,11 +154,11 @@ test.describe('full user journey', () => {
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}/settings(\\?|$)`));
 
 		// Navigate to the Danger tab.
-		await page.getByRole('button', { name: 'Danger' }).click();
+		await page.getByRole('button', { name: 'Danger', exact: true }).click();
 
 		// Type project name into confirmation input and delete.
 		await page.getByPlaceholder(projectName).fill(projectName);
-		await page.getByRole('button', { name: 'Delete project' }).click();
+		await page.getByRole('button', { name: 'Delete project', exact: true }).click();
 
 		// Should redirect to dashboard.
 		await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 });
@@ -194,7 +194,7 @@ test.describe('sign out journey', () => {
 		await userMenuBtn.click();
 
 		// Click "Sign out" in the dropdown.
-		await page.getByRole('button', { name: 'Sign out' }).click();
+		await page.getByRole('button', { name: 'Sign out', exact: true }).click();
 
 		// Should redirect to login.
 		await expect(page).toHaveURL('/login', { timeout: 5_000 });
@@ -287,7 +287,7 @@ test.describe('app creation via modal journey', () => {
 		await page.getByPlaceholder('my-app').fill(appName);
 
 		// Create the app.
-		await page.getByRole('button', { name: 'Create app' }).click();
+		await page.getByRole('button', { name: 'Create app', exact: true }).click();
 
 		// Should navigate to the app drawer URL.
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}/apps/${appName}(\\?|$)`), { timeout: 15_000 });
@@ -296,12 +296,12 @@ test.describe('app creation via modal journey', () => {
 		await expect(page.getByRole('heading', { name: appName })).toBeVisible({ timeout: 10_000 });
 
 		// Switch tabs to verify they work.
-		await page.getByRole('button', { name: 'Deployments' }).click();
-		await page.getByRole('button', { name: 'Variables' }).click();
+		await page.getByRole('button', { name: 'Deployments', exact: true }).click();
+		await page.getByRole('button', { name: 'Variables', exact: true }).click();
 		await expect(page.getByText(/No variables set/).first()).toBeVisible({ timeout: 5_000 });
 
 		// Close the drawer.
-		await page.getByRole('button', { name: 'Close drawer' }).click();
+		await page.getByRole('button', { name: 'Close drawer', exact: true }).click();
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}(\\?|$)`), { timeout: 5_000 });
 
 		// Switch to list view and verify the app appears.

--- a/ui/tests/e2e/navigation.spec.ts
+++ b/ui/tests/e2e/navigation.spec.ts
@@ -57,7 +57,7 @@ test.describe('left rail navigation', () => {
 		await page.goto('/extensions');
 		await expect(page.getByRole('heading', { name: 'Extensions' })).toBeVisible();
 
-		await page.getByRole('link', { name: 'Mortise' }).click();
+		await page.getByRole('link', { name: 'Mortise', exact: true }).click();
 
 		await expect(page).toHaveURL('/');
 	});
@@ -96,7 +96,7 @@ test.describe('left rail navigation', () => {
 		await page.locator('header button[title="User"], header button').filter({ has: page.locator('svg') }).last().click();
 
 		// Click "Sign out" in the dropdown.
-		await page.getByRole('button', { name: 'Sign out' }).click();
+		await page.getByRole('button', { name: 'Sign out', exact: true }).click();
 
 		await expect(page).toHaveURL('/login', { timeout: 5_000 });
 
@@ -167,7 +167,7 @@ test.describe('project scope left rail', () => {
 
 		await expect(page).toHaveURL(new RegExp(`/projects/${name}/settings(\\?|$)`));
 		// Project settings page has no top-level heading; verify the General tab button.
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible();
 	});
 });
 
@@ -298,7 +298,7 @@ test.describe('extensions page', () => {
 
 		// cert-manager card should have a "Docs" link pointing to the cert-manager site.
 		const certManagerCard = page.locator('.rounded-lg').filter({ has: page.getByRole('heading', { name: 'cert-manager' }) });
-		const docsLink = certManagerCard.getByRole('link', { name: 'Docs' });
+		const docsLink = certManagerCard.getByRole('link', { name: 'Docs', exact: true });
 		await expect(docsLink).toBeVisible();
 		await expect(docsLink).toHaveAttribute('href', 'https://cert-manager.io/docs/');
 	});

--- a/ui/tests/e2e/project-members-and-envs.spec.ts
+++ b/ui/tests/e2e/project-members-and-envs.spec.ts
@@ -58,7 +58,7 @@ test.describe('project settings: members tab', () => {
 	test('members tab shows empty state when no members have been added', async ({ page }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -75,7 +75,7 @@ test.describe('project settings: members tab', () => {
 	test('add a member, verify they appear in the list, then remove them', async ({ page }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -121,7 +121,7 @@ test.describe('project settings: members tab', () => {
 	test('adding a non-existent user shows an error', async ({ page }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -158,7 +158,7 @@ test.describe('project settings: PR environments', () => {
 	test('PR environments toggle enables preview and persists', async ({ page, request }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -205,7 +205,7 @@ test.describe('project settings: danger zone', () => {
 
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -213,7 +213,7 @@ test.describe('project settings: danger zone', () => {
 		await page.getByRole('button', { name: 'Danger', exact: true }).click();
 
 		// The delete button starts disabled.
-		const deleteBtn = page.getByRole('button', { name: 'Delete project' });
+		const deleteBtn = page.getByRole('button', { name: 'Delete project', exact: true });
 		await expect(deleteBtn).toBeDisabled({ timeout: 5_000 });
 
 		// Type the project name into the confirmation input.

--- a/ui/tests/e2e/project-settings.spec.ts
+++ b/ui/tests/e2e/project-settings.spec.ts
@@ -42,7 +42,7 @@ test.describe('project settings', () => {
 		await page.goto(`/projects/${projectName}/settings`);
 
 		// Wait for the tabbed settings page to load (General tab is the default).
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -62,13 +62,13 @@ test.describe('project settings', () => {
 		await expect(descInput).toHaveValue('Initial description');
 
 		// Save button.
-		await expect(page.getByRole('button', { name: 'Save changes' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Save changes', exact: true })).toBeVisible();
 	});
 
 	test('project admin updates the project description', async ({ page, request }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -76,16 +76,16 @@ test.describe('project settings', () => {
 		await descInput.clear();
 		await descInput.fill('Updated description for E2E test');
 
-		await page.getByRole('button', { name: 'Save changes' }).click();
+		await page.getByRole('button', { name: 'Save changes', exact: true }).click();
 
 		// The button should complete (no spinner remaining or back to normal text).
-		await expect(page.getByRole('button', { name: 'Save changes' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'Save changes', exact: true })).toBeVisible({
 			timeout: 5_000
 		});
 
 		// Verify the description persisted by reloading.
 		await page.reload();
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 		await expect(descInput).toHaveValue('Updated description for E2E test');
@@ -102,7 +102,7 @@ test.describe('project settings', () => {
 	test('project admin sees PR Environments section with toggle', async ({ page }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -118,7 +118,7 @@ test.describe('project settings', () => {
 	test('project admin can enable PR environments and configure source env', async ({ page }) => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -139,7 +139,7 @@ test.describe('project settings', () => {
 
 		// Reload and verify toggle state persisted.
 		await page.reload();
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 		const toggleAfterReload = page.getByRole('switch', { name: 'Toggle PR environments' });
@@ -150,7 +150,7 @@ test.describe('project settings', () => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
 
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -165,7 +165,7 @@ test.describe('project settings', () => {
 		await expect(page.getByPlaceholder(projectName)).toBeVisible();
 
 		// Delete button is disabled when input is empty.
-		const deleteBtn = page.getByRole('button', { name: 'Delete project' });
+		const deleteBtn = page.getByRole('button', { name: 'Delete project', exact: true });
 		await expect(deleteBtn).toBeDisabled();
 	});
 
@@ -173,7 +173,7 @@ test.describe('project settings', () => {
 		await injectToken(page, adminToken);
 		await page.goto(`/projects/${projectName}/settings`);
 
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
@@ -185,7 +185,7 @@ test.describe('project settings', () => {
 		await expect(page.getByPlaceholder('username')).toBeVisible({ timeout: 5_000 });
 
 		// Switch back to General and verify general content reappears.
-		await page.getByRole('button', { name: 'General' }).click();
+		await page.getByRole('button', { name: 'General', exact: true }).click();
 		await expect(page.locator('input[placeholder="Optional description"]')).toBeVisible();
 	});
 });

--- a/ui/tests/e2e/projects.spec.ts
+++ b/ui/tests/e2e/projects.spec.ts
@@ -38,7 +38,7 @@ test.describe('projects', () => {
 		await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
 
 		// The "+ New Project" button should be visible on the dashboard.
-		await expect(page.getByRole('link', { name: 'New Project' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'New Project', exact: true })).toBeVisible();
 	});
 
 	test('create project via UI', async ({ page, request }) => {
@@ -48,7 +48,7 @@ test.describe('projects', () => {
 		await loginViaUI(page);
 
 		// "+ New Project" button is in the top-right of the dashboard.
-		await page.getByRole('link', { name: 'New Project' }).click();
+		await page.getByRole('link', { name: 'New Project', exact: true }).click();
 		await expect(page).toHaveURL('/projects/new');
 
 		await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible();
@@ -56,7 +56,7 @@ test.describe('projects', () => {
 		await page.getByLabel('Project name').fill(name);
 		await page.getByLabel('Description').fill('E2E test project');
 
-		await page.getByRole('button', { name: 'Create project' }).click();
+		await page.getByRole('button', { name: 'Create project', exact: true }).click();
 
 		// Should redirect to the new project's canvas page.
 		await expect(page).toHaveURL(new RegExp(`/projects/${name}(\\?|$)`), { timeout: 10_000 });
@@ -67,7 +67,7 @@ test.describe('projects', () => {
 		await page.goto('/projects/new');
 
 		const nameInput = page.getByLabel('Project name');
-		const submitButton = page.getByRole('button', { name: 'Create project' });
+		const submitButton = page.getByRole('button', { name: 'Create project', exact: true });
 		const validationError = page.getByText(
 			'Project name must be 1-63 lowercase letters, digits, or hyphens, starting and ending with alphanumeric.'
 		);
@@ -128,7 +128,7 @@ test.describe('projects', () => {
 
 		await expect(page.getByText('No apps in this project')).toBeVisible({ timeout: 10_000 });
 		// "Deploy an app" is a button (not a link) that opens the new app modal.
-		await expect(page.getByRole('button', { name: 'Deploy an app' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Deploy an app', exact: true })).toBeVisible();
 	});
 
 	test('project settings page renders with delete section', async ({ page, request }) => {
@@ -141,14 +141,14 @@ test.describe('projects', () => {
 
 		// Project settings page has a tabbed layout with no top-level heading.
 		// Verify the General tab button is visible to confirm the page loaded.
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
 		// Navigate to the Danger tab to see the delete section.
-		await page.getByRole('button', { name: 'Danger' }).click();
+		await page.getByRole('button', { name: 'Danger', exact: true }).click();
 		await expect(page.getByText('Delete Project', { exact: true })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Delete project' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Delete project', exact: true })).toBeVisible();
 	});
 
 	test('dashboard hides namespace while project settings general shows it', async ({ page, request }) => {
@@ -179,15 +179,15 @@ test.describe('projects', () => {
 
 		// Wait for the page to load. Project settings has no top-level heading;
 		// verify the General tab button is visible.
-		await expect(page.getByRole('button', { name: 'General' })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'General', exact: true })).toBeVisible({
 			timeout: 10_000
 		});
 
 		// Navigate to the Danger tab.
-		await page.getByRole('button', { name: 'Danger' }).click();
+		await page.getByRole('button', { name: 'Danger', exact: true }).click();
 
 		// The delete button is disabled until the user types the project name.
-		const deleteBtn = page.getByRole('button', { name: 'Delete project' });
+		const deleteBtn = page.getByRole('button', { name: 'Delete project', exact: true });
 		await expect(deleteBtn).toBeDisabled();
 
 		// Type the project name into the confirmation input.
@@ -232,7 +232,7 @@ test.describe('projects', () => {
 		await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible();
 
 		// Click the "Cancel" link.
-		await page.getByRole('link', { name: 'Cancel' }).click();
+		await page.getByRole('link', { name: 'Cancel', exact: true }).click();
 
 		await expect(page).toHaveURL('/');
 		await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();

--- a/ui/tests/e2e/staged-changes-deploy.spec.ts
+++ b/ui/tests/e2e/staged-changes-deploy.spec.ts
@@ -75,7 +75,7 @@ test.describe('staged changes deploy flow', () => {
 		await replicasInput.fill('3');
 
 		// Click the Scale "Update" button
-		const updateBtns = page.getByRole('button', { name: 'Update' });
+		const updateBtns = page.getByRole('button', { name: 'Update', exact: true });
 		await updateBtns.last().click();
 
 		// Verify the change persisted via API
@@ -102,7 +102,7 @@ test.describe('staged changes deploy flow', () => {
 		await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeVisible({ timeout: 10_000 });
 
 		// When no staged changes exist, the bar and Discard button should not be visible
-		await expect(page.getByRole('button', { name: 'Discard' })).toHaveCount(0);
+		await expect(page.getByRole('button', { name: 'Discard', exact: true })).toHaveCount(0);
 		await expect(
 			page.getByText(/^\d+ changes? to apply$/i)
 		).toHaveCount(0);
@@ -128,7 +128,7 @@ test.describe('staged changes deploy flow', () => {
 		await imageInput.fill('nginx:1.28');
 
 		// Click Update in Source section (first Update button)
-		await page.getByRole('button', { name: 'Update' }).first().click();
+		await page.getByRole('button', { name: 'Update', exact: true }).first().click();
 
 		// Verify the change persisted via API
 		await expect(async () => {

--- a/ui/tests/e2e/volumes.spec.ts
+++ b/ui/tests/e2e/volumes.spec.ts
@@ -149,7 +149,7 @@ test.describe('storage volumes', () => {
 		await appNameInput.clear();
 		await appNameInput.fill(pgAppName);
 
-		await page.getByRole('button', { name: 'Create app' }).click();
+		await page.getByRole('button', { name: 'Create app', exact: true }).click();
 
 		// Should navigate to the app drawer.
 		await expect(page).toHaveURL(new RegExp(`/projects/${projectName}/apps/${pgAppName}(\\?|$)`), {


### PR DESCRIPTION
CAI-9 lane b2.4, first shard (all specs at once — the sweep is mechanical). 91 `getByRole('button'|'link', { name: '<literal>' })` selectors gain `exact: true`; regex names untouched. The UI E2E job on this PR is the judge: any test that depended on substring matching fails here, visibly, instead of timing out under a retry. Retries (`2` on CI) are left as they are; dropping them is the lane's final config step once this is green.