### PR TITLE
fix(controller): a preview build no longer moves the parent App's phase (CAI-173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           # show the tail inline.
           mkdir -p diagnostics
           kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > diagnostics/operator.log || true
+          kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix --previous > diagnostics/operator-previous.log 2>/dev/null || true
           tail -300 diagnostics/operator.log || true
           kubectl get events -A --sort-by=.lastTimestamp > diagnostics/events.txt || true
           tail -80 diagnostics/events.txt || true
@@ -204,6 +205,7 @@ jobs:
           kubectl --context k3d-mortise-dev -n mortise-system describe pods || true
           mkdir -p diagnostics
           kubectl --context k3d-mortise-dev -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > diagnostics/operator.log || true
+          kubectl --context k3d-mortise-dev -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix --previous > diagnostics/operator-previous.log 2>/dev/null || true
           tail -300 diagnostics/operator.log || true
           kubectl --context k3d-mortise-dev get events -A --sort-by=.lastTimestamp > diagnostics/events.txt || true
           tail -80 diagnostics/events.txt || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,14 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A preview build no longer moves the parent App's phase** (CAI-173,
+  CAI-229's remaining half): starting or finishing a preview environment's
+  build set the App's own phase to Building/Deploying and its
+  BuildStarted/BuildSucceeded conditions, the flush wrote that, and the
+  status pass corrected it a moment later — so the parent flickered on
+  every preview build poll. Preview builds now touch only their own
+  environment status; the PreviewEnvironment carries the outcome.
+
 - **A just-failed preview build no longer flips the parent App to
   Deploying for one reconcile** (CAI-173, CAI-229's sibling): on the pass
   where a preview environment first appeared in status, its failed

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,10 @@ test-integration: ## Create k3d cluster, install chart + test deps, run integrat
 	@echo "==> Installing CRDs..."
 	kubectl --context $(INT_KUBE_CONTEXT) apply -f charts/mortise-core/crds/
 	@echo "==> Waiting for CRDs to be established..."
-	kubectl --context $(INT_KUBE_CONTEXT) wait --for=condition=Established crd/platformconfigs.mortise.mortise.dev --timeout=30s
+	@for i in $$(seq 1 30); do \
+		kubectl --context $(INT_KUBE_CONTEXT) wait --for=condition=Established crd/platformconfigs.mortise.mortise.dev --timeout=30s 2>/dev/null && break; \
+		sleep 1; \
+	done
 	@echo "==> Installing test-only dependencies (registry, Gitea, BuildKit)..."
 	kubectl --context $(INT_KUBE_CONTEXT) create namespace mortise-system --dry-run=client -o yaml | kubectl --context $(INT_KUBE_CONTEXT) apply -f -
 	kubectl --context $(INT_KUBE_CONTEXT) apply -f test/integration/manifests/

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -266,26 +266,32 @@ func (s *Server) watchPodsInNamespace(ctx context.Context, projectName, ns strin
 func (s *Server) drainPodWatch(ctx context.Context, watcher watch.Interface, projectName, ns string, w *sseWriter) {
 	type podKey struct{ app, env string }
 	dirty := map[podKey]bool{}
-	var debounce *time.Timer
+	// The debounce fires through a channel read by this loop so that only
+	// this goroutine touches dirty; a time.AfterFunc callback would iterate
+	// the map while the loop writes it, which is a fatal runtime error that
+	// takes the whole operator down.
+	debounce := time.NewTimer(time.Hour)
+	debounce.Stop()
+	defer debounce.Stop()
+	pending := false
 
 	flush := func() {
 		for k := range dirty {
 			s.emitPodList(ctx, w, projectName, k.app, k.env, ns)
 		}
 		dirty = map[podKey]bool{}
+		pending = false
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			if debounce != nil {
-				debounce.Stop()
-			}
 			return
+		case <-debounce.C:
+			flush()
 		case ev, ok := <-watcher.ResultChan():
 			if !ok {
-				if debounce != nil {
-					debounce.Stop()
+				if pending {
 					flush()
 				}
 				return
@@ -303,14 +309,16 @@ func (s *Server) drainPodWatch(ctx context.Context, watcher watch.Interface, pro
 				continue
 			}
 			dirty[podKey{appName, envName}] = true
-			if debounce == nil {
-				debounce = time.AfterFunc(500*time.Millisecond, func() {
-					flush()
-					debounce = nil
-				})
-			} else {
-				debounce.Reset(500 * time.Millisecond)
+			if pending {
+				if !debounce.Stop() {
+					select {
+					case <-debounce.C:
+					default:
+					}
+				}
 			}
+			debounce.Reset(500 * time.Millisecond)
+			pending = true
 		}
 	}
 }

--- a/internal/api/events_pod_watch_race_test.go
+++ b/internal/api/events_pod_watch_race_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/mortise-org/mortise/internal/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// drainPodWatch debounces pod events into a dirty set. The flush must run on
+// the loop goroutine: a timer callback iterating the map while the loop
+// writes it is a fatal runtime error (not a recoverable panic) that took the
+// operator down mid-E2E. Run with -race; the old shape reports a data race.
+func TestDrainPodWatchFlushesOnLoopGoroutine(t *testing.T) {
+	s := &Server{client: fake.NewClientBuilder().Build()}
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, flusher: rec}
+	fw := watch.NewFake()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.drainPodWatch(ctx, fw, "proj", "pj-proj-production", w)
+	}()
+
+	pod := func() *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "p",
+			Namespace: "pj-proj-production",
+			Labels:    map[string]string{constants.AppNameLabel: "web", constants.EnvironmentLabel: "production"},
+		}}
+	}
+	// Straddle several debounce windows so flushes interleave with writes.
+	for i := 0; i < 8; i++ {
+		fw.Modify(pod())
+		time.Sleep(550 * time.Millisecond)
+		fw.Modify(pod())
+		time.Sleep(20 * time.Millisecond)
+	}
+	fw.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainPodWatch did not return after the watch closed")
+	}
+}

