### PR TITLE
test(e2e): no retries on CI (#442, CAI-9 b2.4 final step)

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
 	globalTeardown: './tests/e2e/global-teardown.ts',
 	fullyParallel: !process.env.CI,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	// No retries: a flaky or substring-matched selector must fail visibly, not
+	// pass on the second try (#442). The exact-selector sweep landed first.
+	retries: 0,
 	workers: process.env.CI ? 4 : 8,
 	reporter: 'html',
 	globalTimeout: 30 * 60 * 1000,


### PR DESCRIPTION
Lane b2.4's config step, after the exact-selector sweep (#542) went green. `retries: 0` on CI so masked failures surface. The UI E2E job on this PR is the judge; if it is red, the failing spec is a real one to fix, not a reason to restore retries.