### PR TITLE
test: dump workload and App state when an integration wait times out

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/moby/buildkit v0.29.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/railwayapp/railpack v0.23.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
@@ -27,6 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	modernc.org/sqlite v1.49.1
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -140,13 +143,11 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
@@ -213,5 +214,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/test/helpers/assertions.go
+++ b/test/helpers/assertions.go
@@ -16,6 +16,13 @@ import (
 // RequireEventually polls fn every 200ms until it returns true or timeout is reached.
 func RequireEventually(t *testing.T, timeout time.Duration, fn func() bool) {
 	t.Helper()
+	requireEventually(t, timeout, fn, nil)
+}
+
+// requireEventually runs onTimeout (if set) before failing, so the state that
+// held the wait is in the test log rather than gone with the namespace.
+func requireEventually(t *testing.T, timeout time.Duration, fn func() bool, onTimeout func()) {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if fn() {
@@ -23,13 +30,16 @@ func RequireEventually(t *testing.T, timeout time.Duration, fn func() bool) {
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
+	if onTimeout != nil {
+		onTimeout()
+	}
 	t.Fatal("timed out waiting for condition")
 }
 
 // AssertPodsRunning asserts that a Deployment exists with the expected number of ready replicas.
 func AssertPodsRunning(t *testing.T, k8sClient client.Client, ns, name string, count int32) {
 	t.Helper()
-	RequireEventually(t, 8*time.Minute, func() bool {
+	requireEventually(t, 8*time.Minute, func() bool {
 		var dep appsv1.Deployment
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Name:      name,
@@ -39,7 +49,7 @@ func AssertPodsRunning(t *testing.T, k8sClient client.Client, ns, name string, c
 			return false
 		}
 		return dep.Status.ReadyReplicas == count
-	})
+	}, func() { DumpWorkloadState(t, k8sClient, ns, name) })
 }
 
 // AssertDeploymentExists asserts a Deployment with the given name exists in the namespace.
@@ -67,7 +77,7 @@ func AssertIngressExists(t *testing.T, k8sClient client.Client, ns, name string)
 // WaitForAppReady polls until App.status.phase == Ready or timeout is reached.
 func WaitForAppReady(t *testing.T, k8sClient client.Client, ns, name string, timeout time.Duration) {
 	t.Helper()
-	RequireEventually(t, timeout, func() bool {
+	requireEventually(t, timeout, func() bool {
 		var app mortisev1alpha1.App
 		if err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Name: name, Namespace: ns,
@@ -75,5 +85,5 @@ func WaitForAppReady(t *testing.T, k8sClient client.Client, ns, name string, tim
 			return false
 		}
 		return app.Status.Phase == mortisev1alpha1.AppPhaseReady
-	})
+	}, func() { DumpAppState(t, k8sClient, ns, name) })
 }

--- a/test/helpers/dump.go
+++ b/test/helpers/dump.go
@@ -1,0 +1,93 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+	"github.com/mortise-org/mortise/internal/constants"
+)
+
+// DumpWorkloadState logs the Deployment, its pods (container states included),
+// and the namespace's events. Called when a wait times out: the test's
+// namespace is deleted by cleanup before CI's diagnostics run, so this is the
+// only record of what the pods were doing.
+func DumpWorkloadState(t *testing.T, k8sClient client.Client, ns, name string) {
+	t.Helper()
+	ctx := context.Background()
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- state of %s/%s at timeout ---\n", ns, name)
+
+	var dep appsv1.Deployment
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &dep); err != nil {
+		fmt.Fprintf(&b, "deployment: %v\n", err)
+	} else {
+		fmt.Fprintf(&b, "deployment: replicas=%d ready=%d updated=%d available=%d generation=%d observed=%d\n",
+			dep.Status.Replicas, dep.Status.ReadyReplicas, dep.Status.UpdatedReplicas, dep.Status.AvailableReplicas, dep.Generation, dep.Status.ObservedGeneration)
+		for _, c := range dep.Status.Conditions {
+			fmt.Fprintf(&b, "  condition %s=%s %s: %s\n", c.Type, c.Status, c.Reason, c.Message)
+		}
+	}
+
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{constants.AppNameLabel: name}); err != nil {
+		fmt.Fprintf(&b, "pods: %v\n", err)
+	}
+	for _, p := range pods.Items {
+		fmt.Fprintf(&b, "pod %s phase=%s node=%s\n", p.Name, p.Status.Phase, p.Spec.NodeName)
+		for _, c := range p.Status.Conditions {
+			if c.Status != corev1.ConditionTrue {
+				fmt.Fprintf(&b, "  condition %s=%s %s: %s\n", c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+		for _, cs := range append(p.Status.InitContainerStatuses, p.Status.ContainerStatuses...) {
+			state := "running"
+			switch {
+			case cs.State.Waiting != nil:
+				state = "waiting " + cs.State.Waiting.Reason + ": " + cs.State.Waiting.Message
+			case cs.State.Terminated != nil:
+				state = fmt.Sprintf("terminated %s exit=%d: %s", cs.State.Terminated.Reason, cs.State.Terminated.ExitCode, cs.State.Terminated.Message)
+			}
+			fmt.Fprintf(&b, "  container %s ready=%v restarts=%d %s\n", cs.Name, cs.Ready, cs.RestartCount, state)
+		}
+	}
+
+	var events corev1.EventList
+	if err := k8sClient.List(ctx, &events, client.InNamespace(ns)); err != nil {
+		fmt.Fprintf(&b, "events: %v\n", err)
+	}
+	sort.Slice(events.Items, func(i, j int) bool { return events.Items[i].LastTimestamp.Before(&events.Items[j].LastTimestamp) })
+	for _, e := range events.Items {
+		fmt.Fprintf(&b, "event %s %s %s/%s %s: %s\n", e.LastTimestamp.Format("15:04:05"), e.Type, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message)
+	}
+	t.Log(b.String())
+}
+
+// DumpAppState logs the App's status and the workload state of every env it
+// reports, for the same reason as DumpWorkloadState.
+func DumpAppState(t *testing.T, k8sClient client.Client, ns, name string) {
+	t.Helper()
+	var app mortisev1alpha1.App
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &app); err != nil {
+		t.Logf("app %s/%s: %v", ns, name, err)
+		return
+	}
+	status, _ := yaml.Marshal(app.Status)
+	t.Logf("--- App %s/%s status at timeout ---\n%s", ns, name, status)
+	project, ok := constants.ProjectFromControlNs(ns)
+	if !ok {
+		return
+	}
+	for _, es := range app.Status.Environments {
+		DumpWorkloadState(t, k8sClient, constants.EnvNamespace(project, es.Name), name)
+	}
+}


### PR DESCRIPTION
10× main run 33309454431 (after #555) was 9/10; run 9's TestFullStackDeploy timed out with `test-db` never Running for 8 minutes and the artifact holds nothing about it: the project's namespaces are deleted by `t.Cleanup` before the diagnostics step, and `kubectl get events -A` at that point has no events for them.

`AssertPodsRunning` now logs the Deployment status, each pod's phase/conditions/container states, and the namespace's events on timeout; `WaitForAppReady` logs the App status and the same for every env it reports. No behaviour change on the passing path.