--- a/internal/controller/app_build_success_idempotent_test.go
+++ b/internal/controller/app_build_success_idempotent_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// CAI-173: a Succeeded BuildRun is re-observed on every reconcile. Only the
+// first observation of a revision+image may set the top-level phase; later
+// passes must leave the phase alone or the status flush flips Ready→Deploying
+// once a second.
+func TestApplyEnvBuildSuccessSetsPhaseOnlyOnce(t *testing.T) {
+	r := &AppReconciler{}
+	app := &mortisev1alpha1.App{}
+	app.Status.Phase = mortisev1alpha1.AppPhaseReady
+
+	if !r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "abc", "img@sha256:1", "sha256:1", 8080, true) {
+		t.Fatal("first application should set the top-level phase")
+	}
+	if app.Status.Phase != mortisev1alpha1.AppPhaseDeploying {
+		t.Fatalf("phase after first application = %q, want Deploying", app.Status.Phase)
+	}
+
+	app.Status.Phase = mortisev1alpha1.AppPhaseReady
+	if r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "abc", "img@sha256:1", "sha256:1", 8080, true) {
+		t.Fatal("re-applying the same build must not set the top-level phase")
+	}
+	if app.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("phase after re-application = %q, want Ready", app.Status.Phase)
+	}
+
+	if !r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "def", "img@sha256:2", "sha256:2", 8080, true) {
+		t.Fatal("a new revision should set the top-level phase again")
+	}
+}

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1167,10 +1167,15 @@ func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName
 
 // applyEnvBuildSuccess records the successful build for a specific environment.
 func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32, countsTopLevel bool) bool {
-	// Update per-env status.
+	// Update per-env status. A BuildRun stays Succeeded for as long as it
+	// exists, so this runs on every reconcile after the build; only the first
+	// application of a given revision+image may move the top-level phase,
+	// otherwise the flush would write Deploying over Ready once a second.
+	alreadyApplied := false
 	found := false
 	for i := range app.Status.Environments {
 		if app.Status.Environments[i].Name == envName {
+			alreadyApplied = app.Status.Environments[i].LastBuiltSHA == revision && app.Status.Environments[i].LastBuiltImage == image
 			app.Status.Environments[i].LastBuiltSHA = revision
 			app.Status.Environments[i].LastBuiltImage = image
 			found = true
@@ -1190,7 +1195,7 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		app.Status.LastBuiltImage = image
 		app.Status.DetectedPort = detectedPort
 	}
-	if !countsTopLevel {
+	if !countsTopLevel || alreadyApplied {
 		// A preview's build outcome lives on its env status and its
 		// PreviewEnvironment; the parent's phase and conditions stay as the
 		// non-preview envs left them.
@@ -3961,6 +3966,7 @@ func (r *AppReconciler) updateStatus(ctx context.Context, app *mortisev1alpha1.A
 }
 
 func (r *AppReconciler) updateAppStatus(ctx context.Context, app *mortisev1alpha1.App, mutate func(status *mortisev1alpha1.AppStatus)) error {
+	site := callerSite(1)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var fresh mortisev1alpha1.App
 		if err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
@@ -3971,7 +3977,7 @@ func (r *AppReconciler) updateAppStatus(ctx context.Context, app *mortisev1alpha
 		if fresh.Status.Phase != before {
 			// Every top-level phase write names itself (CAI-173): the phase
 			// keeps arriving at Deploying with no status pass choosing it.
-			logf.FromContext(ctx).Info("app phase written by mutator", "from", before, "to", fresh.Status.Phase, "site", callerSite(2))
+			logf.FromContext(ctx).Info("app phase written by mutator", "from", before, "to", fresh.Status.Phase, "site", site)
 		}
 		return r.Status().Update(ctx, &fresh)
 	})

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1056,7 +1056,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 				projectAppBuildRunStatus(app, envName, &current)
 				switch current.Status.Phase {
 				case mortisev1alpha1.BuildRunPhaseSucceeded:
-					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort)
+					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
 					return current.Status.Image, false, true, false, nil
 				case mortisev1alpha1.BuildRunPhaseFailed:
 					if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
@@ -1066,7 +1066,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 					}
 					return "", false, true, false, nil
 				default:
-					r.markEnvBuildInProgress(app, envName, revision)
+					r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
 					return "", true, true, false, nil
 				}
 			}
@@ -1098,7 +1098,7 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	projectAppBuildRunStatus(app, envName, run)
 	switch run.Status.Phase {
 	case mortisev1alpha1.BuildRunPhaseSucceeded:
-		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort)
+		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
 		return run.Status.Image, false, true, consumedRebuild, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
 		if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
@@ -1108,21 +1108,30 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 		return "", false, true, consumedRebuild, nil
 	default:
-		r.markEnvBuildInProgress(app, envName, revision)
+		r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
 		return "", true, true, consumedRebuild, nil
 	}
 }
 
