### PR TITLE
fix(controller): quiet two per-run error loops seen under E2E load

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -667,7 +667,9 @@ func (r *AppReconciler) removeAppFinalizerWithRetry(ctx context.Context, key typ
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var fresh mortisev1alpha1.App
 		if err := r.Get(ctx, key, &fresh); err != nil {
-			return err
+			// Gone already: the finalizer was removed by an earlier pass and
+			// the object was collected before this queued event ran.
+			return client.IgnoreNotFound(err)
 		}
 		if !controllerutil.ContainsFinalizer(&fresh, appFinalizer) {
 			return nil

--- a/internal/controller/app_finalizer_gone_test.go
+++ b/internal/controller/app_finalizer_gone_test.go
@@ -1,0 +1,18 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// A queued delete event can run after an earlier pass already removed the
+// finalizer and the App was collected; that is completion, not an error.
+func TestRemoveAppFinalizerWithRetryIgnoresGoneApp(t *testing.T) {
+	r := &AppReconciler{Client: fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()}
+	if err := r.removeAppFinalizerWithRetry(context.Background(), types.NamespacedName{Namespace: "pj-x", Name: "gone"}); err != nil {
+		t.Fatalf("expected nil for a missing App, got %v", err)
+	}
+}

--- a/internal/controller/platformconfig_controller.go
+++ b/internal/controller/platformconfig_controller.go
@@ -184,6 +184,7 @@ func (r *PlatformConfigReconciler) setConfigAppliedCondition(ctx context.Context
 }
 
 func (r *PlatformConfigReconciler) markReady(ctx context.Context, pc *mortisev1alpha1.PlatformConfig) error {
+	orig := pc.DeepCopy()
 	pc.Status.Phase = mortisev1alpha1.PlatformConfigPhaseReady
 	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
 		Type:               "Available",
@@ -192,13 +193,17 @@ func (r *PlatformConfigReconciler) markReady(ctx context.Context, pc *mortisev1a
 		Message:            "PlatformConfig is ready",
 		ObservedGeneration: pc.Generation,
 	})
-	if err := r.Status().Update(ctx, pc); err != nil {
+	// Merge-patch rather than Update: the UI edits spec concurrently and the
+	// cached copy this reconcile read is often behind, so an
+	// optimistic-locked Update conflicts and requeues with backoff.
+	if err := r.Status().Patch(ctx, pc, client.MergeFrom(orig)); err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
 	return nil
 }
 
 func (r *PlatformConfigReconciler) markFailed(ctx context.Context, pc *mortisev1alpha1.PlatformConfig, reason, msg string) error {
+	orig := pc.DeepCopy()
 	pc.Status.Phase = mortisev1alpha1.PlatformConfigPhaseFailed
 	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
 		Type:               "Available",
@@ -207,7 +212,10 @@ func (r *PlatformConfigReconciler) markFailed(ctx context.Context, pc *mortisev1
 		Message:            msg,
 		ObservedGeneration: pc.Generation,
 	})
-	if err := r.Status().Update(ctx, pc); err != nil {
+	// Merge-patch rather than Update: the UI edits spec concurrently and the
+	// cached copy this reconcile read is often behind, so an
+	// optimistic-locked Update conflicts and requeues with backoff.
+	if err := r.Status().Patch(ctx, pc, client.MergeFrom(orig)); err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
 	return nil

--- a/internal/controller/platformconfig_controller.go
+++ b/internal/controller/platformconfig_controller.go
@@ -77,6 +77,7 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		return ctrl.Result{}, err
 	}
+	orig := pc.DeepCopy()
 
 	// Stamp the running operator's identity on every status write, so
 	// `kubectl get platformconfig` names the build production is on.
@@ -86,7 +87,7 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Enforce singleton: only the instance named "platform" is valid.
 	if pc.Name != singletonName {
 		log.Info("rejecting non-singleton PlatformConfig", "name", pc.Name)
-		return ctrl.Result{}, r.markFailed(ctx, &pc, "InvalidName",
+		return ctrl.Result{}, r.markFailed(ctx, orig, &pc, "InvalidName",
 			fmt.Sprintf("PlatformConfig must be named %q; got %q", singletonName, pc.Name))
 	}
 
@@ -94,7 +95,7 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if pc.Spec.Registry.CredentialsSecretRef != nil {
 		if err := validateSecretRef(ctx, r.Client, *pc.Spec.Registry.CredentialsSecretRef, "spec.registry.credentialsSecretRef"); err != nil {
 			log.Info("registry credentials secret ref invalid", "error", err)
-			return ctrl.Result{}, r.markFailed(ctx, &pc, "SecretNotFound", err.Error())
+			return ctrl.Result{}, r.markFailed(ctx, orig, &pc, "SecretNotFound", err.Error())
 		}
 	}
 
@@ -102,7 +103,7 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if pc.Spec.Build.TLSSecretRef != nil {
 		if err := validateSecretRef(ctx, r.Client, *pc.Spec.Build.TLSSecretRef, "spec.build.tlsSecretRef"); err != nil {
 			log.Info("buildkit TLS secret ref invalid", "error", err)
-			return ctrl.Result{}, r.markFailed(ctx, &pc, "SecretNotFound", err.Error())
+			return ctrl.Result{}, r.markFailed(ctx, orig, &pc, "SecretNotFound", err.Error())
 		}
 	}
 
@@ -110,20 +111,20 @@ func (r *PlatformConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if pc.Spec.Observability.LogsAdapterTokenSecretRef != nil {
 		if err := validateSecretRef(ctx, r.Client, *pc.Spec.Observability.LogsAdapterTokenSecretRef, "spec.observability.logsAdapterTokenSecretRef"); err != nil {
 			log.Info("logs adapter token secret ref invalid", "error", err)
-			return ctrl.Result{}, r.markFailed(ctx, &pc, "SecretNotFound", err.Error())
+			return ctrl.Result{}, r.markFailed(ctx, orig, &pc, "SecretNotFound", err.Error())
 		}
 	}
 	if pc.Spec.Observability.MetricsAdapterTokenSecretRef != nil {
 		if err := validateSecretRef(ctx, r.Client, *pc.Spec.Observability.MetricsAdapterTokenSecretRef, "spec.observability.metricsAdapterTokenSecretRef"); err != nil {
 			log.Info("metrics adapter token secret ref invalid", "error", err)
-			return ctrl.Result{}, r.markFailed(ctx, &pc, "SecretNotFound", err.Error())
+			return ctrl.Result{}, r.markFailed(ctx, orig, &pc, "SecretNotFound", err.Error())
 		}
 	}
 
 	r.setRegistryPullCondition(&pc)
 	r.setConfigAppliedCondition(ctx, &pc)
 
-	return ctrl.Result{}, r.markReady(ctx, &pc)
+	return ctrl.Result{}, r.markReady(ctx, orig, &pc)
 }
 
 // setRegistryPullCondition mirrors (and sharpens) the boot-time warning: a
@@ -183,8 +184,7 @@ func (r *PlatformConfigReconciler) setConfigAppliedCondition(ctx context.Context
 	})
 }
 
-func (r *PlatformConfigReconciler) markReady(ctx context.Context, pc *mortisev1alpha1.PlatformConfig) error {
-	orig := pc.DeepCopy()
+func (r *PlatformConfigReconciler) markReady(ctx context.Context, orig, pc *mortisev1alpha1.PlatformConfig) error {
 	pc.Status.Phase = mortisev1alpha1.PlatformConfigPhaseReady
 	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
 		Type:               "Available",
@@ -202,8 +202,7 @@ func (r *PlatformConfigReconciler) markReady(ctx context.Context, pc *mortisev1a
 	return nil
 }
 
-func (r *PlatformConfigReconciler) markFailed(ctx context.Context, pc *mortisev1alpha1.PlatformConfig, reason, msg string) error {
-	orig := pc.DeepCopy()
+func (r *PlatformConfigReconciler) markFailed(ctx context.Context, orig, pc *mortisev1alpha1.PlatformConfig, reason, msg string) error {
 	pc.Status.Phase = mortisev1alpha1.PlatformConfigPhaseFailed
 	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
 		Type:               "Available",


### PR DESCRIPTION
Seen while diagnosing CAI-173 on a local E2E run and in CI artifacts: 41 `update status: Operation cannot be fulfilled on platformconfigs` and 40 `remove finalizer: App ... not found` reconciler errors per run, each requeueing with backoff.

- PlatformConfig status: merge-patch instead of optimistic-locked Update. The UI updates spec concurrently; the cached copy the reconcile read is often behind. This controller is the only status writer.
- App finalizer removal: NotFound on the fresh Get means an earlier pass already removed it and the object was collected; return nil.

Unit test for the finalizer path; PlatformConfig envtest suite unchanged and green.