### PR TITLE
fix(controller): carry a new env's build ref from memory on its first status pass (CAI-173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A just-failed preview build no longer flips the parent App to
+  Deploying for one reconcile** (CAI-173, CAI-229's sibling): on the pass
+  where a preview environment first appeared in status, its failed
+  BuildRun reference was known only in memory, the status writer read
+  build fields from the server copy alone, and the failed preview counted
+  as not-ready until the next pass. The parent reported Deploying for one
+  reconcile; one in ten integration runs read it in that window.
+
 - **A registry target failure is reported** (#444): when the registry
   backend could not produce a push or pull image reference, the
   environment was skipped with a log line and the App stayed `Ready` on

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -3697,7 +3697,20 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 			es.OverriddenEnvKeys = r.overriddenEnvKeysFor(ctx, app, &env, envNs)
 
 			// Carry forward deploy history, restart tracking, and build info.
-			if prev, ok := existingByName[env.Name]; ok {
+			// From the server copy when it knows the env; otherwise from this
+			// reconcile's own in-memory status. On the pass where a preview
+			// env first appears, its BuildRun ref (set by reconcileEnvBuild
+			// moments earlier) exists only in memory; reading it only from
+			// the server left a just-failed preview counting as not-ready for
+			// exactly one pass, and the parent flipped Ready -> Deploying ->
+			// Ready (CAI-173 phase-flip class, CAI-229's sibling).
+			prev, ok := existingByName[env.Name]
+			if !ok {
+				if inMem := envStatusFor(app, env.Name); inMem != nil {
+					prev, ok = *inMem, true
+				}
+			}
+			if ok {
 				es.JoinedAt = prev.JoinedAt
 				es.DeployHistory = prev.DeployHistory
 				es.LastProcessedRestartedAt = prev.LastProcessedRestartedAt

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -990,6 +990,53 @@ func TestUpdateStatusFallsBackToPreviewOnlyBuildFailure(t *testing.T) {
 	}
 }
 
+// The pass where a preview env first appears: its failed BuildRun ref is
+// known to this reconcile in memory but not yet on the server. The parent
+// must not flip to Deploying for that one pass (CAI-173 phase-flip class).
+func TestUpdateStatusUsesInMemoryBuildRefForNewPreviewEnv(t *testing.T) {
+	ctx := context.Background()
+	scheme := newAppStatusTestScheme(t)
+	serverApp := &mortisev1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "pj-default-project"},
+		Spec: mortisev1alpha1.AppSpec{
+			Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeGit, Repo: "https://example/repo.git"},
+			Environments: []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}},
+		},
+		Status: mortisev1alpha1.AppStatus{
+			Conditions:   []metav1.Condition{{Type: "BuildSucceeded", Status: metav1.ConditionTrue, Reason: "BuildComplete", Message: "built registry.example/demo:prod digest=sha256:prod for production"}},
+			Environments: []mortisev1alpha1.EnvironmentStatus{{Name: "production", LastBuiltImage: "registry.example/demo:prod"}},
+		},
+	}
+	productionDep := newReadyDeploymentForStatusTest(t, serverApp, "production")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(serverApp, productionDep).WithObjects(serverApp, productionDep).Build()
+	if err := c.Status().Update(ctx, productionDep); err != nil {
+		t.Fatalf("seed production deployment status: %v", err)
+	}
+	r := &AppReconciler{Client: c, Scheme: scheme}
+
+	// This reconcile's in-memory App already knows pr-6 and its failed build.
+	inMem := serverApp.DeepCopy()
+	inMem.Status.Environments = append(inMem.Status.Environments, mortisev1alpha1.EnvironmentStatus{
+		Name:               "pr-6",
+		CurrentBuildRunRef: &mortisev1alpha1.BuildRunReference{Name: "app-demo-pr-6-x", Phase: mortisev1alpha1.BuildRunPhaseFailed},
+	})
+	resolvedEnvs := []mortisev1alpha1.Environment{{Name: "production"}, {Name: "pr-6"}}
+	previewEnvNames := map[string]struct{}{"pr-6": {}}
+	if err := r.updateStatus(ctx, inMem, resolvedEnvs, previewEnvNames); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	var fresh mortisev1alpha1.App
+	if err := c.Get(ctx, types.NamespacedName{Name: "demo", Namespace: "pj-default-project"}, &fresh); err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if fresh.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("a just-failed preview must not degrade the parent on its first pass: got %q", fresh.Status.Phase)
+	}
+	if es := envStatusFor(&fresh, "pr-6"); es == nil || es.CurrentBuildRunRef == nil {
+		t.Fatalf("the in-memory build ref must be carried onto the new env status: %+v", es)
+	}
+}
+
 func TestUpdateStatusStillCountsPreviewRolloutFailureInTopLevelPhase(t *testing.T) {
 	ctx := context.Background()
 	scheme := newAppStatusTestScheme(t)


### PR DESCRIPTION
The Ready→Deploying phase-flip class, named and fixed. `updateStatus` carried env build fields only from the re-read server copy; a preview env's just-failed BuildRun ref existed only in memory on the pass it first appeared, so the failed-preview exclusion missed for one reconcile. Now falls back to the in-memory env status when the server lacks the env. Unit test reproduces the join pass (fails before). Existing specs on preview rollout gaps unchanged. `make test` green.