-func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName, revision string) {
+// countsTopLevel says whether this env speaks for the App: a preview
+// environment's build must not move the App's own phase or BuildStarted /
+// BuildSucceeded. It used to, and the flush wrote it before updateStatus
+// corrected it, so the parent flickered Ready -> Building/Deploying -> Ready
+// on every preview build poll (CAI-173 phase-flip class; CAI-229 fixed only
+// the failure condition).
+func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName, revision string, countsTopLevel bool) {
 	if app == nil {
 		return
 	}
 
-	app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 	if es := ensureEnvStatus(app, envName); es != nil {
 		es.Phase = mortisev1alpha1.AppPhaseBuilding
 		es.Message = fmt.Sprintf("building revision %s", revision)
 	}
+	if !countsTopLevel {
+		return
+	}
+	app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 
 	meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
 		Type:               "BuildStarted",
@@ -1134,7 +1143,7 @@ func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName
 }
 
 // applyEnvBuildSuccess records the successful build for a specific environment.
-func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32) {
+func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32, countsTopLevel bool) {
 	// Update per-env status.
 	found := false
 	for i := range app.Status.Environments {
@@ -1157,6 +1166,12 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		app.Status.LastBuiltSHA = revision
 		app.Status.LastBuiltImage = image
 		app.Status.DetectedPort = detectedPort
+	}
+	if !countsTopLevel {
+		// A preview's build outcome lives on its env status and its
+		// PreviewEnvironment; the parent's phase and conditions stay as the
+		// non-preview envs left them.
+		return
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
 	meta.RemoveStatusCondition(&app.Status.Conditions, "BuildStarted")

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -3965,9 +3966,25 @@ func (r *AppReconciler) updateAppStatus(ctx context.Context, app *mortisev1alpha
 		if err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &fresh); err != nil {
 			return err
 		}
+		before := fresh.Status.Phase
 		mutate(&fresh.Status)
+		if fresh.Status.Phase != before {
+			// Every top-level phase write names itself (CAI-173): the phase
+			// keeps arriving at Deploying with no status pass choosing it.
+			logf.FromContext(ctx).Info("app phase written by mutator", "from", before, "to", fresh.Status.Phase, "site", callerSite(2))
+		}
 		return r.Status().Update(ctx, &fresh)
 	})
