### PR TITLE
fix: time out git-host calls and run four App workers (CAI-173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,13 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   build fields from the server copy alone, and the failed preview counted
   as not-ready until the next pass. The parent reported Deploying for one
   reconcile; one in ten integration runs read it in that window.
+- **A hung git host no longer stalls every App** (CAI-173): the GitHub,
+  GitLab and Gitea clients had no HTTP timeout and the App controller ran
+  one worker, so a connection that hung during webhook registration held
+  the worker until the kernel gave up on the socket (about three minutes),
+  during which no App on the platform was reconciled. Every git-host
+  client now times out after 30s, webhook registration is bounded, and
+  the App controller runs four workers.
 
 - **A registry target failure is reported** (#444): when the registry
   backend could not produce a push or pull image reference, the

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -3292,6 +3293,10 @@ func conflictIfUnmanaged(obj client.Object, kind string) error {
 // Non-fatal — if registration fails (e.g. no public URL, no permissions),
 // builds still work via manual redeploy.
 func (r *AppReconciler) ensureWebhook(ctx context.Context, app *mortisev1alpha1.App, gp *mortisev1alpha1.GitProvider, token string) error {
+	// Bounded: the git host is outside our control, and this runs on the
+	// reconcile worker. Two calls (list, register) plus slack (CAI-173).
+	ctx, cancel := context.WithTimeout(ctx, 3*git.HostTimeout)
+	defer cancel()
 	log := logf.FromContext(ctx)
 
 	// Resolve the webhook URL from PlatformConfig. Only externalDomain serves
@@ -4944,6 +4949,10 @@ func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	enqueueAppFromSecret := handler.EnqueueRequestsFromMapFunc(r.appRequestsForSecret)
 
 	return ctrl.NewControllerManagedBy(mgr).
+		// More than one worker so a reconcile blocked on something outside
+		// the cluster (a git host, a registry) stalls one App, not all of
+		// them. Every status write already retries on conflict.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 4}).
 		For(&mortisev1alpha1.App{}).
 		Watches(&appsv1.Deployment{}, enqueueAppFromManagedResource).
 		Watches(&batchv1.CronJob{}, enqueueAppFromManagedResource).

--- a/internal/git/api.go
+++ b/internal/git/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 )
 
 // ErrAuthFailed indicates the git token was rejected (401/403). The user
@@ -97,4 +98,15 @@ type GitAPI interface {
 	ResolveBranchHead(ctx context.Context, repo, branch string) (string, error)
 	ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequestSnapshot, error)
 	ListTree(ctx context.Context, owner, repo, branch, path string) ([]TreeEntry, error)
+}
+
+// HostTimeout bounds every HTTP call to a git host. The SDK clients ship
+// with no timeout, and a hung connection to a host held the App
+// controller's single worker for ~3 minutes -- every App on the platform
+// stopped reconciling until the kernel gave up on the socket (CAI-173).
+const HostTimeout = 30 * time.Second
+
+// NewHostHTTPClient returns the http.Client git-host SDKs are built on.
+func NewHostHTTPClient() *http.Client {
+	return &http.Client{Timeout: HostTimeout}
 }

--- a/internal/git/gitea.go
+++ b/internal/git/gitea.go
@@ -15,6 +15,7 @@ import (
 // GiteaAPI implements GitAPI for Gitea / Forgejo via OAuth token.
 type GiteaAPI struct {
 	client *gogitea.Client
+	hc     *http.Client
 	token  string // OAuth access token (also used for git clone)
 	secret string // webhook HMAC secret
 }
@@ -24,13 +25,15 @@ func NewGiteaAPI(baseURL, token, webhookSecret string) (*GiteaAPI, error) {
 	// SetGiteaVersion("") skips the server version query on construction,
 	// avoiding a network call at startup. Actual API calls will still use
 	// the correct server version at call time.
+	hc := NewHostHTTPClient()
 	c, err := gogitea.NewClient(strings.TrimRight(baseURL, "/"),
 		gogitea.SetToken(token),
+		gogitea.SetHTTPClient(hc),
 		gogitea.SetGiteaVersion(""))
 	if err != nil {
 		return nil, fmt.Errorf("new gitea client: %w", err)
 	}
-	return &GiteaAPI{client: c, token: token, secret: webhookSecret}, nil
+	return &GiteaAPI{client: c, hc: hc, token: token, secret: webhookSecret}, nil
 }
 
 func (g *GiteaAPI) RegisterWebhook(ctx context.Context, repo string, cfg WebhookConfig) error {

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -26,6 +26,7 @@ type GitHubAPI struct {
 func NewGitHubAPI(baseURL, token, webhookSecret string) (*GitHubAPI, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
+	tc.Timeout = HostTimeout
 	var c *gogithub.Client
 	if baseURL == "" || baseURL == "https://github.com" {
 		c = gogithub.NewClient(tc)

--- a/internal/git/gitlab.go
+++ b/internal/git/gitlab.go
@@ -21,7 +21,7 @@ type GitLabAPI struct {
 
 // NewGitLabAPI constructs a GitLabAPI. baseURL is e.g. "https://gitlab.com" or a self-hosted URL.
 func NewGitLabAPI(baseURL, token, webhookSecret string) (*GitLabAPI, error) {
-	var opts []gogitlab.ClientOptionFunc
+	opts := []gogitlab.ClientOptionFunc{gogitlab.WithHTTPClient(NewHostHTTPClient())}
 	if baseURL != "" && baseURL != "https://gitlab.com" {
 		opts = append(opts, gogitlab.WithBaseURL(strings.TrimRight(baseURL, "/")+"/api/v4/"))
 	}

--- a/internal/git/host_timeout_test.go
+++ b/internal/git/host_timeout_test.go
@@ -1,0 +1,31 @@
+package git
+
+import (
+	"testing"
+)
+
+// Every git-host client must carry an HTTP timeout: without one, a hung
+// connection blocks the App controller's worker for minutes (CAI-173).
+func TestGitHostClientsHaveTimeouts(t *testing.T) {
+	gh, err := NewGitHubAPI("", "tok", "sec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gh.client.Client().Timeout; got != HostTimeout {
+		t.Errorf("github client timeout = %v, want %v", got, HostTimeout)
+	}
+	gt, err := NewGiteaAPI("https://gitea.example", "tok", "sec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gt.hc == nil || gt.hc.Timeout != HostTimeout {
+		t.Errorf("gitea client timeout not set")
+	}
+	gl, err := NewGitLabAPI("", "tok", "sec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hc := gl.client.HTTPClient(); hc == nil || hc.Timeout != HostTimeout {
+		t.Errorf("gitlab client timeout not set")
+	}
+}


### PR DESCRIPTION
Diagnosed from #526's failed run (33297275088, full operator log artifact): App-controller output for *all* Apps stopped 06:44:2x–06:47:3x while other controllers continued — the single worker was blocked; two unrelated tests timed out behind it (the '312s-then-fail' class). Cause: git-host SDK clients with no HTTP timeout (Gitea also drops ctx), so a hung connection during webhook registration holds the worker ~3 min. Fix: `git.HostTimeout` (30s) on GitHub/GitLab/Gitea clients, bounded context in `ensureWebhook`, `MaxConcurrentReconciles: 4`. Test asserts each client carries the timeout. `make test` green. Production relevance: one slow git host was able to stall every App.