### PR TITLE
fix(controller): skip the status pass when the parent Project is not resolvable (CAI-173)

### DIFF
--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -241,13 +241,18 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if _, err := r.pruneMissingBindingsForConsumer(ctx, &app); err != nil {
 		return ctrl.Result{}, fmt.Errorf("prune missing bindings: %w", err)
 	}
-	var resolvedEnvs []mortisev1alpha1.Environment
-	var previewEnvNames map[string]struct{}
-	var previewBuildIdentities map[string]previewBuildIdentity
-	if project != nil {
-		resolvedEnvs = resolveEnvs(project, &app)
-		previewEnvNames = resolvedPreviewEnvNames(project, resolvedEnvs)
+	if project == nil || len(project.Spec.Environments) == 0 {
+		// Envs derive from the Project. Without it there is nothing to
+		// compute, and running the status pass anyway wrote an empty env
+		// list and Phase=Deploying over a Ready App that nothing re-queued
+		// (CAI-173: 10x main run 33307647979, bindings tests). The cached
+		// Project read lags its creation and its production seed; wait.
+		logf.FromContext(ctx).Info("parent project not resolvable yet; requeueing without a status pass", "projectFound", project != nil)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
+	resolvedEnvs := resolveEnvs(project, &app)
+	previewEnvNames := resolvedPreviewEnvNames(project, resolvedEnvs)
+	var previewBuildIdentities map[string]previewBuildIdentity
 	buildAggregationEnvNames := buildFailureAggregationEnvNames(resolvedEnvs, previewEnvNames)
 	if app.Spec.Source.Type == mortisev1alpha1.SourceTypeGit && len(previewEnvNames) > 0 {
 		previewBuildIdentities, err = r.previewBuildIdentitiesByEnv(ctx, &app, previewEnvNames)

--- a/internal/controller/app_status_pass_without_project_envtest_test.go
+++ b/internal/controller/app_status_pass_without_project_envtest_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// CAI-173: with the parent Project unresolvable from the cache, the status
+// pass used to write an empty env list and Phase=Deploying over a Ready App,
+// and nothing re-queued it. The reconcile must leave status alone and requeue.
+var _ = Describe("status pass without a resolvable Project (CAI-173)", func() {
+	const namespace = "pj-noproject"
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).To(Succeed())
+	})
+	AfterEach(func() { purgeAllAppsIn(ctx, namespace) })
+
+	It("keeps the App's env statuses and phase and requeues", func() {
+		appName := "orphan"
+		app := &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+			Spec: mortisev1alpha1.AppSpec{
+				Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+				Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, app)).To(Succeed()) }()
+		app.Status.Phase = mortisev1alpha1.AppPhaseReady
+		app.Status.Environments = []mortisev1alpha1.EnvironmentStatus{{Name: "production", Phase: mortisev1alpha1.AppPhaseReady, ReadyReplicas: 1}}
+		Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+		reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace}}
+		res, err := reconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+		var fresh mortisev1alpha1.App
+		Expect(k8sClient.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(mortisev1alpha1.AppPhaseReady))
+		Expect(fresh.Status.Environments).To(HaveLen(1))
+	})
+})


### PR DESCRIPTION
10× integration-repeat on main (run 33307647979) failed runs 1 and 7: four binding tests timed out waiting for `test-db` to be Ready. Its phase history: Deploying → Ready → Ready→Deploying with an empty env summary, then frozen. The aggregation yields Deploying with nothing holding only when `envStatuses` is empty, which happens only when `resolvedEnvs` is empty: the cached parent Project read came back missing or unseeded, and the status pass then overwrote a Ready App with an empty env list. Nothing re-triggered a reconcile.

Fix: when the Project is nil or has no environments, requeue after 5s without a status pass. envtest: a Ready App in a control namespace with no Project keeps its phase and env statuses and gets a requeue.

The diagnostics dump PR (#554) makes the next occurrence of this class directly readable from the artifact.