+}
+
+// callerSite returns "file:line" of the caller `skip` frames up, for logs
+// that need to say which code path wrote a value.
+func callerSite(skip int) string {
+	_, file, line, ok := goruntime.Caller(skip + 1)
+	if !ok {
+		return "?"
+	}
+	return fmt.Sprintf("%s:%d", filepath.Base(file), line)
 }
 
 // needsDeployRecord returns true when a new deploy record should be created:

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -337,15 +337,12 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		var image string
 		if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && r.BuildClient != nil {
 			buildIdentity := resolveEnvBuildIdentity(&app, *env, previewBuildIdentities)
-			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, buildAggregationEnvNames, env.Name, buildIdentity.branch, buildIdentity.revision)
+			envImage, requeue, dirty, shouldClearNoCache, err := r.reconcileEnvBuild(ctx, &app, projectionEnvOrder, buildAggregationEnvNames, env.Name, buildIdentity.branch, buildIdentity.revision, &topLevelBuildDirty)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("reconcile buildrun for env %s: %w", env.Name, err)
 			}
 			if dirty {
 				buildStatusDirty = true
-				if envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames) {
-					topLevelBuildDirty = true
-				}
 			}
 			if shouldClearNoCache {
 				clearNoCache = true
@@ -1030,7 +1027,7 @@ func envCountsTowardAppBuildFailure(buildAggregationEnvNames map[string]struct{}
 // its failure in env status only: writing it app-wide would both misattribute the
 // failure to production and trip the terminal-failure short-circuit that halts
 // every subsequent build until a manual rebuild. A nil set means every env counts.
-func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, buildAggregationEnvNames map[string]struct{}, envName, branch, revision string) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
+func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, buildAggregationEnvNames map[string]struct{}, envName, branch, revision string, topLevelPhaseSet *bool) (image string, requeue bool, statusDirty bool, shouldClearNoCache bool, err error) {
 	log := logf.FromContext(ctx)
 
 	branch = firstNonEmpty(branch, app.Spec.Source.Branch)
@@ -1069,7 +1066,9 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 				projectAppBuildRunStatus(app, envName, &current)
 				switch current.Status.Phase {
 				case mortisev1alpha1.BuildRunPhaseSucceeded:
-					r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
+					if r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, current.Status.Image, current.Status.Digest, current.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames)) && topLevelPhaseSet != nil {
+						*topLevelPhaseSet = true
+					}
 					return current.Status.Image, false, true, false, nil
 				case mortisev1alpha1.BuildRunPhaseFailed:
 					if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
@@ -1079,7 +1078,9 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 					}
 					return "", false, true, false, nil
 				default:
-					r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
+					if r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames)) && topLevelPhaseSet != nil {
+						*topLevelPhaseSet = true
+					}
 					return "", true, true, false, nil
 				}
 			}
@@ -1111,7 +1112,9 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 	projectAppBuildRunStatus(app, envName, run)
 	switch run.Status.Phase {
 	case mortisev1alpha1.BuildRunPhaseSucceeded:
-		r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
+		if r.applyEnvBuildSuccess(ctx, app, projectionEnvOrder, envName, revision, run.Status.Image, run.Status.Digest, run.Status.DetectedPort, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames)) && topLevelPhaseSet != nil {
+			*topLevelPhaseSet = true
+		}
 		return run.Status.Image, false, true, consumedRebuild, nil
 	case mortisev1alpha1.BuildRunPhaseFailed:
 		if envCountsTowardAppBuildFailure(buildAggregationEnvNames, envName) {
@@ -1121,7 +1124,9 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 		}
 		return "", false, true, consumedRebuild, nil
 	default:
-		r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames))
+		if r.markEnvBuildInProgress(app, envName, revision, envSelectedForBuildFailureAggregation(envName, buildAggregationEnvNames)) && topLevelPhaseSet != nil {
+			*topLevelPhaseSet = true
+		}
 		return "", true, true, consumedRebuild, nil
 	}
 }
