### PR TITLE
fix(ui): keep a revealed variable revealed across the refetch that follows a save

### DIFF
--- a/ui/src/lib/components/drawer/VariablesTab.svelte
+++ b/ui/src/lib/components/drawer/VariablesTab.svelte
@@ -139,15 +139,23 @@
 		return (!entry.source || entry.source === 'user') && !entry.bindingRef && !entry.secretRef;
 	}
 
+	// A refetch (after a save, or a later fetch resolving) rebuilds the rows;
+	// a value the user revealed must stay revealed or the input they are about
+	// to type into disappears under them.
+	function keepRevealed(prev: EnvEntry[], next: EnvEntry[]): EnvEntry[] {
+		const revealed = new Set(prev.filter((e) => e.revealed).map((e) => e.name));
+		return next.map((e) => (revealed.has(e.name) ? { ...e, revealed: true } : e));
+	}
+
 	async function loadEnv(envName: string, preserveDraftOnError = false): Promise<boolean> {
 		envSection.loading = true;
 		envSection.error = '';
 		try {
 			const rows = await api.getEnv(project, app.metadata.name, envName);
-			const entries: EnvEntry[] = (rows ?? []).map(r => ({
+			const entries: EnvEntry[] = keepRevealed(envSection.entries, (rows ?? []).map(r => ({
 				name: r.name, value: r.value, source: r.source ?? 'user', revealed: false,
 				bindingRef: r.bindingRef, bindingKey: r.bindingKey, secretRef: r.secretRef
-			}));
+			})));
 			envSection.entries = entries;
 			envSection.originalEntries = entries.map(e => ({ ...e }));
 			envSection.editedKeys = new Set();
@@ -178,9 +186,9 @@
 		sharedSection.error = '';
 		try {
 			const rows = await api.getSharedVars(project);
-			sharedSection.entries = (rows ?? []).map(r => ({
+			sharedSection.entries = keepRevealed(sharedSection.entries, (rows ?? []).map(r => ({
 				name: r.name, value: r.value, source: r.source ?? 'shared', revealed: false
-			}));
+			})));
 			sharedSection.originalEntries = sharedSection.entries.map(e => ({ ...e }));
 			sharedSection.editedKeys = new Set();
 		} catch (e) {
@@ -197,9 +205,9 @@
 		buildSection.error = '';
 		try {
 			const rows = await api.getBuildArgs(project, app.metadata.name, activeEnv);
-			const entries: EnvEntry[] = (rows ?? []).map(r => ({
+			const entries: EnvEntry[] = keepRevealed(buildSection.entries, (rows ?? []).map(r => ({
 				name: r.name, value: r.value ?? '', source: 'user', revealed: false
-			}));
+			})));
 			buildSection.entries = entries;
 			buildSection.originalEntries = entries.map(e => ({ ...e }));
 			buildSection.editedKeys = new Set();
@@ -445,9 +453,9 @@
 				.filter(e => e.name.trim() !== '')
 				.map(e => ({ name: e.name, value: e.value }));
 			const result = await api.putBuildArgs(project, app.metadata.name, activeEnv, filtered);
-			buildSection.entries = (result ?? []).map(r => ({
+			buildSection.entries = keepRevealed(buildSection.entries, (result ?? []).map(r => ({
 				name: r.name, value: r.value ?? '', source: 'user', revealed: false
-			}));
+			})));
 			buildSection.originalEntries = buildSection.entries.map(e => ({ ...e }));
 			buildSection.editedKeys = new Set();
 			markStale();

--- a/ui/src/lib/components/drawer/VariablesTab.test.ts
+++ b/ui/src/lib/components/drawer/VariablesTab.test.ts
@@ -116,3 +116,40 @@ describe('VariablesTab runtime ownership', () => {
 		expect(within(automaticRow).queryAllByRole('button')).toHaveLength(2);
 	});
 });
+
+describe('VariablesTab reveal state', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		currentEnv.mockReturnValue('production');
+		let rows: Row[] = [{ name: 'USER', value: 'before', source: 'user' }];
+		getEnv.mockImplementation(async () => rows.map(row => ({ ...row })));
+		setEnv.mockImplementation(async (_project: string, _app: string, _env: string, vars: Record<string, string>) => {
+			rows = Object.entries(vars).map(([name, value]) => ({ name, value, source: 'user' }));
+		});
+		updateApp.mockImplementation(async (_project: string, _name: string, spec: AppSpec) => ({ ...makeApp(), spec }));
+	});
+
+	// A revealed value must stay revealed across the refetch that follows a
+	// save; the E2E "manual saves preserve ... projections" lost its input to
+	// that refetch (CAI-165 E2E measurement, run 33313012705).
+	it('keeps a revealed row revealed after a save refetches the section', async () => {
+		render(VariablesTab, { props: { project: 'demo', app: makeApp() } });
+		const panel = runtimePanel();
+		await waitFor(() => expect(within(panel).getByText('USER')).toBeTruthy());
+		const userRow = within(panel).getByText('USER').closest('div.group') as HTMLElement;
+		await fireEvent.click(within(userRow).getByTitle('Reveal'));
+		expect(within(userRow).getByRole('textbox')).toBeTruthy();
+
+		const header = panel.querySelector('.flex.items-center.justify-between') as HTMLElement;
+		const iconButtons = Array.from(header.querySelectorAll('button')).filter(b => b.querySelector('svg'));
+		await fireEvent.click(iconButtons[iconButtons.length - 1]);
+		await fireEvent.input(within(panel).getByPlaceholderText('VARIABLE_NAME'), { target: { value: 'NEW' } });
+		await fireEvent.input(within(panel).getByPlaceholderText('value or binding ref'), { target: { value: 'one' } });
+		await fireEvent.click(within(panel).getByRole('button', { name: 'Add' }));
+		await waitFor(() => expect(setEnv).toHaveBeenCalled());
+		await waitFor(() => expect(getEnv.mock.calls.length).toBeGreaterThan(1));
+
+		const again = within(panel).getByText('USER').closest('div.group') as HTMLElement;
+		await waitFor(() => expect(within(again).getByRole('textbox')).toBeTruthy());
+	});
+});


### PR DESCRIPTION
UI E2E 10× (run 33313012705) was 9/10; the one failure was `manual saves preserve automatic bindings, fromBinding, and secretRef projections`: after Add, the test clicked Reveal on the new row and the row's `<input>` never appeared. `loadEnv` (called after every save) rebuilds the rows with `revealed: false`, so a Reveal that lands while that refetch is in flight is undone.

Fix: rebuilt rows inherit `revealed` from the rows they replace (runtime, shared, build sections). Vitest reproduces it: fails on the old component, passes on the new.