### PR TITLE
fix(controller): confirm against the live Project before GC'ing an env namespace (CAI-173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,12 @@ Mortise uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   status pass corrected it a moment later — so the parent flickered on
   every preview build poll. Preview builds now touch only their own
   environment status; the PreviewEnvironment carries the outcome.
+- **A just-added environment's namespace is no longer garbage-collected
+  by a lagging cache** (CAI-173): the Project controller deleted env
+  namespaces not in its cached view of `spec.environments`, so an
+  environment added by the clone API could have its namespace deleted
+  while the clone was still copying Secrets into it (the API answered
+  500). The GC now confirms against the live Project before deleting.
 
 - **A just-failed preview build no longer flips the parent App to
   Deploying for one reconcile** (CAI-173, CAI-229's sibling): on the pass

--- a/internal/api/project_envs.go
+++ b/internal/api/project_envs.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -553,6 +554,13 @@ func (s *Server) CloneProjectEnvironment(w http.ResponseWriter, r *http.Request)
 
 	// Clone env overrides and Secret-backed env vars from source to target for every App.
 	if err := s.cloneAppOverrides(r.Context(), projectName, projectNs(project), sourceName, req.Name); err != nil {
+		// The target namespace can still be terminating from a previous
+		// environment of the same name; that is a retryable conflict, not
+		// an internal error (CAI-173).
+		if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "being terminated") {
+			writeJSON(w, http.StatusConflict, errorResponse{fmt.Sprintf("environment %q's namespace is still terminating; retry shortly", req.Name)})
+			return
+		}
 		writeError(w, r, err)
 		return
 	}

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -498,6 +498,7 @@ func (r *ProjectReconciler) gcStaleEnvNamespaces(ctx context.Context, project *m
 	}); err != nil {
 		return fmt.Errorf("list env namespaces: %w", err)
 	}
+	var live *mortisev1alpha1.Project // fetched uncached, once, only if a delete is pending
 	for i := range nsList.Items {
 		ns := &nsList.Items[i]
 		envName := ns.Labels[constants.EnvironmentLabel]
@@ -507,11 +508,38 @@ func (r *ProjectReconciler) gcStaleEnvNamespaces(ctx context.Context, project *m
 		if !ns.DeletionTimestamp.IsZero() {
 			continue
 		}
+		// Deleting is irreversible and `desired` came from the cache. An env
+		// added a moment ago (the clone API writes the Project spec, and the
+		// App controller creates the env namespace from the cloned App
+		// overrides before this controller's cache catches up) looked stale
+		// here and was deleted while the clone was still copying its Secrets
+		// (CAI-173, env-clone 500s). Confirm against the live Project first.
+		if r.APIReader != nil {
+			if live == nil {
+				live = &mortisev1alpha1.Project{}
+				if err := r.APIReader.Get(ctx, types.NamespacedName{Name: project.Name}, live); err != nil {
+					return fmt.Errorf("re-read project before env namespace gc: %w", err)
+				}
+			}
+			if projectDeclaresEnv(live, envName) {
+				logf.FromContext(ctx).Info("env namespace looked stale in the cache but the live Project declares it; keeping", "namespace", ns.Name, "env", envName)
+				continue
+			}
+		}
 		if err := r.Delete(ctx, ns); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("delete stale env ns %q: %w", ns.Name, err)
 		}
 	}
 	return nil
+}
+
+func projectDeclaresEnv(project *mortisev1alpha1.Project, envName string) bool {
+	for _, e := range project.Spec.Environments {
+		if e.Name == envName {
+			return true
+		}
+	}
+	return false
 }
 
 // deleteOwnedNamespaces requests deletion of every namespace this Project owns

--- a/internal/controller/project_env_ns_gc_test.go
+++ b/internal/controller/project_env_ns_gc_test.go
@@ -1,0 +1,53 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+// The cache can lag a just-added environment; the GC must confirm against
+// the live Project before deleting a namespace that only looks stale.
+func TestGCStaleEnvNamespacesConfirmsAgainstLiveProject(t *testing.T) {
+	ctx := context.Background()
+	scheme := gcTestScheme(t)
+	envNs := func(env string) *corev1.Namespace {
+		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: constants.EnvNamespace("demo", env),
+			Labels: map[string]string{
+				constants.ProjectLabel:       "demo",
+				constants.NamespaceRoleLabel: constants.NamespaceRoleEnv,
+				constants.EnvironmentLabel:   env,
+			},
+		}}
+	}
+	cachedProject := &mortisev1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: mortisev1alpha1.ProjectSpec{Environments: []mortisev1alpha1.ProjectEnvironment{{Name: "production"}}}}
+	liveProject := cachedProject.DeepCopy()
+	liveProject.Spec.Environments = append(liveProject.Spec.Environments, mortisev1alpha1.ProjectEnvironment{Name: "staging"})
+
+	cache := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cachedProject, envNs("production"), envNs("staging"), envNs("old")).Build()
+	live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(liveProject).Build()
+	r := &ProjectReconciler{Client: cache, Scheme: scheme, APIReader: live}
+
+	desired := map[string]string{"production": constants.EnvNamespace("demo", "production")} // the cache's view
+	if err := r.gcStaleEnvNamespaces(ctx, cachedProject, desired); err != nil {
+		t.Fatal(err)
+	}
+	var ns corev1.Namespace
+	if err := cache.Get(ctx, types.NamespacedName{Name: constants.EnvNamespace("demo", "staging")}, &ns); err != nil {
+		t.Fatalf("staging namespace was deleted although the live Project declares it: %v", err)
+	}
+	err := cache.Get(ctx, types.NamespacedName{Name: constants.EnvNamespace("demo", "old")}, &ns)
+	if err == nil || !errors.IsNotFound(err) {
+		t.Fatalf("a genuinely stale namespace must still be deleted: err=%v", err)
+	}
+}


### PR DESCRIPTION
Env-clone 500s, diagnosed from the artifact: the Project controller's stale-namespace GC worked from its cached spec and deleted a just-added environment's namespace (created by the App controller from cloned overrides) while the clone was still copying Secrets. GC now confirms against `APIReader` before deleting; unit test covers lagging-cache keep vs genuinely-stale delete. The clone handler maps the terminating-namespace Forbidden to 409. `make test` green.