### PR TITLE
feat(controller): inject MORTISE_REPLICAS into every container (CAI-258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`MORTISE_REPLICAS` is injected into every container** (CAI-258): the
+  same value written to the Deployment's `replicas`, so an app that holds
+  process-local state (a rate limiter, a spend ledger) can refuse to run
+  scaled instead of silently running N budgets. Joins `PORT`,
+  `MORTISE_IMAGE` and `MORTISE_REVISION` as a reserved name.
+
 - **Declaring a reserved variable is reported** (CAI-220): `PORT`,
   `MORTISE_IMAGE` and `MORTISE_REVISION` are set on the container itself
   and beat every `envFrom` source, so a user-declared `PORT` landed in the

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -163,7 +163,7 @@ type ConfigFile struct {
 	Content string `json:"content"`
 }
 
-// PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+// PORT, MORTISE_IMAGE, MORTISE_REVISION and MORTISE_REPLICAS are set by Mortise on the
 // container itself and win over anything declared as an EnvVar; declaring
 // them raises the EnvKeysReserved condition instead of taking effect.
 // EnvVar is one environment variable for an App environment. Set exactly one

--- a/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
+++ b/charts/mortise-core/crds/mortise.mortise.dev_apps.yaml
@@ -199,7 +199,7 @@ spec:
                     env:
                       items:
                         description: |-
-                          PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                          PORT, MORTISE_IMAGE, MORTISE_REVISION and MORTISE_REPLICAS are set by Mortise on the
                           container itself and win over anything declared as an EnvVar; declaring
                           them raises the EnvKeysReserved condition instead of taking effect.
                           EnvVar is one environment variable for an App environment. Set exactly one
@@ -614,7 +614,7 @@ spec:
                   flags that should not be repeated per environment.
                 items:
                   description: |-
-                    PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                    PORT, MORTISE_IMAGE, MORTISE_REVISION and MORTISE_REPLICAS are set by Mortise on the
                     container itself and win over anything declared as an EnvVar; declaring
                     them raises the EnvKeysReserved condition instead of taking effect.
                     EnvVar is one environment variable for an App environment. Set exactly one

--- a/config/crd/bases/mortise.mortise.dev_apps.yaml
+++ b/config/crd/bases/mortise.mortise.dev_apps.yaml
@@ -199,7 +199,7 @@ spec:
                     env:
                       items:
                         description: |-
-                          PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                          PORT, MORTISE_IMAGE, MORTISE_REVISION and MORTISE_REPLICAS are set by Mortise on the
                           container itself and win over anything declared as an EnvVar; declaring
                           them raises the EnvKeysReserved condition instead of taking effect.
                           EnvVar is one environment variable for an App environment. Set exactly one
@@ -614,7 +614,7 @@ spec:
                   flags that should not be repeated per environment.
                 items:
                   description: |-
-                    PORT, MORTISE_IMAGE and MORTISE_REVISION are set by Mortise on the
+                    PORT, MORTISE_IMAGE, MORTISE_REVISION and MORTISE_REPLICAS are set by Mortise on the
                     container itself and win over anything declared as an EnvVar; declaring
                     them raises the EnvKeysReserved condition instead of taking effect.
                     EnvVar is one environment variable for an App environment. Set exactly one

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -1677,6 +1677,10 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 	portEnv := []corev1.EnvVar{
 		{Name: "PORT", Value: strconv.Itoa(int(appPort(app)))},
 		{Name: imageEnvName, Value: image},
+		// The same value written to spec.replicas below, so an app holding
+		// process-local state (a rate limiter, a ledger) can fail closed
+		// when scaled instead of silently running N budgets (CAI-258).
+		{Name: replicasEnvName, Value: strconv.Itoa(int(replicas))},
 	}
 	if es := envStatusFor(app, env.Name); es != nil && es.LastBuiltSHA != "" {
 		portEnv = append(portEnv, corev1.EnvVar{Name: revisionEnvName, Value: es.LastBuiltSHA})

--- a/internal/controller/app_controller_test.go
+++ b/internal/controller/app_controller_test.go
@@ -7069,12 +7069,13 @@ var _ = Describe("App Controller — git source", func() {
 			}, &dep)).To(Succeed())
 
 			// Deployment only carries the literals injected by the controller:
-			// PORT and MORTISE_IMAGE. An image-source App has no built
-			// revision, so MORTISE_REVISION is absent rather than empty.
+			// PORT, MORTISE_IMAGE and MORTISE_REPLICAS. An image-source App
+			// has no built revision, so MORTISE_REVISION is absent, not empty.
 			envVars := dep.Spec.Template.Spec.Containers[0].Env
-			Expect(envVars).To(HaveLen(2))
+			Expect(envVars).To(HaveLen(3))
 			Expect(envVars[0].Name).To(Equal("PORT"))
 			Expect(envVars[1]).To(Equal(corev1.EnvVar{Name: "MORTISE_IMAGE", Value: testImageNginx}))
+			Expect(envVars[2]).To(Equal(corev1.EnvVar{Name: "MORTISE_REPLICAS", Value: "1"}), "replicas default to 1 (CAI-258)")
 			for _, ev := range envVars {
 				Expect(ev.Name).NotTo(Equal("MORTISE_REVISION"))
 			}

--- a/internal/controller/app_reserved_env.go
+++ b/internal/controller/app_reserved_env.go
@@ -20,7 +20,7 @@ const reservedEnvKeysCondition = "EnvKeysReserved"
 // the container runs the platform's value anyway -- with nothing saying so
 // (CAI-220). Rejecting at admission is not available (CAI-161), so the
 // controller reports it on the App instead.
-var reservedEnvKeys = map[string]struct{}{"PORT": {}, imageEnvName: {}, revisionEnvName: {}}
+var reservedEnvKeys = map[string]struct{}{"PORT": {}, imageEnvName: {}, revisionEnvName: {}, replicasEnvName: {}}
 
 func setReservedEnvKeysCondition(conds *[]metav1.Condition, app *mortisev1alpha1.App, envs []mortisev1alpha1.Environment, generation int64) {
 	var parts []string

--- a/internal/controller/build_runner.go
+++ b/internal/controller/build_runner.go
@@ -163,6 +163,10 @@ const revisionEnvName = "MORTISE_REVISION"
 // reference the pod is running, digest included.
 const imageEnvName = "MORTISE_IMAGE"
 
+// replicasEnvName is the container env var that carries the Deployment's
+// replica count, from the same variable written to spec.replicas.
+const replicasEnvName = "MORTISE_REPLICAS"
+
 // withRevisionBuildArg adds MORTISE_REVISION to the user's build args. It is
 // added here, at submission, rather than into BuildRunSpec.BuildArgs: the
 // BuildRun input hash already covers the revision, and adding a derived arg


### PR DESCRIPTION
Fixes CAI-258 (raised by eys-mgr). `MORTISE_REPLICAS` beside `PORT`/`MORTISE_IMAGE`/`MORTISE_REVISION`, from the same `replicas` variable written to the Deployment; reserved name; docs comment and CHANGELOG. Existing image-source envtest asserts the value. `make test` green. Pod template changes, so it rolls once on upgrade like CAI-180's variables (already noted for that release).