### PR TITLE
fix(controller): read the env-hash uncached and use Recreate for Apps with storage (CAI-173)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -413,6 +413,7 @@ func main() {
 
 	appReconciler := &controller.AppReconciler{
 		Client:          mgr.GetClient(),
+		APIReader:       mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
 		BuildClient:     stk.build,
 		GitClient:       stk.git,

--- a/internal/controller/app_controller.go
+++ b/internal/controller/app_controller.go
@@ -131,6 +131,9 @@ const appResourceConflictCondition = "ResourceConflict"
 // AppReconciler reconciles a App object
 type AppReconciler struct {
 	client.Client
+	// APIReader bypasses the cache for reads that must see this reconcile's
+	// own writes (the env Secret hash stamped on the pod template).
+	APIReader       client.Reader
 	Scheme          *runtime.Scheme
 	Clock           clock.Clock
 	BuildClient     build.BuildClient
@@ -1706,6 +1709,16 @@ func carryRestartMarkers(desired, existing map[string]string) map[string]string 
 	return desired
 }
 
+// deploymentStrategy picks Recreate for Apps with volumes: a rolling update
+// starts the new pod while the old one still holds the ReadWriteOnce claim,
+// and a database on that claim never becomes ready under the old one.
+func deploymentStrategy(app *mortisev1alpha1.App) appsv1.DeploymentStrategy {
+	if len(app.Spec.Storage) > 0 {
+		return appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
+	}
+	return appsv1.DeploymentStrategy{}
+}
+
 func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1alpha1.App, env *mortisev1alpha1.Environment, envNs, image, credentialsHash string, autoRedeploy bool) error {
 	name := deploymentName(app.Name)
 	replicas := int32(1)
@@ -1818,6 +1831,7 @@ func (r *AppReconciler) reconcileDeployment(ctx context.Context, app *mortisev1a
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
+			Strategy: deploymentStrategy(app),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: appLabels(app, env.Name),
 			},
@@ -3320,6 +3334,14 @@ func hashEnvSecretData(ctx context.Context, reader client.Reader, appName, envNs
 }
 
 func (r *AppReconciler) hashEnvSecretData(ctx context.Context, appName, envNs string) string {
+	// The env Secret was written earlier in this same reconcile; the cache
+	// has usually not seen it yet on the create pass, so a cached read
+	// stamped no hash, and the next pass stamped one: two pod templates a
+	// second apart, two ReplicaSets, and for an App with an RWO volume two
+	// pods fighting over one PVC (CAI-173, 10x main run 33310674068).
+	if r.APIReader != nil {
+		return hashEnvSecretData(ctx, r.APIReader, appName, envNs)
+	}
 	return hashEnvSecretData(ctx, r.Client, appName, envNs)
 }
 

--- a/internal/controller/app_storage_strategy_envtest_test.go
+++ b/internal/controller/app_storage_strategy_envtest_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mortisev1alpha1 "github.com/mortise-org/mortise/api/v1alpha1"
+)
+
+// CAI-173: an App with a volume must not roll with two pods alive at once.
+var _ = Describe("Deployment strategy for Apps with storage (CAI-173)", func() {
+	const namespace = "pj-default-project"
+	const envNsProduction = "pj-default-project-production"
+	ctx := context.Background()
+
+	AfterEach(func() { purgeAllAppsIn(ctx, namespace) })
+
+	It("uses Recreate when the App declares storage and the default otherwise", func() {
+		withVol := &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "with-vol", Namespace: namespace},
+			Spec: mortisev1alpha1.AppSpec{
+				Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+				Storage:      []mortisev1alpha1.VolumeSpec{{Name: "data", MountPath: "/data", Size: resource.MustParse("1Gi")}},
+				Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+			},
+		}
+		noVol := &mortisev1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-vol", Namespace: namespace},
+			Spec: mortisev1alpha1.AppSpec{
+				Source:       mortisev1alpha1.AppSource{Type: mortisev1alpha1.SourceTypeImage, Image: testImageNginx},
+				Environments: []mortisev1alpha1.Environment{{Name: "production"}},
+			},
+		}
+		for _, app := range []*mortisev1alpha1.App{withVol, noVol} {
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			defer func(a *mortisev1alpha1.App) { Expect(k8sClient.Delete(ctx, a)).To(Succeed()) }(app)
+			reconciler := &AppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: app.Name, Namespace: namespace}}
+			for i := 0; i < 2; i++ {
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		var dep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "with-vol", Namespace: envNsProduction}, &dep)).To(Succeed())
+		Expect(dep.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "no-vol", Namespace: envNsProduction}, &dep)).To(Succeed())
+		Expect(dep.Spec.Strategy.Type).NotTo(Equal(appsv1.RecreateDeploymentStrategyType))
+	})
+})


### PR DESCRIPTION
From the timeout-state dump added in #556 (10× main run 33310674068, run 9): both failing `test-db` Deployments had generation 2 with two ReplicaSets scaled up in the same second, two postgres pods Pending on one RWO `WaitForFirstConsumer` PVC, and the scheduler's VolumeBinding thrashing (`selectedNode annotation reset`, PVC conflicts) until the 8-minute wait expired.

Two defects:
- `reconcileDeployment` read the env Secret back through the cache right after writing it, so the first pod template carried no `mortise.dev/env-hash` and the next pass added one. `AppReconciler.APIReader` (wired from the manager) is now used for that read.
- Apps with `spec.storage` rolled with the default RollingUpdate; a new pod cannot mount the claim the old one holds. They now use `Recreate`.

envtest: storage App gets Recreate, non-storage App does not. `make test` green.