@@ -1132,9 +1137,12 @@ func (r *AppReconciler) reconcileEnvBuild(ctx context.Context, app *mortisev1alp
 // corrected it, so the parent flickered Ready -> Building/Deploying -> Ready
 // on every preview build poll (CAI-173 phase-flip class; CAI-229 fixed only
 // the failure condition).
-func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName, revision string, countsTopLevel bool) {
+// Returns true when it set the App's top-level phase, which is the only
+// case in which the build-status flush may write Phase (CAI-173: copying an
+// unset in-memory phase wrote back the stale cached read).
+func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName, revision string, countsTopLevel bool) bool {
 	if app == nil {
-		return
+		return false
 	}
 
 	if es := ensureEnvStatus(app, envName); es != nil {
@@ -1142,7 +1150,7 @@ func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName
 		es.Message = fmt.Sprintf("building revision %s", revision)
 	}
 	if !countsTopLevel {
-		return
+		return false
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseBuilding
 
@@ -1153,10 +1161,11 @@ func (r *AppReconciler) markEnvBuildInProgress(app *mortisev1alpha1.App, envName
 		Message:            fmt.Sprintf("building revision %s for %s", revision, envName),
 		LastTransitionTime: metav1.NewTime(r.clock().Now()),
 	})
+	return true
 }
 
 // applyEnvBuildSuccess records the successful build for a specific environment.
-func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32, countsTopLevel bool) {
+func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1alpha1.App, projectionEnvOrder []string, envName, revision, image, digest string, detectedPort int32, countsTopLevel bool) bool {
 	// Update per-env status.
 	found := false
 	for i := range app.Status.Environments {
@@ -1184,7 +1193,7 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		// A preview's build outcome lives on its env status and its
 		// PreviewEnvironment; the parent's phase and conditions stay as the
 		// non-preview envs left them.
-		return
+		return false
 	}
 	app.Status.Phase = mortisev1alpha1.AppPhaseDeploying
 	meta.RemoveStatusCondition(&app.Status.Conditions, "BuildStarted")
@@ -1195,6 +1204,7 @@ func (r *AppReconciler) applyEnvBuildSuccess(_ context.Context, app *mortisev1al
 		Message:            fmt.Sprintf("built %s digest=%s for %s", image, digest, envName),
 		LastTransitionTime: metav1.NewTime(r.clock().Now()),
 	})
+	return true
 }
 
 // buildParams bundles the inputs the background build goroutine needs. Keeping

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -294,6 +294,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// time we reach here — we just materialise the per-app objects inside.
 	needsRequeue := false
 	buildStatusDirty := false
+	topLevelBuildDirty := false
 	clearNoCache := false
 	var domainCollisionErrs []string
 	projectionEnvOrder := make([]string, 0, len(resolvedEnvs))
@@ -342,6 +343,9 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			}
 			if dirty {
 				buildStatusDirty = true
+				if envSelectedForBuildFailureAggregation(env.Name, buildAggregationEnvNames) {
+					topLevelBuildDirty = true
+				}
 			}
 			if shouldClearNoCache {
 				clearNoCache = true
@@ -404,8 +408,17 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// avoids resourceVersion conflicts from per-env Status().Update() calls.
 	if buildStatusDirty {
 		if err := r.updateAppStatus(ctx, &app, func(status *mortisev1alpha1.AppStatus) {
-			status.Phase = app.Status.Phase
-			status.Conditions = app.Status.Conditions
+			// Phase and the build conditions are copied only when a top-level
+			// env's build changed them this pass. Copying the in-memory values
+			// unconditionally wrote back whatever the (possibly stale) cached
+			// read held at reconcile start -- a Deploying from minutes ago --
+			// and updateStatus corrected it a moment later: the flip seen in
+			// one integration run in ten, and never logged as Ready ->
+			// Deploying because no status pass ever chose Deploying (CAI-173).
+			if topLevelBuildDirty {
+				status.Phase = app.Status.Phase
+				mergeBuildConditions(&status.Conditions, app.Status.Conditions)
+			}
 			status.LastBuiltSHA = app.Status.LastBuiltSHA
 			status.LastBuiltImage = app.Status.LastBuiltImage
 			status.DetectedPort = app.Status.DetectedPort
@@ -5100,5 +5113,19 @@ func mergeEnvBuildFields(dst *[]mortisev1alpha1.EnvironmentStatus, src []mortise
 		de.LastBuiltImage = se.LastBuiltImage
 		de.CurrentBuildRunRef = se.CurrentBuildRunRef
 		de.LastSuccessfulBuildRunRef = se.LastSuccessfulBuildRunRef
+	}
+}
+
+// mergeBuildConditions carries only the conditions the build path owns
+// (BuildStarted, BuildSucceeded) from the in-memory status onto a fresh
+// one: set when present in src, removed when absent. Everything else on the
+// fresh status is left to its own writers.
+func mergeBuildConditions(dst *[]metav1.Condition, src []metav1.Condition) {
+	for _, t := range []string{"BuildStarted", "BuildSucceeded"} {
+		if c := meta.FindStatusCondition(src, t); c != nil {
+			meta.SetStatusCondition(dst, *c)
+		} else {
+			meta.RemoveStatusCondition(dst, t)
+		}
 	}
 }

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -732,7 +732,7 @@ func TestApplyEnvBuildSuccessClearsBuildStartedCondition(t *testing.T) {
 		},
 	}
 
-	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "newsha", "registry.example/demo:new", "sha256:new", 8080)
+	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "newsha", "registry.example/demo:new", "sha256:new", 8080, true)
 
 	if cond := meta.FindStatusCondition(app.Status.Conditions, "BuildStarted"); cond != nil {
 		t.Fatalf("expected BuildStarted to be cleared after build success, got %+v", cond)

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -732,7 +732,7 @@ func TestApplyEnvBuildSuccessClearsBuildStartedCondition(t *testing.T) {
 		},
 	}
 
