### PR TITLE
fix(auth): fall back to an uncached read when a user Secret is not in the cache yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,12 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   environment added by the clone API could have its namespace deleted
   while the clone was still copying Secrets into it (the API answered
   500). The GC now confirms against the live Project before deleting.
+- **Logging in right after a user is created no longer fails on a cache
+  miss**: authentication read user Secrets only through the manager's
+  cache, which can lag a just-created Secret by milliseconds, so the
+  first login after `POST /api/admin/users` (or `mortise admin
+  create-user`) could answer "invalid credentials". A cache miss now
+  falls back to an uncached read; unknown users still fail.
 
 - **A just-failed preview build no longer flips the parent App to
   Deploying for one reconcile** (CAI-173, CAI-229's sibling): on the pass

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -493,7 +493,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authProvider := auth.NewNativeAuthProvider(mgr.GetClient())
+	authProvider := auth.NewNativeAuthProvider(mgr.GetClient()).WithUncachedReader(mgr.GetAPIReader())
 	jwtHelper := auth.NewJWTHelper(mgr.GetClient())
 
 	var uiSub fs.FS

--- a/internal/auth/native.go
+++ b/internal/auth/native.go
@@ -31,6 +31,13 @@ var (
 type NativeAuthProvider struct {
 	client client.Client
 	jwt    *JWTHelper
+	// uncached, when set, is consulted on a cache miss during
+	// authentication. The cached client can lag a just-created user Secret
+	// by milliseconds; a login that immediately follows user creation then
+	// reads "invalid credentials" (seen in E2E the moment retries went to
+	// zero). Misses are bounded by the login limiter, so this costs an
+	// apiserver read only on the failure path.
+	uncached client.Reader
 }
 
 func NewNativeAuthProvider(c client.Client) *NativeAuthProvider {
@@ -38,6 +45,13 @@ func NewNativeAuthProvider(c client.Client) *NativeAuthProvider {
 		client: c,
 		jwt:    NewJWTHelper(c),
 	}
+}
+
+// WithUncachedReader sets the reader consulted on a cache miss during
+// authentication (typically the manager's APIReader).
+func (n *NativeAuthProvider) WithUncachedReader(r client.Reader) *NativeAuthProvider {
+	n.uncached = r
+	return n
 }
 
 // dummyPasswordHash is compared against when the user does not exist, so the
@@ -70,6 +84,12 @@ func (n *NativeAuthProvider) Authenticate(ctx context.Context, creds Credentials
 		Name:      userSecretName(creds.Email),
 		Namespace: namespace,
 	}, &secret)
+	if errors.IsNotFound(err) && n.uncached != nil {
+		err = n.uncached.Get(ctx, types.NamespacedName{
+			Name:      userSecretName(creds.Email),
+			Namespace: namespace,
+		}, &secret)
+	}
 	if errors.IsNotFound(err) {
 		_ = compareHashAndPassword(dummyPasswordHash, []byte(creds.Password))
 		return Principal{}, fmt.Errorf("invalid credentials")

--- a/internal/auth/native_uncached_test.go
+++ b/internal/auth/native_uncached_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// A user created a moment ago may not be in the cache yet; authentication
+// must fall back to an uncached read before calling the credentials invalid.
+func TestAuthenticateFallsBackToUncachedReader(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	apiserver := fake.NewClientBuilder().WithScheme(scheme).Build() // has the user
+	if err := NewNativeAuthProvider(apiserver).CreateUser(ctx, "new@example.com", "correct horse", RoleMember); err != nil {
+		t.Fatal(err)
+	}
+	cache := fake.NewClientBuilder().WithScheme(scheme).Build() // lagging: empty
+
+	if _, err := NewNativeAuthProvider(cache).Authenticate(ctx, Credentials{Email: "new@example.com", Password: "correct horse"}); err == nil {
+		t.Fatal("without a fallback the cache miss must fail (this is the race)")
+	}
+	withFallback := NewNativeAuthProvider(cache).WithUncachedReader(apiserver)
+	if _, err := withFallback.Authenticate(ctx, Credentials{Email: "new@example.com", Password: "correct horse"}); err != nil {
+		t.Fatalf("fallback read must authenticate the just-created user: %v", err)
+	}
+	if _, err := withFallback.Authenticate(ctx, Credentials{Email: "nobody@example.com", Password: "x"}); err == nil {
+		t.Fatal("an unknown user must still fail")
+	}
+}


### PR DESCRIPTION
Second flake surfaced by retries=0: `platform-settings-actions.spec.ts:257` — login immediately after user creation can miss the controller-runtime cache. `Authenticate` now retries the user-Secret read through `mgr.GetAPIReader()` on NotFound only. Test: empty cache fails; with fallback succeeds; unknown user still fails. Same shape affects `mortise admin create-user` followed by `mortise login`.