### PR TITLE
ci: dump App/Project status and workloads in failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           mkdir -p diagnostics
           kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > diagnostics/operator.log || true
           kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix --previous > diagnostics/operator-previous.log 2>/dev/null || true
+          kubectl get apps.mortise.mortise.dev,projects.mortise.mortise.dev,previewenvironments.mortise.mortise.dev -A -o yaml > diagnostics/mortise-resources.yaml 2>/dev/null || true
+          kubectl get pods,deployments -A -o wide > diagnostics/workloads.txt 2>/dev/null || true
           tail -300 diagnostics/operator.log || true
           kubectl get events -A --sort-by=.lastTimestamp > diagnostics/events.txt || true
           tail -80 diagnostics/events.txt || true
@@ -206,6 +208,8 @@ jobs:
           mkdir -p diagnostics
           kubectl --context k3d-mortise-dev -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > diagnostics/operator.log || true
           kubectl --context k3d-mortise-dev -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix --previous > diagnostics/operator-previous.log 2>/dev/null || true
+          kubectl --context k3d-mortise-dev get apps.mortise.mortise.dev,projects.mortise.mortise.dev,previewenvironments.mortise.mortise.dev -A -o yaml > diagnostics/mortise-resources.yaml 2>/dev/null || true
+          kubectl --context k3d-mortise-dev get pods,deployments -A -o wide > diagnostics/workloads.txt 2>/dev/null || true
           tail -300 diagnostics/operator.log || true
           kubectl --context k3d-mortise-dev get events -A --sort-by=.lastTimestamp > diagnostics/events.txt || true
           tail -80 diagnostics/events.txt || true

--- a/.github/workflows/integration-repeat.yml
+++ b/.github/workflows/integration-repeat.yml
@@ -72,6 +72,8 @@ jobs:
         run: |
           kubectl -n mortise-system logs -l app.kubernetes.io/name=mortise --tail=-1 --all-containers --prefix > result/operator.log || true
           kubectl get events -A --sort-by=.lastTimestamp > result/events.txt || true
+          kubectl get apps.mortise.mortise.dev,projects.mortise.mortise.dev,previewenvironments.mortise.mortise.dev -A -o yaml > result/mortise-resources.yaml 2>/dev/null || true
+          kubectl get pods,deployments -A -o wide > result/workloads.txt 2>/dev/null || true
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Failure diagnostics on ci.yml (integration + E2E) and integration-repeat.yml now include `mortise-resources.yaml` (Apps, Projects, PreviewEnvironments, all namespaces) and `workloads.txt` (pods, deployments). The 10× main run 33307647979 froze two Apps in Deploying with an empty env list; the logs show the transition but not the state that produced it.