-	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "newsha", "registry.example/demo:new", "sha256:new", 8080, true)
+	_ = r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "production", "newsha", "registry.example/demo:new", "sha256:new", 8080, true)
 
 	if cond := meta.FindStatusCondition(app.Status.Conditions, "BuildStarted"); cond != nil {
 		t.Fatalf("expected BuildStarted to be cleared after build success, got %+v", cond)

--- a/internal/controller/app_flush_conditions_test.go
+++ b/internal/controller/app_flush_conditions_test.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The flush must carry only the build-owned conditions, never replace the
+// whole slice with the in-memory (possibly stale) copy.
+func TestMergeBuildConditions(t *testing.T) {
+	fresh := []metav1.Condition{
+		{Type: "PodHealthy", Status: metav1.ConditionFalse, Reason: "CrashLoopBackOff"}, // set by updateStatus, must survive
+		{Type: "BuildStarted", Status: metav1.ConditionTrue, Reason: "BuildInProgress"},
+	}
+	inMem := []metav1.Condition{
+		{Type: "BuildSucceeded", Status: metav1.ConditionTrue, Reason: "BuildComplete", Message: "built x"},
+		// no BuildStarted: the build finished
+	}
+	mergeBuildConditions(&fresh, inMem)
+	if meta.FindStatusCondition(fresh, "PodHealthy") == nil {
+		t.Fatal("a condition the build path does not own was dropped")
+	}
+	if meta.FindStatusCondition(fresh, "BuildStarted") != nil {
+		t.Fatal("BuildStarted must be removed when the in-memory status no longer has it")
+	}
+	if c := meta.FindStatusCondition(fresh, "BuildSucceeded"); c == nil || c.Message != "built x" {
+		t.Fatalf("BuildSucceeded must be carried: %+v", c)
+	}
+}

--- a/internal/controller/app_preview_build_phase_test.go
+++ b/internal/controller/app_preview_build_phase_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// A preview env's build must not move the parent's phase or its
+// BuildStarted / BuildSucceeded conditions -- only its own env status
+// (CAI-173 phase-flip class).
+func TestPreviewBuildDoesNotTouchTopLevelPhase(t *testing.T) {
+	r := &AppReconciler{}
+	app := &mortisev1alpha1.App{Status: mortisev1alpha1.AppStatus{
+		Phase:        mortisev1alpha1.AppPhaseReady,
+		Conditions:   []metav1.Condition{{Type: "BuildSucceeded", Status: metav1.ConditionTrue, Reason: "BuildComplete", Message: "built img for production"}},
+		Environments: []mortisev1alpha1.EnvironmentStatus{{Name: "production", Phase: mortisev1alpha1.AppPhaseReady}},
+	}}
+
+	r.markEnvBuildInProgress(app, "pr-1", "abc", false)
+	if app.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("preview build start moved the parent phase to %q", app.Status.Phase)
+	}
+	if meta.FindStatusCondition(app.Status.Conditions, "BuildStarted") != nil {
+		t.Fatal("preview build start set the parent's BuildStarted")
+	}
+	if es := envStatusFor(app, "pr-1"); es == nil || es.Phase != mortisev1alpha1.AppPhaseBuilding {
+		t.Fatalf("preview env status must still record the build: %+v", es)
+	}
+
+	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "pr-1", "abc", "img:pr", "sha256:x", 0, false)
+	if app.Status.Phase != mortisev1alpha1.AppPhaseReady {
+		t.Fatalf("preview build success moved the parent phase to %q", app.Status.Phase)
+	}
+	if c := meta.FindStatusCondition(app.Status.Conditions, "BuildSucceeded"); c == nil || c.Message != "built img for production" {
+		t.Fatalf("preview build success rewrote the parent's BuildSucceeded: %+v", c)
+	}
+	if es := envStatusFor(app, "pr-1"); es == nil || es.LastBuiltSHA != "abc" {
+		t.Fatalf("preview env status must record the built revision: %+v", es)
+	}
+
+	// A selected env still drives the parent.
+	r.markEnvBuildInProgress(app, "production", "def", true)
+	if app.Status.Phase != mortisev1alpha1.AppPhaseBuilding {
+		t.Fatalf("a production build must move the parent to Building, got %q", app.Status.Phase)
+	}
+}

