### PR TITLE
test(e2e): re-assert the apps row after Refresh before clicking through

### DIFF
--- a/ui/tests/e2e/dashboard.spec.ts
+++ b/ui/tests/e2e/dashboard.spec.ts
@@ -61,7 +61,13 @@ test.describe('cluster dashboard', () => {
 		// Row click-through lands on the project page. The project route may
 		// carry an env query param (added by the O4 dashboard work), so
 		// anchor on the path and tolerate a query string.
+		//
+		// Refresh above refetches and re-renders the table; clicking the row
+		// while it is being replaced lands on a detached element and no
+		// navigation happens (first failure seen the moment retries went to
+		// zero, #546). Re-assert the row after the refresh, then click.
+		await expect(row).toBeVisible();
 		await row.click();
-		await expect(page).toHaveURL(new RegExp(`/projects/${project}(\\?.*)?$`));
+		await expect(page).toHaveURL(new RegExp(`/projects/${project}(\\?.*)?$`), { timeout: 15_000 });
 	});
 });


### PR DESCRIPTION
First flake surfaced by retries=0 (#546): `dashboard.spec.ts` clicks Refresh, then the row while the table re-renders; the click lands on a detached element and `toHaveURL` times out at 5 s (#547's E2E run). Re-assert the row after the refresh, then click, with a 15 s navigation timeout. Test-only.