--- a/internal/controller/app_preview_build_phase_test.go
+++ b/internal/controller/app_preview_build_phase_test.go
@@ -21,7 +21,7 @@ func TestPreviewBuildDoesNotTouchTopLevelPhase(t *testing.T) {
 		Environments: []mortisev1alpha1.EnvironmentStatus{{Name: "production", Phase: mortisev1alpha1.AppPhaseReady}},
 	}}
 
-	r.markEnvBuildInProgress(app, "pr-1", "abc", false)
+	_ = r.markEnvBuildInProgress(app, "pr-1", "abc", false)
 	if app.Status.Phase != mortisev1alpha1.AppPhaseReady {
 		t.Fatalf("preview build start moved the parent phase to %q", app.Status.Phase)
 	}
@@ -32,7 +32,7 @@ func TestPreviewBuildDoesNotTouchTopLevelPhase(t *testing.T) {
 		t.Fatalf("preview env status must still record the build: %+v", es)
 	}
 
-	r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "pr-1", "abc", "img:pr", "sha256:x", 0, false)
+	_ = r.applyEnvBuildSuccess(context.Background(), app, []string{"production"}, "pr-1", "abc", "img:pr", "sha256:x", 0, false)
 	if app.Status.Phase != mortisev1alpha1.AppPhaseReady {
 		t.Fatalf("preview build success moved the parent phase to %q", app.Status.Phase)
 	}
@@ -44,7 +44,7 @@ func TestPreviewBuildDoesNotTouchTopLevelPhase(t *testing.T) {
 	}
 
 	// A selected env still drives the parent.
-	r.markEnvBuildInProgress(app, "production", "def", true)
+	_ = r.markEnvBuildInProgress(app, "production", "def", true)
 	if app.Status.Phase != mortisev1alpha1.AppPhaseBuilding {
 		t.Fatalf("a production build must move the parent to Building, got %q", app.Status.Phase)
 	}

--- a/internal/controller/buildrun_controller.go
+++ b/internal/controller/buildrun_controller.go
@@ -611,7 +611,9 @@ func (r *BuildRunReconciler) projectTerminalBuildRunStatus(ctx context.Context, 
 				}
 				return err
 			}
+			before := app.Status.Phase
 			projectAppBuildRunStatus(&app, br.Spec.Environment, br)
+			logf.FromContext(ctx).Info("app status written by buildrun projection", "app", app.Name, "phase", app.Status.Phase, "phaseBefore", before, "rv", app.ResourceVersion)
 			return r.Status().Update(ctx, &app)
 		})
 	default:

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -552,7 +552,7 @@ func TestReconcileEnvBuildProjectsCurrentTerminalRunBeforeRevisionShortCircuit(t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -645,7 +645,7 @@ func TestReconcileEnvBuildSkipsTerminalCurrentRunWhenManualRebuildRequested(t *t
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
+	image, requeue, statusDirty, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -734,7 +734,7 @@ func TestReconcileEnvBuildRebuildRequestReachesEveryEnv(t *testing.T) {
 	}
 
 	for _, env := range envs {
-		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, nil, env, "main", "same-sha")
+		image, requeue, _, shouldClearNoCache, err := r.reconcileEnvBuild(context.Background(), app, envs, nil, env, "main", "same-sha", nil)
 		if err != nil {
 			t.Fatalf("reconcileEnvBuild %s: %v", env, err)
 		}
@@ -818,7 +818,7 @@ func TestReconcileEnvBuildProjectsFailedCurrentRunIntoStatus(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, nil, "pr-6", "feature/preview-fail", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"pr-6"}, nil, "pr-6", "feature/preview-fail", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestReconcileEnvBuildDoesNotReuseAnotherEnvsCurrentRun(t *testing.T) {
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, nil, "staging", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "staging"}, nil, "staging", "main", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestReconcileEnvBuildDoesNotShortCircuitLastBuiltSHAWhenInputHashChanges(t 
 		RegistryBackend: &fakeRegistryBackend{},
 	}
 
-	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha")
+	image, requeue, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production"}, nil, "production", "main", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}
@@ -1058,7 +1058,7 @@ func TestApplyEnvBuildSuccessDoesNotOverwriteProjectedMetadataWithLaterEnv(t *te
 	}
 
 	r := &AppReconciler{}
-	r.applyEnvBuildSuccess(context.Background(), app, []string{"production", "preview"}, "preview", "preview-sha", "registry.example.com/demo:preview", "sha256:preview", 3000, true)
+	_ = r.applyEnvBuildSuccess(context.Background(), app, []string{"production", "preview"}, "preview", "preview-sha", "registry.example.com/demo:preview", "sha256:preview", 3000, true)
 
 	if app.Status.LastBuiltSHA != "prod-sha" {
 		t.Fatalf("expected projected SHA to stay on production, got %q", app.Status.LastBuiltSHA)
@@ -1200,7 +1200,7 @@ func TestReconcileEnvBuildKeepsPreviewFailureOffTopLevelApp(t *testing.T) {
 	// production is the only env that may speak for the App; pr-6 is a preview.
 	aggregation := map[string]struct{}{"production": {}}
 
-	image, _, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "pr-6"}, aggregation, "pr-6", "feature/preview-fail", "same-sha")
+	image, _, statusDirty, _, err := r.reconcileEnvBuild(context.Background(), app, []string{"production", "pr-6"}, aggregation, "pr-6", "feature/preview-fail", "same-sha", nil)
 	if err != nil {
 		t.Fatalf("reconcileEnvBuild: %v", err)
 	}

--- a/internal/controller/buildrun_support_test.go
+++ b/internal/controller/buildrun_support_test.go
@@ -1058,7 +1058,7 @@ func TestApplyEnvBuildSuccessDoesNotOverwriteProjectedMetadataWithLaterEnv(t *te
 	}
 
 	r := &AppReconciler{}
-	r.applyEnvBuildSuccess(context.Background(), app, []string{"production", "preview"}, "preview", "preview-sha", "registry.example.com/demo:preview", "sha256:preview", 3000)
+	r.applyEnvBuildSuccess(context.Background(), app, []string{"production", "preview"}, "preview", "preview-sha", "registry.example.com/demo:preview", "sha256:preview", 3000, true)
 
 	if app.Status.LastBuiltSHA != "prod-sha" {
 		t.Fatalf("expected projected SHA to stay on production, got %q", app.Status.LastBuiltSHA)


### PR DESCRIPTION
The Ready→Deploying phase-flip class, both halves. (1) `markEnvBuildInProgress`/`applyEnvBuildSuccess` set the App's phase and BuildStarted/BuildSucceeded for preview envs; now gated on the aggregation set. (2) The build-status flush copied the in-memory Phase/Conditions wholesale, writing back whatever the possibly-stale cached read held at reconcile start; #538's log showed Deploying→Ready on every pass and never the reverse. The flush now writes Phase and merges only the build-owned conditions when a top-level env's build changed them. Unit tests for both; `make test` green. Integration on this PR is the judge; 10× re-measure after merge.